### PR TITLE
docs/openapi: unify role terminology (operator→analyst, viewer→user) + policy doc

### DIFF
--- a/docs/policy/roles-terminology.md
+++ b/docs/policy/roles-terminology.md
@@ -1,0 +1,5 @@
+# Role Terminology Policy (Phase 10)
+對外文件/回應/前端字詞一律使用：
+- analyst（原 operator）
+- user（原 viewer）
+後端為相容保留 alias（operator→analyst、viewer→user），實作見 normalize_role()（#152）。


### PR DESCRIPTION
Align public terms to analyst/user; backend keeps aliases via normalize_role(). Fixes #89