### PR TITLE
hotfix: Fix governance module import path and agent_type

### DIFF
--- a/agents/ops_agent/worker.py
+++ b/agents/ops_agent/worker.py
@@ -100,7 +100,7 @@ class OpsAgentWorker:
             )
             logger.info("✅ Initialized Ops Agent OODA Loop")
             
-            self.agent_id = self.reputation_engine.get_or_create_agent('ops')
+            self.agent_id = self.reputation_engine.get_or_create_agent('ops_agent')
             if self.agent_id:
                 logger.info(f"✅ Registered with Governance (agent_id: {self.agent_id})")
                 permission_level = self.reputation_engine.get_permission_level(self.agent_id)

--- a/handoff/20250928/40_App/orchestrator/governance/reputation_engine.py
+++ b/handoff/20250928/40_App/orchestrator/governance/reputation_engine.py
@@ -39,6 +39,13 @@ class ReputationEngine:
         try:
             from orchestrator.persistence.db_client import get_client
             return get_client()
+        except (ImportError, ModuleNotFoundError):
+            try:
+                from persistence.db_client import get_client
+                return get_client()
+            except Exception as e:
+                print(f"[ReputationEngine] Supabase unavailable: {e}")
+                return None
         except Exception as e:
             print(f"[ReputationEngine] Supabase unavailable: {e}")
             return None


### PR DESCRIPTION
## 問題描述

PR #624 和 #628 修復了 PyYAML 和 Supabase SDK 依賴後，worker 仍顯示：

```
⚠️ Could not register with Governance (degraded mode)
```

**根本原因**：兩個問題導致 governance 註冊失敗

1. **模組導入路徑錯誤**：
   ```
   worker.py 設定: sys.path.insert(0, 'handoff/20250928/40_App/orchestrator')
   reputation_engine.py 嘗試: from orchestrator.persistence.db_client import get_client
   結果: ModuleNotFoundError (尋找 orchestrator/orchestrator/persistence)
   ```

2. **Agent type 不符合資料庫限制**：
   ```python
   worker 使用: get_or_create_agent('ops')  # ❌
   資料庫限制: 只允許 'ops_agent', 'dev_agent', 'pm_agent' 等
   錯誤: agent_reputation_agent_type_check constraint violation
   ```

## 修復方案

### 1. reputation_engine.py：新增 fallback 導入邏輯
```python
try:
    from orchestrator.persistence.db_client import get_client  # 原本路徑
    return get_client()
except (ImportError, ModuleNotFoundError):
    try:
        from persistence.db_client import get_client  # fallback 路徑
        return get_client()
    except Exception as e:
        print(f"[ReputationEngine] Supabase unavailable: {e}")
        return None
```

- 先嘗試完整路徑（orchestrator.persistence）
- 失敗則嘗試相對路徑（persistence）
- 兩者都失敗才返回 None

### 2. worker.py：修正 agent_type
```python
- self.agent_id = self.reputation_engine.get_or_create_agent('ops')
+ self.agent_id = self.reputation_engine.get_or_create_agent('ops_agent')
```

- 符合資料庫 check constraint
- 與現有 ops_agent 記錄對應（agent_id: 7df3273c-1c9c-49cf-9fb3-41d8494768d8）

## 驗證

本地測試成功連接 Supabase 並註冊：
```
✅ Successfully registered agent: 7df3273c-1c9c-49cf-9fb3-41d8494768d8
   Permission Level: sandbox_only, Reputation Score: 100
```

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）✅ 僅修改程式邏輯
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯 ✅ 工程 PR

## 審查重點

1. **Import fallback 邏輯**：確認 fallback 機制不會隱藏其他重要錯誤（如權限問題、資料表不存在等）

2. **Agent type 一致性**：worker.py line 153 檢查 `task.assigned_to != "ops"`，但現在註冊為 `'ops_agent'`。請確認：
   - Task routing identifier (`assigned_to = "ops"`) 
   - Governance registration type (`agent_type = "ops_agent"`)
   
   是否為刻意設計的不同識別符？

3. **資料庫相容性**：確認所有環境（dev/staging/prod）的資料庫都有 `'ops_agent'` 類型配置

4. **Policies.yaml**：本地測試時出現 policies.yaml 路徑錯誤，但在 production 應該正常。請確認 Render 環境中此檔案路徑正確

## 相關 PR

- PR #618: Agent Governance Framework Integration
- PR #624: Add PyYAML dependency  
- PR #628: Add Supabase SDK dependency

---

**Link to Devin run:** https://app.devin.ai/sessions/e92ff7dba2194644be2027a96e24cebb  
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918