### PR TITLE
fix(ci): Start preview server before Playwright authentication

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -143,17 +143,6 @@ jobs:
       - name: Build application
         run: pnpm build
 
-      - name: Setup Playwright authentication
-        env:
-          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_TEST_URL }}
-          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_TEST_KEY }}
-          TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
-          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-        run: |
-          pnpm exec playwright install --with-deps chromium
-          pnpm exec playwright test tests/auth.setup.spec.ts
-          node ../scripts/make-lhci-cookie.js
-
       - name: Start preview server
         run: |
           pnpm preview --port 4173 &
@@ -172,6 +161,17 @@ jobs:
           done
           echo "Server failed to start within 120 seconds"
           exit 1
+
+      - name: Setup Playwright authentication
+        env:
+          VITE_SUPABASE_URL: ${{ secrets.SUPABASE_TEST_URL }}
+          VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_TEST_KEY }}
+          TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
+          TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+        run: |
+          pnpm exec playwright install --with-deps chromium
+          pnpm exec playwright test tests/auth.setup.spec.ts
+          node ../scripts/make-lhci-cookie.js
 
       - name: Run Lighthouse CI (main - accurate)
         run: pnpm dlx @lhci/cli collect --url=http://localhost:4173/ --url=http://localhost:4173/login --url=http://localhost:4173/pricing --url=http://localhost:4173/dashboard --url=http://localhost:4173/settings --numberOfRuns=3


### PR DESCRIPTION
## 摘要

修復 Lighthouse CI workflow 中 Playwright 認證測試失敗的問題。將 preview server 啟動步驟移到認證測試之前執行。

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 問題

Lighthouse CI 的 `lhci-main` job 在執行 Playwright 認證測試時失敗：

```
Error: page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:4173/login
```

## 根本原因

工作流程步驟順序錯誤：
1. ❌ 先執行 "Setup Playwright authentication" (嘗試連接 localhost:4173)
2. ❌ 後執行 "Start preview server" (啟動 localhost:4173)

導致認證測試在 server 啟動之前就嘗試連線，因此失敗。

## 解決方案

調整步驟執行順序：
1. ✅ Build application
2. ✅ **Start preview server** (啟動 localhost:4173)
3. ✅ **Wait for server** (等待 server 就緒)
4. ✅ **Setup Playwright authentication** (執行認證測試)
5. ✅ Run Lighthouse CI

## 重點審查項目

- [ ] 步驟順序邏輯正確：server 必須先啟動，認證測試才能執行
- [ ] 所有環境變數仍正確傳遞給認證步驟
- [ ] "Wait for server" 步驟會在 server 啟動失敗時正確退出 (exit 1)

---

**Link to Devin run**: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918