### PR TITLE
PR 1.3: Improve Mobile Typography - Responsive Text Sizing (Week 1)

### DIFF
--- a/handoff/20250928/40_App/morningai_enhanced/frontend-dashboard/src/components/AppleHero.jsx
+++ b/handoff/20250928/40_App/morningai_enhanced/frontend-dashboard/src/components/AppleHero.jsx
@@ -121,7 +121,7 @@ const AppleHero = ({ onGetStarted, onLearnMore }) => {
           </motion.div>
 
           <motion.h1
-            className="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tight"
+            className="text-3xl sm:text-5xl lg:text-6xl font-bold tracking-tight"
             {...animationProps}
           >
             <span className="block text-gray-900 dark:text-white">


### PR DESCRIPTION
## 概要
改善 Landing Page Hero 區塊在移動端的字級響應式設計，將最大字級從 `text-5xl` 降至 `text-3xl`，防止小螢幕上出現過大文字。

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 變更內容

**檔案**: `AppleHero.jsx` (1 行)

### 響應式字級調整
```diff
- className="text-5xl sm:text-6xl lg:text-7xl font-bold tracking-tight"
+ className="text-3xl sm:text-5xl lg:text-6xl font-bold tracking-tight"
```

**變更說明**:
- 移動端 (< 640px): text-5xl → **text-3xl** ✅
- 平板 (≥ 640px): text-6xl → **text-5xl** 
- 桌面 (≥ 1024px): text-7xl → **text-6xl**

## 問題背景
根據 CTO 技術報告 (PR #462)，當前 Hero 區塊存在 **P1 響應式設計不完整問題** (-0.5 分)：
- 移動端字體過大，影響閱讀體驗
- 佔用過多垂直空間，需要過度滾動
- 不符合移動端 UI 最佳實踐

## 審核重點 🔍

### 必須驗證
1. **移動端視覺效果** (最重要)
   - [ ] 在實際手機上檢查標題大小是否合適
   - [ ] 確認文字不會過小而難以閱讀
   - [ ] 驗證整體視覺平衡與層級

2. **桌面視覺效果**
   - [ ] 確認 Hero 標題仍具有足夠視覺衝擊力
   - [ ] 檢查與其他元素的視覺層級關係

3. **響應式斷點**
   - [ ] sm: (640px) 和 lg: (1024px) 斷點過渡流暢
   - [ ] 無水平滾動或文字截斷

## 設計系統對齊
✅ 符合 `docs/UX/Design System/Tokens.md § 響應式設計` 規範  
✅ 符合 `docs/UX/SAAS_UX_STRATEGY.md § 8.5` 移動端優化指南  
✅ 遵循 PR #465 設計系統文檔標準

## 測試建議
```bash
# 使用開發者工具測試響應式斷點
- 375px (iPhone SE) - 應顯示 text-3xl
- 640px (iPad Mini) - 應顯示 text-5xl  
- 1024px (Desktop) - 應顯示 text-6xl
```

---

**Link to Devin run**: https://app.devin.ai/sessions/86c5aea8246a4e26a57f9e4a6beab758  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918  
**Ref**: docs/ENGINEERING_TEAM_INSTRUCTIONS.md § PR 1.3