### PR TITLE
fix(worker): remove decode_responses=True to prevent UnicodeDecodeError

### DIFF
--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -41,7 +41,7 @@ else:
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-redis = Redis.from_url(redis_url, decode_responses=True)
+redis = Redis.from_url(redis_url)
 q = Queue("orchestrator", connection=redis)
 
 def run_step(step: str):


### PR DESCRIPTION
## Summary
Fixes critical worker crash bug by removing `decode_responses=True` from Redis connection initialization.

## Problem
The RQ worker was experiencing intermittent crashes with `UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 0` when RQ tried to read its internal binary data (heartbeat info, job metadata) from Redis.

## Root Cause
- `decode_responses=True` forces ALL Redis responses to be decoded as UTF-8 strings
- RQ stores internal data as pickled/binary data that cannot be decoded as UTF-8
- When RQ reads this binary data, Redis attempts UTF-8 decoding and fails

## Solution
Remove `decode_responses=True` parameter to allow RQ to handle encoding/decoding internally as designed.

## Safety Analysis
- ✅ Our code in `run_orchestrator_task` uses `json.dumps()` which already converts data to strings before writing to Redis
- ✅ We don't perform any Redis read operations in worker.py that would require automatic string decoding
- ✅ This aligns with RQ's documented best practices

## Testing
- [x] Verified worker.py code doesn't read from Redis (only writes)
- [x] Confirmed all Redis writes use json.dumps() for string conversion
- [ ] **Needs production verification**: Worker can process tasks without crashes

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## Human Review Checklist
- [ ] **Critical**: Verify no other Redis read operations in codebase rely on `decode_responses=True`
- [ ] Confirm worker logs show successful task processing after deployment
- [ ] Check that E2E workflow passes after this fix is deployed
- [ ] Verify no regression in task status updates or error handling

---
**Link to Devin run**: https://app.devin.ai/sessions/4d73941cad414878a1ff65aaacf030aa  
**Requested by**: Ryan Chen (@RC918)