### PR TITLE
fix(ci): Allow manual trigger for lhci-main job

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -111,7 +111,7 @@ jobs:
           fi
 
   lhci-main:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     concurrency:
       group: lhci-main


### PR DESCRIPTION
## 摘要

修改 `lighthouse-ci` workflow，允許 `lhci-main` job 可以透過手動觸發 (`workflow_dispatch`) 執行，以便測試 Phase 2 (Playwright 認證) 功能。

## 變更內容

修改 `.github/workflows/lhci.yml` 第 114 行條件：
```yaml
# 修改前
if: github.ref == 'refs/heads/main' && github.event_name == 'push'

# 修改後  
if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
```

## 為什麼需要這個修改？

PR #591 剛將 `lighthouse-ci` workflow 合併到 main 分支。根據 GitHub Actions 的已知行為，**新增的 workflow 不會在添加它的那次 commit 上自動觸發**。

這意味著：
- 這次合併不會自動執行 `lhci-main` job
- 需要手動觸發才能測試 Phase 2 的 Playwright 認證功能
- 未來的 pushes 會正常自動觸發

## 安全性說明

這個修改是安全的：
- ✅ 仍然限制在 `main` 分支 (`github.ref == 'refs/heads/main'`)
- ✅ 只有 repo maintainers 才能手動觸發 workflows (GitHub 權限控制)
- ✅ 已有 concurrency 控制防止多個實例同時運行
- ✅ 遵循 GitHub Actions 標準模式 (許多 workflows 都支援 push + workflow_dispatch)

## 人工審查檢查清單

- [ ] Boolean 條件語法正確
- [ ] 符合 GitHub Actions 最佳實踐
- [ ] 不會造成非預期的 workflow 觸發

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 CI/CD 配置

---

**Link to Devin run:** https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8  
**Requested by:** Ryan Chen (ryan2939z@gmail.com) (@RC918)