### PR TITLE
fix(ci): add working-directory for Tolgee sync

### DIFF
--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -21,6 +21,7 @@ jobs:
         run: npm i -g @tolgee/cli
 
       - name: Pull translations from Tolgee
+        working-directory: handoff/20250928/40_App/frontend-dashboard
         run: |
           tolgee pull \
             --api-url https://app.tolgee.io \


### PR DESCRIPTION
## Problem

The Tolgee sync workflow was failing with "Not a valid project ID" error because the Tolgee CLI was running in the wrong directory.

## Solution

Added `working-directory: handoff/20250928/40_App/frontend-dashboard` to the "Pull translations from Tolgee" step.

The Tolgee CLI needs to run in the frontend-dashboard directory where:
- `tolgee.config.json` is located
- `src/i18n/locales` directory exists

## Testing

After merging this PR, the Tolgee sync workflow should successfully pull translations from Tolgee.

---

**Link to Devin run**: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918