### PR TITLE
PR 1.2: Unify Empty State Component in Approvals (Week 1)

### DIFF
--- a/handoff/20250928/40_App/morningai_enhanced/frontend-dashboard/src/components/DecisionApproval.jsx
+++ b/handoff/20250928/40_App/morningai_enhanced/frontend-dashboard/src/components/DecisionApproval.jsx
@@ -7,7 +7,8 @@ import {
   TrendingUp, 
   DollarSign,
   Zap,
-  Info
+  Info,
+  Inbox
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
@@ -17,6 +18,7 @@ import { Label } from '@/components/ui/label'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog'
 import { Progress } from '@/components/ui/progress'
 import { useToast } from '@/hooks/use-toast'
+import { EmptyState } from '@/components/feedback/EmptyState'
 
 const DecisionApproval = () => {
   const { toast } = useToast()
@@ -286,13 +288,11 @@ const DecisionApproval = () => {
       {/* 待審批決策列表 */}
       <div className="space-y-4">
         {pendingDecisions.length === 0 ? (
-          <Card>
-            <CardContent className="p-8 text-center">
-              <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 mb-2">沒有待審批的決策</h3>
-              <p className="text-gray-600">所有決策都已處理完畢，系統運行正常</p>
-            </CardContent>
-          </Card>
+          <EmptyState
+            icon={Inbox}
+            title="尚無待審批任務"
+            description="當有新的 AI 決策需要審批時,會顯示在這裡。所有決策都已處理完畢，系統運行正常。"
+          />
         ) : (
           pendingDecisions.map((decision) => (
             <Card key={decision.id} className="border-l-4 border-l-orange-400">


### PR DESCRIPTION
## 概要

在決策審批頁面統一使用 `EmptyState` 組件，取代原有的自訂空狀態標記，以符合設計系統規範。

## 變更內容

**修改檔案**: `DecisionApproval.jsx`

### 變更項目
1. **引入 EmptyState 組件**
   - 新增 `import { EmptyState } from '@/components/feedback/EmptyState'`
   - 新增 `Inbox` 圖示引入

2. **替換空狀態實作**
   - **移除**: 使用 `Card` + `CardContent` 的自訂空狀態標記
   - **新增**: 使用統一的 `EmptyState` 組件
   - 更新圖示：`CheckCircle` → `Inbox` (更符合「收件匣為空」的語意)
   - 更新文案：
     - 標題：「沒有待審批的決策」→「尚無待審批任務」
     - 描述：擴充說明，增加引導性

## 設計對齊

✅ 符合 `docs/UX/SAAS_UX_STRATEGY.md § 5.4` 空狀態設計原則：
- 使用統一的空狀態組件
- 清楚的標題與描述
- 適當的圖示選擇

## 審查重點 ⚠️

### 🔴 高優先級
1. **視覺回歸測試**
   - 原空狀態使用 `Card` 容器 (p-8 padding)
   - 新的 `EmptyState` 組件可能有不同的 padding/spacing
   - **需確認**: 空狀態在審批頁面中的視覺呈現是否正確

2. **實作不完整**
   - PR 1.2 要求包含「骨架屏」(skeleton screens)，但本 PR 未實作
   - PR 1.2 要求應用到「所有主要頁面」，但僅修改了 DecisionApproval
   - **問題**: 這是否應該是一個更大範圍的 PR？

3. **文案變更**
   - 標題與描述文字有調整
   - **需確認**: 是否符合 Copywriting 指南？是否需要設計團隊審核？

### 🟡 中優先級
4. **其他頁面狀態**
   - StrategyManagement、HistoryAnalysis、CostAnalysis 已使用 EmptyState
   - Dashboard 未使用（但合理，因為顯示小工具）
   - **建議**: 是否需要全面審查所有頁面的空狀態一致性？

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
- ⚠️ **注意**: 包含輕微的文案變更（title & description）

---

**Link to Devin run**: https://app.devin.ai/sessions/86c5aea8246a4e26a57f9e4a6beab758  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918