### PR TITLE
fix(ci): use tolgee login before pull

### DIFF
--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -25,7 +25,8 @@ jobs:
         env:
           TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
         run: |
-          tolgee pull --api-key "$TOLGEE_API_KEY"
+          tolgee login "$TOLGEE_API_KEY"
+          tolgee pull --project-id=23882 --path ./src/i18n/locales
 
       - name: Create PR if changes
         uses: peter-evans/create-pull-request@v6


### PR DESCRIPTION
## Problem

The Tolgee sync workflow was failing with 401 authentication error (`invalid_project_api_key`) even with correct API key and project ID.

## Root Cause

The Tolgee CLI requires authentication via `tolgee login` before running `tolgee pull`. Our workflow was trying to pass the API key directly to the pull command, which doesn't work.

## Solution

1. **Use `tolgee login` first** to authenticate with the API key
2. **Then run `tolgee pull`** with explicit `--project-id` and `--path` parameters

This matches the recommended workflow shown in Tolgee's Integrate page.

## Testing

After merging this PR, the Tolgee sync workflow should successfully authenticate and pull translations.

---

**Link to Devin run**: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918