### PR TITLE
fix(ci): Fix __dirname usage in ES module for Playwright auth test

### DIFF
--- a/frontend-dashboard-deploy/tests/auth.setup.spec.ts
+++ b/frontend-dashboard-deploy/tests/auth.setup.spec.ts
@@ -15,7 +15,10 @@
 
 import { test as setup, expect } from '@playwright/test';
 import path from 'path';
+import { fileURLToPath } from 'url';
 
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const authFile = path.join(__dirname, '../playwright/.auth/storageState.json');
 
 setup('authenticate', async ({ page }) => {


### PR DESCRIPTION
## 摘要

修復 Playwright 認證測試在 CI 中執行失敗的問題。將 CommonJS 的 `__dirname` 改為 ES module 相容的寫法。

## 問題

Lighthouse CI workflow 的 `lhci-main` job 在執行 Playwright 認證測試時失敗：

```
ReferenceError: __dirname is not defined in ES module scope
at tests/auth.setup.spec.ts:19
```

## 根本原因

`frontend-dashboard-deploy/package.json` 設定為 `"type": "module"`，所有 .ts/.js 檔案都被視為 ES modules。ES modules 不支援 CommonJS 的 `__dirname` 全域變數。

## 解決方案

使用 ES module 標準做法取代 `__dirname`：

```typescript
import { fileURLToPath } from 'url';

const __filename = fileURLToPath(import.meta.url);
const __dirname = path.dirname(__filename);
```

這是 Node.js 官方推薦的 ES module 中取得目錄路徑的方式。

## 測試計畫

合併後將手動觸發 `lighthouse-ci` workflow 來驗證：
1. Playwright 認證測試能成功執行
2. 認證狀態正確儲存到 `playwright/.auth/storageState.json`
3. Lighthouse CI 能使用認證狀態測試受保護頁面

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR，僅含邏輯修正

## 審查重點
- [ ] ES module 寫法是否正確（應該是標準做法）
- [ ] 確認沒有其他檔案使用 `__dirname` 需要類似修正
- [ ] 等待 CI 執行結果，確認 Playwright 認證完整流程成功

---

**Link to Devin run**: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8  
**Requested by**: Ryan Chen (@RC918)