### PR TITLE
fix(worker): remove context manager - RQ Worker doesn't support it

### DIFF
--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -125,5 +125,5 @@ def run_orchestrator_task(task_id: str, question: str, repo: str):
 if __name__ == "__main__":
     from rq import Worker
     print("Starting RQ worker for 'orchestrator' queue...")
-    with Worker([q], connection=redis) as worker:
-        worker.work()
+    worker = Worker([q], connection=redis)
+    worker.work()


### PR DESCRIPTION
## Summary

Fixes `TypeError: 'Worker' object does not support the context manager protocol` that was causing the `morningai-agent-worker` service to crash immediately on startup.

**Root Cause**: PR #73 introduced a context manager pattern (`with Worker(...) as worker:`) but the RQ Worker class doesn't support this protocol in the deployed version.

**Solution**: Replace context manager with standard Worker initialization pattern.

## Changes

**File**: `handoff/20250928/40_App/orchestrator/redis_queue/worker.py`
- Remove `with Worker([q], connection=redis) as worker:` 
- Replace with `worker = Worker([q], connection=redis); worker.work()`

This is a 2-line change that switches from context manager to standard initialization.

## Impact

- **Before**: Worker crashes with TypeError, service restarts every 5 minutes
- **After**: Worker should stay running and process tasks from Redis queue
- **Fixes**: `/api/agent/faq` endpoint returning 503 errors due to no worker processing tasks

## Human Review Checklist

- [ ] **Worker stability**: Verify in Render logs that worker no longer crashes with TypeError
- [ ] **Task processing**: Confirm `/api/agent/faq` returns 202 instead of 503 for valid requests  
- [ ] **Resource cleanup**: Ensure worker terminates gracefully when service is stopped (without context manager)
- [ ] **Redis connectivity**: Check worker successfully connects and processes tasks from `orchestrator` queue

## 提醒
- [ ] 不修改 OpenAPI/資料欄位（若要改，先提 RFC） ✅
- [ ] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯 ✅

---

**Link to Devin run**: https://app.devin.ai/sessions/4d73941cad414878a1ff65aaacf030aa  
**Requested by**: @RC918