### PR TITLE
fix(vercel): Update rootDirectory to point to correct frontend-dashbo…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,6 @@
   "framework": "vite",
   "buildCommand": "pnpm build",
   "installCommand": "pnpm install",
-  "outputDirectory": "dist"
+  "outputDirectory": "dist",
+  "rootDirectory": "handoff/20250928/40_App/frontend-dashboard"
 }


### PR DESCRIPTION
…ard path

PROBLEM:
- Vercel was deploying morningai_enhanced/frontend-dashboard (old version)
- PR #324 UI/UX improvements were not visible in production
- New components (PageLoader, OfflineIndicator, etc.) missing

SOLUTION:
- Add rootDirectory config pointing to handoff/20250928/40_App/frontend-dashboard
- This ensures Vercel deploys the correct frontend with Phase 1 UI/UX improvements

IMPACT:
- Next deployment will include all Phase 1 UI/UX enhancements
- Users will see PageLoader animations, skeleton screens, and error handling

## 提醒
- [ ] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [ ] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
