### PR TITLE
fix(ci): use JSON_I18NEXT format for Tolgee sync

### DIFF
--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -48,7 +48,7 @@ jobs:
             --api-key $TOLGEE_API_KEY \
             --project-id $TOLGEE_PROJECT_ID \
             --path src/i18n/locales \
-            --format json
+            --format JSON_I18NEXT
       
       - name: Check for changes
         id: check_changes


### PR DESCRIPTION
## 問題描述

Tolgee CI workflow 的 `sync-translations` job 失敗，錯誤訊息：

```
error: option '--format <format>' argument 'json' is invalid.
Allowed choices are: JSON_TOLGEE, JSON_ICU, JSON_I18NEXT, JSON_JAVA, ...
```

![Tolgee CI Error](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org-586ab28be1e7412aa1c72d6ab213d157/ec5a90c6-b043-44e7-b38f-a44bafa6dc3c?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT75MQD67Y4%2F20251022%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20251022T040635Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEGwaCXVzLWVhc3QtMSJGMEQCIGjmTLx70fNrH%2BGs%2BVvRFbOGOnDfrz9ZcbGWrbccvGnhAiAYLDytR4IewQOccSqW0XMihTU5KnV4lxJ4ESVu4H%2FY2Sq3BQglEAEaDDI3MjUwNjQ5ODMwMyIM9v5O3NlyBjrVGHJiKpQFjj54Su0PSPYm2zDTSiU6tjqBVmCWKQ0dFjNdlPr0sNOzR5eAqS01JCDSyeL1U9AzI%2FeMBvvDWGBFLPu4%2B4yNDK4k7NFpXdB4tm5E2AfiucY7bKuq4Id14vi261XjTVgbXdXV4SVrvW%2B5BgWBP80ouy877UE6iT%2FvWUJg%2Bfw69wa64hVLEDu1zrMycUTbSUMTZz0nhGhlK3k7eQzBQhydRk%2FFOV%2BmMyipmq3vt768N76wBxAxOH8X2I3S0Ite%2BL7HrhRBOzgZAcy3WUYCkwLUidGcXF1fuhJbmTbBqMcePM3Ilz2LhYWIUWta0Xl9%2F9NRP%2BeLtHLCZbAAh9nkIaDvOmX4SXtCpBP1PLgYbTTGp8ZQ9FgTDS1HXIKVDxjtQthVlge57OrNk4gkMVVZwCuJYtWslms%2B5RDP6PvON9ZdAsFmgXmVrnr7BPd4CnTt3UmnqLG9HB%2FKZx%2FJbzhgIrvbKDZyFJwSg0WtUSgI5DCbmrAjvv97DN49F3mf82SG7pNgAfJrcR4ZdIqvwSx1Gx4tD4sfj7QfX62aZYT%2FZCMvXpyys63Y8xwHCurwAzD%2BERaeiVjU9%2FKInwgylACvcqugqNuS8Ql1CNrBq3qGZHuko1ZGX%2B7GpubwMptQmf3EfzDv0XkiRM%2Fqsf9%2FBbDzFxg3Go3CxGKjtSuWEWrE3lpEeJ%2B2%2BPUvuESI%2Bf63gAvi1JL%2Bv4Ttw97bQ9j1nFFtc1%2Bmj62cvPV7XNUY8iHt3tzo8u9x7xKTGQ5Jtv8o3p%2B6ijPkO1bF7MPB5MJOZpCOb%2FoHu7fzIZ6BK%2BVMeSXF9UVvj%2BMy5RKATegyk7SXLlaYoKRImYEn2BOolYOM5ErqbKttKb1e4%2Fl4MfO23MPJ0qduuCOIxG7WMMeo4ccGOpkBM5WZQkuo1bBr3Z6SzyzK6oPzRI2bJv95Ly%2FZ7%2BBdYmBm3X%2BZL887SO64wJzd7BCLoAEPrxbs13keY0%2BoE1%2FMyXWIseTDMsFGVanbOmIkeeRvcAUkGn5F7pC%2F7nv5NvQ%2Bkfpy5R2Ihub2AtXofYxf%2BRF%2B0Hbs%2BoBtrTGReR9tadmETKLnDmJgHIsbWq1NJ4kta0TU5w1kxUHV&X-Amz-Signature=d5e7ead24aa4c4aca91a60f106ed201c4978d53a40b3123f816dfa619b518989)

## 根本原因

Tolgee CLI 新版本不再接受 `--format json` 參數，需要使用明確的格式名稱。由於本專案使用 i18next 架構，正確的格式應該是 `JSON_I18NEXT`。

## 修復內容

**變更檔案**: `.github/workflows/tolgee-sync.yml`

```diff
- --format json
+ --format JSON_I18NEXT
```

## 驗收標準

- [ ] GitHub Actions workflow 執行成功
- [ ] 可成功從 Tolgee 拉取翻譯檔案
- [ ] 翻譯檔案格式與現有 i18next 結構相容

## 注意事項

⚠️ **無法本地測試**: 此變更只能透過實際執行 GitHub Actions workflow 來驗證。建議合併後手動觸發 workflow 或等待自動排程執行來確認修復成功。

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

✅ 本 PR 僅修改 CI 配置，不涉及 API 或資料欄位變更

---

🤖 Link to Devin run: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8  
👤 Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918