### PR TITLE
fix(ci): Use locally installed Playwright to avoid version conflicts

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -150,8 +150,8 @@ jobs:
           TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
         run: |
-          pnpm dlx playwright install --with-deps chromium
-          pnpm dlx playwright test tests/auth.setup.spec.ts
+          pnpm exec playwright install --with-deps chromium
+          pnpm exec playwright test tests/auth.setup.spec.ts
           node ../scripts/make-lhci-cookie.js
 
       - name: Start preview server


### PR DESCRIPTION
## 摘要

修復 Lighthouse CI workflow 中 Playwright 版本衝突問題。將 `pnpm dlx playwright` 改為 `pnpm exec playwright`，使用本地安裝的版本而非下載新版本。

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 問題

Lighthouse CI 的 `lhci-main` job 在執行 Playwright 認證測試時持續失敗：
```
Error: Playwright Test did not expect test() to be called here.
Most common reasons include:
- You have two different versions of @playwright/test.
```

## 根本原因

使用 `pnpm dlx playwright` 會下載並使用獨立的 Playwright 版本，與專案中透過 `package.json` 安裝的 `@playwright/test` 版本衝突。當測試檔案 import `@playwright/test` 時，會使用專案版本，但 CLI 使用 dlx 版本，導致版本不一致錯誤。

## 解決方案

改用 `pnpm exec playwright`，確保使用與 `@playwright/test` 相同的本地安裝版本：
- `pnpm dlx playwright` → 下載臨時版本（會衝突）
- `pnpm exec playwright` → 使用 node_modules 中的版本（正確）

## 變更內容

- `.github/workflows/lhci.yml` 第 153-154 行：
  - `pnpm dlx playwright install` → `pnpm exec playwright install`
  - `pnpm dlx playwright test` → `pnpm exec playwright test`

## 測試注意事項

⚠️ **此 PR 無法在 PR CI 中完整測試**，因為 `lhci-main` job 只在 main 分支執行。需要：
1. 合併後手動觸發 workflow (`workflow_dispatch`)
2. 確認 Playwright 認證測試成功執行
3. 驗證認證頁面 (`/dashboard`, `/settings`) 的 Lighthouse 測試正常運行

## 人工審查重點

1. **邏輯正確性**：使用 `pnpm exec` 而非 `pnpm dlx` 是否為正確的版本衝突解決方案？
2. **依賴確認**：確認 `@playwright/test` 已在 `frontend-dashboard-deploy/package.json` 的 devDependencies 中（來自 PR #622）
3. **風險認知**：理解此變更只能在合併後於 main 分支驗證

## 相關資訊

- **Devin Session**: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8
- **Requested by**: Ryan Chen (@RC918)
- **Related PRs**: #621 (workflow manual trigger), #622 (add @playwright/test), #623 (fix __dirname), #625 (add playwright.config.ts)