### PR TITLE
fix(orchestrator): Fix Dockerfile COPY paths to resolve ModuleNotFoundError

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -9,15 +9,15 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching
-COPY orchestrator/requirements.txt .
+COPY orchestrator/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
-# Copy orchestrator code
-COPY orchestrator/ /app/
+# Copy orchestrator code (preserve directory structure)
+COPY orchestrator/ ./orchestrator/
 
 # Install orchestrator package
-RUN pip install --no-cache-dir -e /app
+RUN pip install --no-cache-dir -e ./orchestrator
 
 # Expose port
 EXPOSE 8000


### PR DESCRIPTION
## 概述
修復 Orchestrator 生產環境部署失敗問題 (`ModuleNotFoundError: No module named 'orchestrator'`)

## 問題描述
PR #565 合併後，Render 部署失敗，錯誤訊息：
```
ModuleNotFoundError: No module named 'orchestrator'
```

**根本原因**：Dockerfile 的 `COPY orchestrator/ /app/` 會將 orchestrator 目錄的**內容**複製到 /app，導致目錄結構變成：
```
/app/
  setup.py
  api/
  schemas/
  task_queue/
```

但 `setup.py` 使用 `find_packages()` 期望找到 `orchestrator` 套件目錄，實際需要：
```
/app/
  orchestrator/
    setup.py
    api/
    schemas/
    task_queue/
```

## 變更內容
**orchestrator/Dockerfile** (4 行變更):
1. `COPY orchestrator/requirements.txt .` → `COPY orchestrator/requirements.txt ./requirements.txt`
2. `COPY orchestrator/ /app/` → `COPY orchestrator/ ./orchestrator/` (保留目錄結構)
3. `RUN pip install -e /app` → `RUN pip install -e ./orchestrator`

## 測試驗證
✅ **本地 Docker build 成功**
```bash
docker build -f orchestrator/Dockerfile -t test-orch-fixed .
# Successfully built orchestrator-1.0.0
```

✅ **模組匯入測試成功**
```bash
docker run --rm test-orch-fixed python -c "import orchestrator; print('✓')"
# ✓ orchestrator module imported successfully
```

✅ **FastAPI app 匯入測試成功**（需要環境變數）
```bash
docker run --rm -e ORCHESTRATOR_JWT_SECRET=test... -e REDIS_URL=redis://... \
  test-orch-fixed python -c "from orchestrator.api.main import app; print('✓')"
# ✓ FastAPI app imported successfully with env vars
```

## 影響範圍
- 僅影響 Docker 建置流程
- 不影響應用程式邏輯或 API
- 不修改 render.yaml 或其他配置檔

## 部署驗證重點
合併後請確認：
1. Render 自動部署觸發
2. Docker build 成功完成
3. 容器啟動無 ModuleNotFoundError
4. `/health` 端點回應正常

## 提醒
- [x] 不修改 OpenAPI/資料欄位（本 PR 無涉及）
- [x] 工程 PR 僅含 API/邏輯（本 PR 僅修改 Dockerfile）

---

**Devin run**: https://app.devin.ai/sessions/2023940518f2448689213a3d61ebbd0b  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918  
**Priority**: 🚨 CRITICAL HOTFIX - 生產環境無法啟動