### PR TITLE
fix: add PyGithub dependency to orchestrator setup.py to fix E2E test failures

### DIFF
--- a/handoff/20250928/40_App/orchestrator/setup.py
+++ b/handoff/20250928/40_App/orchestrator/setup.py
@@ -9,6 +9,7 @@ setup(
         "langchain-community>=0.2.16",
         "langchain-openai>=0.1.23",
         "langgraph>=0.2.4",
+        "PyGithub==2.4.0",
         "supabase==2.6.0",
         "openai==1.52.2",
         "requests==2.32.3",


### PR DESCRIPTION
## 問題描述

E2E 測試持續失敗，所有任務都卡在 `queued` 狀態無法處理。分析日誌後發現 worker 服務無法正常啟動。

## 根本原因

Worker 啟動時需要導入 `graph.execute`，該模組依賴 `tools.github_api`，而 `github_api.py` 需要 `PyGithub` 函式庫。但是 `setup.py` 的 `install_requires` 中缺少 `PyGithub`，導致 `pip install -e .` 時未安裝此依賴，worker 服務啟動失敗。

雖然 `PyGithub==2.4.0` 已列在 `requirements.txt` 中，但由於 Render 部署時執行 `pip install -e .`，只會安裝 `setup.py` 中聲明的依賴，因此 worker 無法啟動。

## 修復內容

在 `handoff/20250928/40_App/orchestrator/setup.py` 的 `install_requires` 中添加 `PyGithub==2.4.0`。

## 人工審查重點

- [ ] ✅ 確認 PyGithub 版本號與 requirements.txt 一致
- [ ] ⚠️ 部署後驗證 worker 服務能成功啟動（檢查 Render logs）
- [ ] ⚠️ 部署後執行 E2E 測試確認任務能正常處理

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

---

**Link to Devin run**: https://app.devin.ai/sessions/a6c88268b1df401ea9edd10c29bacd41  
**Requested by**: Ryan Chen (@RC918)

**注意事項**：此修復未經完整端到端測試，需要在 Render 部署後驗證 worker 服務是否正常運行。