### PR TITLE
fix(worker): remove socket_timeout to prevent RQ polling timeouts

### DIFF
--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -88,14 +88,12 @@ redis = Redis.from_url(
     redis_url, 
     decode_responses=True,
     socket_connect_timeout=10,
-    socket_timeout=300,
     socket_keepalive=True,
     socket_keepalive_options={
         socket.TCP_KEEPIDLE: 30,
         socket.TCP_KEEPINTVL: 10,
         socket.TCP_KEEPCNT: 6
     },
-    health_check_interval=60,
     retry=redis_retry,
     retry_on_timeout=True
 )
@@ -103,14 +101,12 @@ redis_client_rq = Redis.from_url(
     redis_url, 
     decode_responses=False,
     socket_connect_timeout=10,
-    socket_timeout=300,
     socket_keepalive=True,
     socket_keepalive_options={
         socket.TCP_KEEPIDLE: 30,
         socket.TCP_KEEPINTVL: 10,
         socket.TCP_KEEPCNT: 6
     },
-    health_check_interval=60,
     retry=redis_retry,
     retry_on_timeout=True
 )


### PR DESCRIPTION
## 概述

修復 worker 每 ~58 分鐘崩潰的 Redis 連線超時問題。根據 RQ 官方文檔，移除過低的 `socket_timeout` 設定，讓 RQ 自動計算正確的超時值。

## 問題背景

Worker 持續在約 58 分鐘後崩潰，錯誤訊息為 "Redis connection timeout"，儘管 PR #272 已增加超時設定。

**根本原因發現**：
- RQ 文檔要求 `socket_timeout >= dequeue_timeout + 10 = 415 秒`
- 我們設定的 `socket_timeout=300` 太低，導致 RQ 在等待 job 時被中斷
- 文檔警告：*"Setting a socket_timeout with a lower value than the dequeue_timeout will cause a TimeoutError since it will interrupt the worker while it gets new jobs from the queue"*

## 變更內容

**移除參數**：
- ❌ `socket_timeout=300` → 讓 RQ 自動計算為 415 秒
- ❌ `health_check_interval=60` → 我們有自己的 heartbeat 監控

**保留設定**：
- ✅ `socket_keepalive` 和相關選項（防止 idle 連線中斷）
- ✅ `retry` 和 `retry_on_timeout`（連線恢復能力）
- ✅ `socket_connect_timeout=10`（連線建立超時，與 socket_timeout 不同）

## 重點審查項目

- [ ] **驗證 RQ 文檔聲明**：確認 socket_timeout 要求 ≥415 秒的說法正確
- [ ] **確認移除 health_check_interval 安全**：我們有獨立的 heartbeat 監控系統
- [ ] **考慮回滾計劃**：如果此修復導致新問題的處理方式
- [ ] **部署監控**：需監控 >1 小時確認修復成功

## 測試計劃

**部署後驗證**：
1. Worker 持續運行 >1 小時無崩潰
2. 無 "Redis connection timeout" 錯誤
3. Heartbeat 監控持續正常
4. E2E 功能正常運作

## 參考資料

- [RQ Connections 文檔](https://python-rq.org/docs/connections/#timeout)
- 相關 PR：#272 (timeout 增加)、#275 (zombie worker 清理)

---

**Link to Devin run**: https://app.devin.ai/sessions/4d73941cad414878a1ff65aaacf030aa  
**Requested by**: @RC918

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯