### PR TITLE
hotfix: Add Supabase SDK dependency for governance integration

### DIFF
--- a/agents/ops_agent/requirements.txt
+++ b/agents/ops_agent/requirements.txt
@@ -6,3 +6,4 @@ redis==5.0.1
 requests==2.31.0
 pydantic>=2.10.0
 PyYAML>=6.0
+supabase==2.6.0


### PR DESCRIPTION
## 問題描述

PR #624 修復了 PyYAML 依賴後，worker 可以啟動但顯示：

```
⚠️ Could not register with Governance (degraded mode)
```

**根本原因**：Governance 模組需要 Supabase SDK 來連接資料庫，但 ops_agent 的 requirements.txt 中缺少此依賴。

**錯誤追蹤**：
```
governance/reputation_engine.py 
  → governance/persistence/db_client.py 
  → from supabase import create_client  ❌
```

## 修復方案

新增 `supabase==2.6.0` 到 `agents/ops_agent/requirements.txt`

- 版本與 orchestrator 保持一致（2.6.0）
- Supabase 環境變數已在 Render 配置（SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY）
- 修復後 worker 將能完整使用 governance 功能（reputation tracking, permission checks）

## 驗證步驟

合併後檢查 Render 的 `morningai-ops-agent-worker` logs：

✅ 應該看到：
```
✅ Registered with Governance (agent_id: ...)
   Permission Level: sandbox_only, Reputation Score: 100
```

❌ 不應該再看到：
```
⚠️ Could not register with Governance (degraded mode)
```

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）✅ 僅修改 requirements.txt
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯 ✅ 僅修改依賴配置

## 審查重點

1. **版本一致性**：`supabase==2.6.0` 與 orchestrator/requirements.txt 版本一致 ✓
2. **環境變數**：Supabase credentials 已在 Render 配置（見截圖）
3. **部署驗證**：合併後需檢查 Render logs 確認 governance 註冊成功

## 相關 PR

- PR #618: Agent Governance Framework Integration（已合併）
- PR #624: Add PyYAML dependency（已合併）
- PR #625: Add Supabase SDK dependency（本 PR）

---

**Link to Devin run:** https://app.devin.ai/sessions/e92ff7dba2194644be2027a96e24cebb  
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918