### PR TITLE
fix: resolve Mock API routing issue by removing duplicate /api/ prefix

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/main.py
+++ b/handoff/20250928/40_App/api-backend/src/main.py
@@ -55,7 +55,7 @@ app.register_blueprint(dashboard_bp, url_prefix='/api/dashboard')
 
 if BACKEND_SERVICES_AVAILABLE:
     try:
-        app.register_blueprint(mock_api, url_prefix='/api')
+        app.register_blueprint(mock_api)
     except NameError:
         pass
 


### PR DESCRIPTION
- Remove url_prefix='/api' from mock_api blueprint registration in main.py
- Mock API routes already define /api/ prefix in route decorators
- Fixes double /api/ prefix issue causing 404 errors
- All mock endpoints now correctly accessible at /api/dashboard/mock, /api/checkout/mock, /api/settings/mock
- Verified all endpoints return 200 status codes

Co-Authored-By: RyanChen <ryan2939x@gmail.com>
