### PR TITLE
feat(ci): Add Playwright configuration for LHCI authentication tests

### DIFF
--- a/frontend-dashboard-deploy/playwright.config.ts
+++ b/frontend-dashboard-deploy/playwright.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30000,
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+  },
+});


### PR DESCRIPTION
## 摘要

新增 Playwright 設定檔，修復 Lighthouse CI workflow 中 Phase 2 (Playwright 認證) 執行失敗的問題。

## 問題

Lighthouse CI 的 `lhci-main` job 在執行 Playwright 認證測試時失敗：
```
Error: Playwright Test did not expect test() to be called here.
Most common reasons include:
- You are calling test() in a configuration file.
```

## 根本原因

Playwright 需要 `playwright.config.ts` 設定檔才能正確執行測試。缺少此檔案時，Playwright 無法識別測試檔案並正確初始化測試環境。

## 解決方案

新增最小化的 Playwright 設定檔：
- `testDir`: 指向 `./tests` 目錄
- `timeout`: 30 秒測試超時
- `baseURL`: `http://localhost:4173` (與 workflow 中的 preview server 一致)
- `trace`: 首次重試時啟用追蹤

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR，僅含 CI/測試配置

## 人工審查重點
- [ ] 此最小化設定是否足夠 CI 認證測試使用？
- [ ] 是否需要額外的 Playwright 設定（例如：browser、reporter、retry）？
- [ ] baseURL 是否應改為可通過環境變數配置？

---

**Link to Devin run**: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918

**Context**: 此 PR 是 PR #591 (Lighthouse CI 實作) 的後續修復，用於啟用 Phase 2 (Playwright 認證頁面測試)。這是修復過程中發現的第三個問題。