### PR TITLE
fix(worker): increase Redis socket timeout to prevent connection drops

### DIFF
--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -83,34 +83,34 @@ else:
 redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
 RQ_QUEUE_NAME = os.getenv("RQ_QUEUE_NAME", "orchestrator")
 
-redis_retry = RedisRetry(ExponentialBackoff(base=1, cap=10), retries=3)
+redis_retry = RedisRetry(ExponentialBackoff(base=1, cap=10), retries=5)
 redis = Redis.from_url(
     redis_url, 
     decode_responses=True,
-    socket_connect_timeout=5,
-    socket_timeout=30,
+    socket_connect_timeout=10,
+    socket_timeout=300,
     socket_keepalive=True,
     socket_keepalive_options={
-        socket.TCP_KEEPIDLE: 60,
+        socket.TCP_KEEPIDLE: 30,
         socket.TCP_KEEPINTVL: 10,
-        socket.TCP_KEEPCNT: 3
+        socket.TCP_KEEPCNT: 6
     },
-    health_check_interval=30,
+    health_check_interval=60,
     retry=redis_retry,
     retry_on_timeout=True
 )
 redis_client_rq = Redis.from_url(
     redis_url, 
     decode_responses=False,
-    socket_connect_timeout=5,
-    socket_timeout=30,
+    socket_connect_timeout=10,
+    socket_timeout=300,
     socket_keepalive=True,
     socket_keepalive_options={
-        socket.TCP_KEEPIDLE: 60,
+        socket.TCP_KEEPIDLE: 30,
         socket.TCP_KEEPINTVL: 10,
-        socket.TCP_KEEPCNT: 3
+        socket.TCP_KEEPCNT: 6
     },
-    health_check_interval=30,
+    health_check_interval=60,
     retry=redis_retry,
     retry_on_timeout=True
 )


### PR DESCRIPTION
## 問題描述
Worker 每 ~2 分鐘崩潰並重啟，日誌顯示 "Redis connection timeout, quitting..." 錯誤。這導致任務卡在 "queued" 狀態無法處理，E2E 測試失敗。

## 解決方案
增加 Redis 連線超時設定，使 Worker 在空閒等待任務時能維持穩定連線：

- `socket_timeout`: 30s → 300s (5分鐘)
- `socket_connect_timeout`: 5s → 10s  
- `TCP_KEEPIDLE`: 60s → 30s (更早開始 keepalive 檢查)
- `TCP_KEEPCNT`: 3 → 6 (更多重試次數)
- `health_check_interval`: 30s → 60s
- `retry attempts`: 3 → 5

## 人工審查重點
- [ ] **超時值是否合理**: 300s socket timeout 是否過長？是否有 Redis 提供商的建議值？
- [ ] **監控計劃**: 部署後如何驗證 Worker 穩定性？需要設定哪些告警？
- [ ] **根本原因**: 是否應調查 Render ↔ Redis 之間的網路連線品質？
- [ ] **資源影響**: 更長的連線超時是否會影響 Redis 連線數限制？

## 測試計劃
部署後監控：
1. Worker 日誌中不再出現 "Redis connection timeout" 錯誤
2. 任務能正常從 "queued" → "running" → "done" 
3. E2E workflow 通過率提升

## 風險評估
🟡 **中等風險**: 超時值未經生產環境驗證，可能需要根據實際表現調整。

---

**Link to Devin run**: https://app.devin.ai/sessions/4d73941cad414878a1ff65aaacf030aa  
**Requested by**: @RC918

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯