### PR TITLE
fix(ci): Allow baseline commit to fail due to branch protection

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -189,6 +189,7 @@ jobs:
 
       - name: Commit baseline updates
         if: always()
+        continue-on-error: true
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore(ci): update LHCI baseline & trend [skip ci]"


### PR DESCRIPTION
## Summary

修正 Lighthouse CI workflow 在嘗試 commit baseline 更新時因為 branch protection rule 而失敗的問題。

## Context

在 workflow run 18741898241 中，Lighthouse CI 成功完成所有測試（包括 Phase 2 認證的頁面測試），但在最後一步 "Commit baseline updates" 失敗了：

```
remote: error: GH013: Repository rule violations found for refs/heads/main
remote: - Changes must be made through a pull request.
error: failed to push some refs to 'https://github.com/RC918/morningai'
```

這是因為 main 分支有 branch protection rule，不允許直接 push，必須透過 PR。

## Changes

**`.github/workflows/lhci.yml`:**
- 在 "Commit baseline updates" 步驟添加 `continue-on-error: true`
- 這允許 workflow 即使 commit 失敗也能成功完成

## Impact

- ✅ Workflow 不會因為無法 commit baseline 而失敗
- ⚠️ Baseline 更新不會自動 commit 到 main（但仍會計算並存在 artifacts 中）
- ✅ 不影響 Lighthouse CI 測試本身的執行

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
- [x] 此為 CI/workflow 修正，不涉及 API 或 UI 變更

## Human Review Checklist

**Critical items to verify:**
1. ⚠️ **Silent failure acceptable?** - Baseline commits will now fail silently. Is this the desired behavior, or should we implement automated PR creation for baseline updates?
2. ✅ **Workflow success** - Verify that the workflow completes successfully after this change (trigger a test run)
3. 💡 **Future consideration** - Should we add a notification when baseline commit fails, or implement a better solution (e.g., automated PR for baseline updates)?

**Note**: Lighthouse CI Phase 2 authentication is now working correctly! The previous run successfully tested `/dashboard` and `/settings` pages with mock authentication.

---

**Link to Devin run**: https://app.devin.ai/sessions/6d970144dd4c4def9839fe3f8a573ab8

**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918