### PR TITLE
feat: Package orchestrator to remove sys.path dependencies (Batch 2)

### DIFF
--- a/handoff/20250928/40_App/api-backend/tests/test_rq_worker.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_rq_worker.py
@@ -14,9 +14,6 @@ from rq import Queue
 def test_worker_module_imports():
     """Test that worker module can be imported"""
     try:
-        import sys
-        import os
-        sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../orchestrator'))
         from redis_queue import worker
         
         assert hasattr(worker, 'run_orchestrator_task')

--- a/handoff/20250928/40_App/orchestrator/__init__.py
+++ b/handoff/20250928/40_App/orchestrator/__init__.py
@@ -1,0 +1,4 @@
+"""
+Morning AI Orchestrator Package
+"""
+__version__ = "0.1.0"

--- a/handoff/20250928/40_App/orchestrator/redis_queue/__init__.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/__init__.py
@@ -1,0 +1,8 @@
+"""
+Redis Queue module for orchestrator
+"""
+try:
+    from .worker import enqueue, run_orchestrator_task, check_worker_health
+    __all__ = ['enqueue', 'run_orchestrator_task', 'check_worker_health']
+except ImportError:
+    pass

--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -30,8 +30,6 @@ if SENTRY_DSN:
 else:
     log_structured("INFO", "Sentry not configured", "startup")
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
 redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 DEMO_MODE = os.getenv("DEMO_MODE", "false").lower() == "true"
 WORKER_ID = os.getenv("RENDER_INSTANCE_ID", os.getenv("HOSTNAME", "worker-local"))
@@ -295,3 +293,6 @@ if __name__ == "__main__":
     log_structured("INFO", "Worker health check", "health_check", **health)
     
     print("RQ Worker started. Listening for orchestrator tasks...")
+    
+    w = Worker(['orchestrator'], connection=redis, exception_handlers=[custom_exception_handler])
+    w.work()

--- a/handoff/20250928/40_App/orchestrator/setup.py
+++ b/handoff/20250928/40_App/orchestrator/setup.py
@@ -1,0 +1,22 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="morningai-orchestrator",
+    version="0.1.0",
+    packages=find_packages(),
+    py_modules=['graph'],
+    install_requires=[
+        "langchain-community>=0.2.16",
+        "langchain-openai>=0.1.23",
+        "langgraph>=0.2.4",
+        "supabase==2.6.0",
+        "openai==1.52.2",
+        "requests==2.32.3",
+        "sentry-sdk==2.19.2",
+        "redis",
+        "rq"
+    ],
+    python_requires=">=3.12",
+    author="Morning AI",
+    description="Morning AI orchestrator for agent workflows",
+)

--- a/render.yaml
+++ b/render.yaml
@@ -41,7 +41,8 @@ services:
     buildCommand: |
       cd handoff/20250928/40_App/orchestrator &&
       pip install --upgrade pip &&
-      pip install -r requirements.txt
+      pip install -r requirements.txt &&
+      pip install -e .
     startCommand: cd handoff/20250928/40_App/orchestrator && rq worker orchestrator --url $REDIS_URL
     envVars:
       - key: REDIS_URL


### PR DESCRIPTION
# feat: Package orchestrator to remove sys.path dependencies (Batch 2)

## 概要
將 orchestrator 打包為可安裝的 Python package，移除所有 `sys.path.insert()` 相對路徑依賴。這是 Batch 2 任務的第一部分，專注於改善代碼架構和部署可靠性。

## 主要變更

### 📦 Package 結構
- **新增 `setup.py`**: 定義 orchestrator 為可安裝的 Python package
- **新增 `__init__.py`**: 使 orchestrator 和 redis_queue 成為正式的 Python modules
- **移除 `sys.path.insert()`**: 從 worker.py 和 test_rq_worker.py 中移除手動路徑操作

### 🚀 部署改進
- **更新 render.yaml**: 在 build 過程中加入 `pip install -e .` 安裝 orchestrator package
- **簡化 import**: 現在可以直接 `from redis_queue import worker` 而不需要路徑操作

### 🔧 Worker 執行
- **新增 worker 執行邏輯**: 在 worker.py 末尾加入 `w.work()` 啟動 RQ worker

## 📋 人工審查重點

- [ ] **🔥 高風險**: 驗證 render.yaml 的 `pip install -e .` 在部署時不會失敗
- [ ] **🔥 高風險**: 確認 worker service 能正常啟動並處理任務
- [ ] **⚠️ 中風險**: 檢查 package import 在沒有 sys.path.insert() 的情況下正常工作
- [ ] **⚠️ 中風險**: 驗證 `w.work()` 不會影響現有 RQ worker 行為
- [ ] **✅ 低風險**: 確認測試 `test_worker_module_imports` 通過

## 🧪 測試狀態
- ✅ Package import 測試通過
- ✅ 本地 `pip install -e .` 成功
- ⚠️ 由於 Redis 依賴，部分功能測試在本地跳過（預期行為）
- ❗ **需要在 render 環境驗證完整部署流程**

## 💡 後續任務
此 PR 完成 Batch 2 的 package 化部分。後續還需要：
- E2E 測試擴充（已確認現有 E2E 測試預期 202 狀態碼）
- API 從 Redis 讀取 trace_id/pr_url（已實現，無需修改）

## 提醒
- [ ] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [ ] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

---
**Link to Devin run**: https://app.devin.ai/sessions/a9f5cf1b80b54eebb1edded4abe57147  
**Requested by**: @RC918