### PR TITLE
fix(ci): Use mock credentials for Playwright authentication test

### DIFF
--- a/frontend-dashboard-deploy/tests/auth.setup.spec.ts
+++ b/frontend-dashboard-deploy/tests/auth.setup.spec.ts
@@ -22,22 +22,15 @@ const __dirname = path.dirname(__filename);
 const authFile = path.join(__dirname, '../playwright/.auth/storageState.json');
 
 setup('authenticate', async ({ page }) => {
-  const testEmail = process.env.TEST_EMAIL;
-  const testPassword = process.env.TEST_PASSWORD;
-
-  if (!testEmail || !testPassword) {
-    throw new Error('TEST_EMAIL and TEST_PASSWORD environment variables are required');
-  }
-
   console.log('🔐 Starting authentication setup...');
-  console.log(`   Email: ${testEmail}`);
+  console.log('   Using mock credentials: admin/admin123');
 
   await page.goto('http://localhost:4173/login');
 
   await page.waitForLoadState('networkidle');
 
-  await page.fill('input[name="username"]', testEmail);
-  await page.fill('input[name="password"]', testPassword);
+  await page.fill('input[name="username"]', 'admin');
+  await page.fill('input[name="password"]', 'admin123');
 
   await page.click('button[type="submit"]');
 


### PR DESCRIPTION
## 摘要

將 Playwright 認證測試改為使用 mock 憑證（`admin/admin123`）而非從環境變數讀取 Supabase 測試帳號憑證。

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 問題

Playwright 認證測試失敗，因為：
1. 測試嘗試使用 `TEST_EMAIL` 和 `TEST_PASSWORD` 環境變數中的 Supabase 憑證
2. 但前端應用目前只實作了 mock 認證系統，不支援真正的 Supabase 認證
3. Mock 認證只接受 `admin/admin123` 憑證
4. 使用 Supabase 憑證登入失敗，導致無法取得 localStorage 資料用於後續的 Lighthouse CI 測試

## 解決方案

修改 `auth.setup.spec.ts` 測試檔案：
- 移除讀取 `TEST_EMAIL` 和 `TEST_PASSWORD` 環境變數的邏輯
- 直接使用 mock 憑證 `admin/admin123` 進行登入測試
- 保持其他測試流程不變（等待頁面載入、填寫表單、等待重導向、儲存 session state）

## ⚠️ 重要審查點

1. **認證系統對齊**: 此 PR 假設目前使用 mock 認證系統。如果未來需要測試真正的 Supabase 認證，需要重新調整此測試
2. **未經驗證**: 此變更尚未在 CI 中測試過。需要確認：
   - Mock 認證是否會成功重導向至 dashboard
   - Mock 認證是否會在 localStorage 儲存可用的 session 資料
   - 儲存的資料是否能被後續的 LHCI Puppeteer 腳本正確使用
3. **硬編碼憑證**: 直接在測試中使用 `admin/admin123` 可能導致維護問題，如果 mock 憑證改變需要同步更新

## 相關連結

- Devin 工作階段: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8
- 請求者: Ryan Chen (@RC918)