### PR TITLE
fix(worker): prevent zombie workers and improve monitoring

### DIFF
--- a/.github/scripts/check_heartbeat.py
+++ b/.github/scripts/check_heartbeat.py
@@ -1,7 +1,7 @@
 import os,sys,time,json,redis,datetime as dt
 r=redis.from_url(os.environ['REDIS_URL']); now=time.time()
 active={ w.decode().split(':')[-1] for w in r.smembers('rq:workers') }  # 目前存活 worker_id 集合
-stale=[]; purged=[]
+stale=[]; purged=[]; corrupted_cleanup=[]
 for k in r.scan_iter('worker:heartbeat:*'):
     key=k.decode(); val=(r.get(k) or b'{}').decode()
     try:
@@ -10,10 +10,20 @@ for k in r.scan_iter('worker:heartbeat:*'):
     except Exception: t=0
     age=int(now-t) if t else 999999
     wid=key.split(':')[-1]
+    
+    # Force-cleanup corrupted workers (age=999999 = unparseable heartbeat)
+    if age >= 999999:
+        r.delete(k)
+        r.srem('rq:workers', wid)  # Also remove from active workers set (important-comment)
+        corrupted_cleanup.append((key, wid))
+        continue
+    
     if wid not in active:
         if age>600: r.delete(k); purged.append(key)   # 清理孤兒鍵（>10m）
         continue                                      # 不納入判斷
     if age>120: stale.append((key,age))
 if stale:
     print("Stale active heartbeats:", stale); sys.exit(1)
-print("OK: active heartbeats fresh;", "purged_orphans="+str(len(purged)))
+print(f"OK: active heartbeats fresh; purged_orphans={len(purged)}; corrupted_cleanup={len(corrupted_cleanup)}")
+if corrupted_cleanup:
+    print(f"Cleaned up corrupted workers: {corrupted_cleanup}")

--- a/.github/workflows/worker-heartbeat-monitor.yml
+++ b/.github/workflows/worker-heartbeat-monitor.yml
@@ -2,6 +2,9 @@ name: Worker Heartbeat Monitor
 on:
   schedule: [{ cron: '*/15 * * * *' }]
   workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
 jobs:
   check-heartbeat:
     runs-on: ubuntu-latest

--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -206,12 +206,16 @@ def cleanup_heartbeat():
             logger.info(f"Heartbeat thread stopped successfully", extra={"operation": "shutdown", "worker_id": WORKER_ID})
     
     try:
+        if redis_client_rq:
+            redis_client_rq.srem('rq:workers', WORKER_ID)
+            logger.info(f"Removed worker from rq:workers set", extra={"operation": "shutdown", "worker_id": WORKER_ID})
+        
         if redis:
             heartbeat_key = f"worker:heartbeat:{WORKER_ID}"
             redis.delete(heartbeat_key)
             logger.info(f"Cleaned up heartbeat key", extra={"operation": "shutdown", "worker_id": WORKER_ID, "key": heartbeat_key})
     except Exception as e:
-        logger.exception(f"Failed to cleanup heartbeat key", extra={"operation": "shutdown", "worker_id": WORKER_ID})
+        logger.exception(f"Failed to cleanup Redis keys", extra={"operation": "shutdown", "worker_id": WORKER_ID})
         if SENTRY_DSN:
             sentry_sdk.capture_exception(e)
 


### PR DESCRIPTION
## 問題描述

Worker Heartbeat Monitor workflow 每 15 分鐘失敗，根本原因是 zombie worker `srv-d3homah5pdvs73fekke0-p259v` 崩潰後未正確清理，在 Redis 中留下損壞的 heartbeat 資料 (age=999999)，觸發監控失敗和 GitHub 權限錯誤。

## 解決方案

### 1. 增強 Worker 清理邏輯 (`worker.py`)
- 在 `cleanup_heartbeat()` 中新增從 `rq:workers` set 移除 worker 的邏輯
- 使用 `redis_client_rq.srem('rq:workers', WORKER_ID)` 確保 RQ 不再認為該 worker 存活
- 防止 worker 崩潰時留下 zombie entries

### 2. 強化監控腳本 (`check_heartbeat.py`)  
- 新增強制清理損壞 worker 的邏輯 (age >= 999999)
- 同時從 heartbeat key 和 `rq:workers` set 移除損壞的 worker
- 增加 `corrupted_cleanup` 統計和日誌輸出

### 3. 修復 GitHub 權限 (`worker-heartbeat-monitor.yml`)
- 新增 `permissions: { contents: read, issues: write }` 
- 允許 workflow 在檢測到 heartbeat 失敗時建立 GitHub issue

## 測試影響

⚠️ **無法本地測試 Redis 操作** - 所有變更都涉及 Redis 狀態管理，需要在 staging 環境驗證

## 人工檢查清單

- [ ] **Redis 客戶端使用正確性**: 確認 `redis_client_rq` (decode_responses=False) 用於 RQ 操作，`redis` (decode_responses=True) 用於應用資料
- [ ] **age=999999 閾值安全性**: 確認此閾值只會匹配損壞的 heartbeat 資料，不會誤刪正常 worker  
- [ ] **清理順序正確性**: 驗證先從 `rq:workers` 移除，再刪除 heartbeat key 的順序是否合理
- [ ] **競態條件檢查**: 多個 Redis 操作之間是否可能出現時序問題
- [ ] **Staging 環境測試**: 部署到 staging 後監控 Worker Heartbeat Monitor workflow 是否正常運行
- [ ] **Worker 穩定性驗證**: 確認 worker 可以正常啟動、處理任務、優雅關閉

## 立即效果

下次 Worker Heartbeat Monitor 運行時 (15 分鐘內)，更新的腳本將自動清理 zombie worker `srv-d3homah5pdvs73fekke0-p259v`，終止每 15 分鐘的失敗循環。

---


**Link to Devin run**: https://app.devin.ai/sessions/4d73941cad414878a1ff65aaacf030aa  
**Requested by**: @RC918