### PR TITLE
hotfix: Add PyYAML dependency for governance module

### DIFF
--- a/agents/ops_agent/requirements.txt
+++ b/agents/ops_agent/requirements.txt
@@ -5,3 +5,4 @@ pytest-asyncio==1.2.0
 redis==5.0.1
 requests==2.31.0
 pydantic>=2.10.0
+PyYAML>=6.0


### PR DESCRIPTION
## 問題描述

PR #618 合併後，`morningai-ops-agent-worker` 在 Render 部署時無法啟動，錯誤訊息：

```
ModuleNotFoundError: No module named 'yaml'
```

**錯誤追蹤：**
```
agents/ops_agent/worker.py:28 
  → governance/__init__.py:2 
  → governance/policy_guard.py:3 
  → import yaml  ❌
```

## 修復方案

新增 `PyYAML>=6.0` 到 `agents/ops_agent/requirements.txt`

Governance 模組的 `policy_guard.py` 需要 PyYAML 來解析 policy 配置檔案，但 ops-agent-worker 的依賴清單中遺漏了這個套件。

## 驗證步驟

合併後檢查 Render 的 `morningai-ops-agent-worker` logs：

✅ 應該看到：
```
Governance modules initialized
Registered with Governance (agent_id: ...)
```

❌ 不應該再看到：
```
ModuleNotFoundError: No module named 'yaml'
```

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）✅ 僅修改 requirements.txt
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯 ✅ 僅修改依賴配置

## 審查重點

1. **PyYAML 版本限制**：使用 `>=6.0` 是否合適？是否需要更嚴格的版本鎖定？
2. **修復範圍**：是否有其他 worker/service 也使用 governance 模組但缺少此依賴？
3. **部署驗證**：合併後需立即檢查 Render logs 確認 worker 正常啟動

---

**Link to Devin run:** https://app.devin.ai/sessions/e92ff7dba2194644be2027a96e24cebb  
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918