### PR TITLE
docs: fill Sentry alert URLs & channel (FE/React/BE)

### DIFF
--- a/docs/sentry-alerts.md
+++ b/docs/sentry-alerts.md
@@ -117,3 +117,11 @@ for i in range(3):
 ## Backend 規則（回填）
 - Error Rule URL: https://sentry.io/organizations/morningai-core/alerts/rules/16341755/
 - 通知管道: Email / Slack #oncall
+
+
+## Sentry 規則回填（2025-10-07）
+- Frontend Error Rule URL: https://sentry.io/organizations/morningai-core/alerts/rules/16293151/
+- React Error Rule URL:    https://sentry.io/organizations/morningai-core/alerts/rules/16330925/
+- Backend Error Rule URL:  https://sentry.io/organizations/morningai-core/alerts/rules/16341755/
+- 通知管道: Email / Slack #oncall
+


### PR DESCRIPTION
Backfill rule links: 16293151 / 16330925 / 16341755; channel: Email / Slack #oncall.