### PR TITLE
fix(ci): add Tolgee config file and simplify workflow

### DIFF
--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -22,13 +22,10 @@ jobs:
 
       - name: Pull translations from Tolgee
         working-directory: handoff/20250928/40_App/frontend-dashboard
+        env:
+          TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
         run: |
-          tolgee pull \
-            --api-url https://app.tolgee.io \
-            --api-key "${{ secrets.TOLGEE_API_KEY }}" \
-            --project-id "${{ secrets.TOLGEE_PROJECT_ID }}" \
-            --path src/i18n/locales \
-            --format JSON_I18NEXT
+          tolgee pull --api-key "$TOLGEE_API_KEY"
 
       - name: Create PR if changes
         uses: peter-evans/create-pull-request@v6

--- a/handoff/20250928/40_App/frontend-dashboard/.tolgeerc
+++ b/handoff/20250928/40_App/frontend-dashboard/.tolgeerc
@@ -1,0 +1,8 @@
+{
+  "projectId": 23882,
+  "apiUrl": "https://app.tolgee.io",
+  "format": "JSON_I18NEXT",
+  "pull": {
+    "path": "./src/i18n/locales"
+  }
+}


### PR DESCRIPTION
## Problem

The Tolgee sync workflow was failing with "Not a valid project ID" error even after setting secrets correctly. The issue appears to be with how the Tolgee CLI parses command-line arguments for secrets.

## Solution

1. **Added `.tolgeerc` config file** in `handoff/20250928/40_App/frontend-dashboard/`:
   - Specifies `projectId: 23882`
   - Sets `apiUrl`, `format`, and `path` configuration
   - This eliminates the need to pass these as command-line arguments

2. **Simplified workflow**:
   - Now only passes API key via environment variable
   - Relies on `.tolgeerc` for all other configuration
   - Avoids argument parsing issues with GitHub secrets

## Testing

After merging this PR, the Tolgee sync workflow should successfully pull translations from Tolgee using the config file.

---

**Link to Devin run**: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918