### PR TITLE
fix: Combine redis installation with script execution in worker-heartbeat-monitor

### DIFF
--- a/.github/workflows/worker-heartbeat-monitor.yml
+++ b/.github/workflows/worker-heartbeat-monitor.yml
@@ -9,13 +9,11 @@ jobs:
   check-heartbeat:
     runs-on: ubuntu-latest
     steps:
-      - name: Install redis library
-        run: pip install redis
-      
       - name: Check worker heartbeats
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
         run: |
+          pip install redis
           python - <<'PY'
           import os, sys, time
           import redis


### PR DESCRIPTION
## Summary
修復 worker-heartbeat-monitor 工作流程執行時的 `ModuleNotFoundError: No module named 'redis'` 錯誤（workflow run #21）。\n\n## Root Cause\n工作流程將 redis 安裝和 Python 腳本分成兩個獨立步驟。在 GitHub Actions 中，不同步驟可能使用不同的 Python 環境，導致 pip 安裝的套件無法被後續腳本使用。\n\n## Changes\n- 移除獨立的 \"Install redis library\" 步驟\n- 將 `pip install redis` 合併到 Python 腳本執行的同一個 `run:` 區塊中\n- 確保已安裝的套件在同一個 Python 環境中可用\n\n## Testing\n- [ ] CI 檢查通過\n- [ ] 手動觸發工作流程成功\n- [ ] 工作流程日誌中無 ModuleNotFoundError\n- [ ] 工作流程退出碼為 0（成功）或 78（中性/無心跳檢測）\n\n## Related\n- Fixes workflow run #21 failure\n- Previous fix PR #174 / #173\n- Issue #162 - Worker hardening\n\nRequested by: @RC918\nLink to Devin run: https://app.devin.ai/sessions/10a80cd84a224137b4070c020970f125