### PR TITLE
feat(ci): Add @playwright/test as dev dependency for LHCI authentication

### DIFF
--- a/frontend-dashboard-deploy/package.json
+++ b/frontend-dashboard-deploy/package.json
@@ -79,6 +79,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
+    "@playwright/test": "^1.56.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/frontend-dashboard-deploy/pnpm-lock.yaml
+++ b/frontend-dashboard-deploy/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       '@eslint/js':
         specifier: ^9.25.0
         version: 9.36.0
+      '@playwright/test':
+        specifier: ^1.56.1
+        version: 1.56.1
       '@types/react':
         specifier: ^19.1.2
         version: 19.1.15
@@ -737,6 +740,11 @@ packages:
 
   '@orval/zod@7.13.0':
     resolution: {integrity: sha512-jEEj0uRO5D5D1CHKQdth5Atl5Ap4/P21SMiOFmVpiArlXr4LQtMpbkiPVM2tsQXIhtC38c9oMt8+rOx1rYSjcw==}
+
+  '@playwright/test@1.56.1':
+    resolution: {integrity: sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -2571,6 +2579,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3396,6 +3409,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.56.1:
+    resolution: {integrity: sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.56.1:
+    resolution: {integrity: sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -4783,6 +4806,10 @@ snapshots:
       - openapi-types
       - supports-color
       - typescript
+
+  '@playwright/test@1.56.1':
+    dependencies:
+      playwright: 1.56.1
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6822,6 +6849,9 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -7665,6 +7695,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.56.1: {}
+
+  playwright@1.56.1:
+    dependencies:
+      playwright-core: 1.56.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 


### PR DESCRIPTION
## 摘要

修復 Lighthouse CI workflow 中 Phase 2 (Playwright 認證) 執行失敗的問題。新增 `@playwright/test` 為 devDependency。

## 問題

PR #591 合併後，嘗試執行 `lhci-main` job 時失敗，錯誤訊息：
```
Error: Cannot find package '@playwright/test' imported from .../tests/auth.setup.spec.ts
```

## 根本原因

`tests/auth.setup.spec.ts` 檔案使用 `import { test, expect } from '@playwright/test'`，但 `@playwright/test` 套件未列在 `package.json` 的 devDependencies 中。

Workflow 原本使用 `pnpm dlx playwright` 下載 CLI 工具，但這不會安裝 `@playwright/test` 套件本身。

## 解決方案

新增 `@playwright/test@^1.56.1` 作為 devDependency。

## 變更內容

- ✅ `frontend-dashboard-deploy/package.json`: 新增 `@playwright/test@^1.56.1` 到 devDependencies
- ✅ `frontend-dashboard-deploy/pnpm-lock.yaml`: 自動生成的 lockfile 更新

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 審查重點

1. **版本選擇**: 使用 `^1.56.1`（最新版本），確認是否適合專案
2. **依賴範圍**: 確認放在 devDependencies 正確（僅 CI 使用）
3. **套件大小**: Playwright 含瀏覽器二進位檔，約 50MB，會影響 CI 構建時間

## 測試計畫

合併後，手動觸發 `lighthouse-ci` workflow 驗證 Phase 2 認證測試是否成功執行。

---

Link to Devin run: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918