### PR TITLE
ci: heartbeat monitor permissions fix

### DIFF
--- a/.github/workflows/worker-heartbeat-monitor.yml
+++ b/.github/workflows/worker-heartbeat-monitor.yml
@@ -69,6 +69,8 @@ jobs:
       
       - name: Create issue on heartbeat failure
         if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
         uses: actions/github-script@v7
         with:
           script: |
@@ -109,3 +111,7 @@ jobs:
             } else {
               console.log('Heartbeat alert issue already exists, skipping duplicate');
             }
+
+permissions:
+  contents: read
+  issues: write


### PR DESCRIPTION
Add top-level permissions (issues: write) and pass GH_TOKEN to auto-create issue on failure.