### PR TITLE
fix(worker): actually start RQ worker in __main__ block

### DIFF
--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -123,4 +123,7 @@ def run_orchestrator_task(task_id: str, question: str, repo: str):
         raise
 
 if __name__ == "__main__":
-    print("RQ Worker started. Listening for orchestrator tasks...")
+    from rq import Worker
+    print("Starting RQ worker for 'orchestrator' queue...")
+    with Worker([q], connection=redis) as worker:
+        worker.work()


### PR DESCRIPTION
## Summary

Fixes the RQ worker service crashing immediately on startup, which was causing `/api/agent/faq` endpoint to return 503 errors.

**Problem**: The `morningai-agent-worker` service was restarting every 5 minutes because `worker.py`'s `__main__` block only printed a message and exited, instead of actually starting the RQ worker to process Redis queue tasks.

**Solution**: Replace the print-only `__main__` block with proper RQ Worker initialization that keeps the process running and consumes tasks from the `orchestrator` queue.

## Changes

- **File**: `handoff/20250928/40_App/orchestrator/redis_queue/worker.py`
- **Before**: `print("RQ Worker started. Listening for orchestrator tasks...")` → process exits
- **After**: Instantiate `Worker([q], connection=redis)` and call `worker.work()` → process stays running

## Human Review Checklist

- [ ] **Worker stays running**: Verify in Render logs that worker no longer crashes every 5 minutes  
- [ ] **Redis connectivity**: Confirm worker successfully connects to Redis (no connection errors)
- [ ] **Task processing**: Test that `/api/agent/faq` now returns 202 instead of 503 for valid payloads
- [ ] **Graceful shutdown**: Ensure worker terminates properly when service is stopped in Render

## 提醒
- [ ] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [ ] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯 ✅

---

**Link to Devin run**: https://app.devin.ai/sessions/4d73941cad414878a1ff65aaacf030aa  
**Requested by**: @RC918