### PR TITLE
🔴 HOTFIX: Preserve tenant_id in Task Status Updates (Critical Production Bug)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/persistence/db_writer.py
+++ b/handoff/20250928/40_App/orchestrator/persistence/db_writer.py
@@ -60,13 +60,14 @@ def upsert_task_queued(
         logger.error(f"DB write failed for task {task_id} (queued): {e}")
         return False
 
-def upsert_task_running(task_id: str, trace_id: str) -> bool:
+def upsert_task_running(task_id: str, trace_id: str, tenant_id: Optional[str] = None) -> bool:
     """
     Update task when worker starts processing.
     
     Args:
         task_id: UUID task identifier
         trace_id: UUID trace identifier
+        tenant_id: Tenant UUID (optional, defaults to default tenant if not provided)
     
     Returns:
         True if successful, False otherwise
@@ -80,19 +81,20 @@ def upsert_task_running(task_id: str, trace_id: str) -> bool:
             "trace_id": trace_id,
             "status": "running",
             "started_at": now,
-            "updated_at": now
+            "updated_at": now,
+            "tenant_id": tenant_id or "00000000-0000-0000-0000-000000000001"
         }
         
         client.table("agent_tasks").upsert(data, on_conflict="task_id").execute()
         
-        logger.info(f"DB write success: task {task_id} status=running")
+        logger.info(f"DB write success: task {task_id} status=running tenant_id={data['tenant_id']}")
         return True
         
     except Exception as e:
         logger.error(f"DB write failed for task {task_id} (running): {e}")
         return False
 
-def upsert_task_done(task_id: str, trace_id: str, pr_url: str) -> bool:
+def upsert_task_done(task_id: str, trace_id: str, pr_url: str, tenant_id: Optional[str] = None) -> bool:
     """
     Update task when worker completes successfully.
     
@@ -100,6 +102,7 @@ def upsert_task_done(task_id: str, trace_id: str, pr_url: str) -> bool:
         task_id: UUID task identifier
         trace_id: UUID trace identifier
         pr_url: GitHub PR URL
+        tenant_id: Tenant UUID (optional, defaults to default tenant if not provided)
     
     Returns:
         True if successful, False otherwise
@@ -114,19 +117,20 @@ def upsert_task_done(task_id: str, trace_id: str, pr_url: str) -> bool:
             "status": "done",
             "pr_url": pr_url,
             "finished_at": now,
-            "updated_at": now
+            "updated_at": now,
+            "tenant_id": tenant_id or "00000000-0000-0000-0000-000000000001"
         }
         
         client.table("agent_tasks").upsert(data, on_conflict="task_id").execute()
         
-        logger.info(f"DB write success: task {task_id} status=done pr_url={pr_url}")
+        logger.info(f"DB write success: task {task_id} status=done pr_url={pr_url} tenant_id={data['tenant_id']}")
         return True
         
     except Exception as e:
         logger.error(f"DB write failed for task {task_id} (done): {e}")
         return False
 
-def upsert_task_error(task_id: str, trace_id: str, error_msg: str) -> bool:
+def upsert_task_error(task_id: str, trace_id: str, error_msg: str, tenant_id: Optional[str] = None) -> bool:
     """
     Update task when worker encounters an error.
     
@@ -134,6 +138,7 @@ def upsert_task_error(task_id: str, trace_id: str, error_msg: str) -> bool:
         task_id: UUID task identifier
         trace_id: UUID trace identifier
         error_msg: Error message text
+        tenant_id: Tenant UUID (optional, defaults to default tenant if not provided)
     
     Returns:
         True if successful, False otherwise
@@ -148,12 +153,13 @@ def upsert_task_error(task_id: str, trace_id: str, error_msg: str) -> bool:
             "status": "error",
             "error_msg": error_msg[:500],
             "finished_at": now,
-            "updated_at": now
+            "updated_at": now,
+            "tenant_id": tenant_id or "00000000-0000-0000-0000-000000000001"
         }
         
         client.table("agent_tasks").upsert(data, on_conflict="task_id").execute()
         
-        logger.info(f"DB write success: task {task_id} status=error")
+        logger.info(f"DB write success: task {task_id} status=error tenant_id={data['tenant_id']}")
         return True
         
     except Exception as e:


### PR DESCRIPTION
## 🔴 CRITICAL PRODUCTION HOTFIX

**Sentry Alert**: `DB write failed for task (running): null value in column "tenant_id" violates not-null constraint`

## 問題描述

RLS Phase 2 部署後，任務從 "queued" 轉換為 "running" 時發生 NOT NULL constraint 違規錯誤。

### Root Cause
Migration 003 將 `agent_tasks.tenant_id` 設為 NOT NULL，但只有 `upsert_task_queued()` 包含 tenant_id。其他三個狀態更新函數沒有包含 tenant_id：
- ❌ `upsert_task_running()`
- ❌ `upsert_task_done()`
- ❌ `upsert_task_error()`

Supabase 的 `upsert(on_conflict="task_id")` 會**替換整列**，導致 tenant_id 變成 NULL。

### 錯誤流程
```
1. upsert_task_queued() → tenant_id = "00...001" ✅
2. upsert_task_running() → tenant_id = NULL ❌
3. PostgreSQL rejects: NOT NULL constraint violated 💥
```

## 修復內容

為三個函數添加可選的 `tenant_id` 參數（向後相容）：

**修改函數簽名**:
```python
# Before
def upsert_task_running(task_id: str, trace_id: str) -> bool:

# After  
def upsert_task_running(task_id: str, trace_id: str, tenant_id: Optional[str] = None) -> bool:
```

**更新 data dict**:
```python
data = {
    # ... existing fields ...
    "tenant_id": tenant_id or "00000000-0000-0000-0000-000000000001"  # 新增
}
```

**增強日誌**:
```python
logger.info(f"... tenant_id={data['tenant_id']}")  # 方便 debug
```

## 影響範圍

- ✅ **向後相容**: 參數為 optional，現有呼叫者無需修改
- ✅ **修復 Sentry 錯誤**: 解決 constraint violation
- ✅ **3 個函數**: `upsert_task_running`, `upsert_task_done`, `upsert_task_error`

## 🔍 審查重點

### ⚠️ CRITICAL - 必須確認
1. **預設 tenant UUID 正確性**: `"00000000-0000-0000-0000-000000000001"` 是否與 Migration 003 一致？
2. **Supabase upsert 行為**: 確認 `upsert(on_conflict="task_id")` 確實會替換所有欄位（非部分更新）
3. **現有呼叫者**: 檢查 `agent.py` 等呼叫處是否應明確傳遞 tenant_id？

### 🟡 建議檢查
4. **其他類似函數**: 是否有其他函數也有相同問題？
5. **Production 資料清理**: 是否需要 migration 修復現有 NULL 資料？

## 測試狀態

⚠️ **未在真實資料庫測試** - 缺少 DATABASE_URL credentials
- ✅ 程式邏輯審查通過
- ✅ 向後相容性確認
- ⏳ 需要 staging 環境驗證

## 提醒
- [x] 不修改 OpenAPI/資料欄位（純後端邏輯修復）
- [x] 工程 PR 僅含 API/邏輯（無 UI 變更）

## 部署建議

1. **立即合併** - P0 production blocker
2. **部署到 staging** - 快速煙霧測試
3. **部署到 production** - 修復 Sentry 錯誤
4. **監控 Sentry** - 確認錯誤停止

---

**Session**: https://app.devin.ai/sessions/a7f7650db2b548b0b181747c729b8818  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918  
**Related Sentry**: morningai-backend-v2 / DB write failed