### PR TITLE
chore: P1 Dependency Version Unification - Playwright ^1.56.1

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/package.json
+++ b/handoff/20250928/40_App/frontend-dashboard/package.json
@@ -80,7 +80,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
-    "@playwright/test": "^1.48.2",
+    "@playwright/test": "^1.56.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",

--- a/handoff/20250928/40_App/owner-console/package.json
+++ b/handoff/20250928/40_App/owner-console/package.json
@@ -79,7 +79,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
-    "@playwright/test": "^1.48.2",
+    "@playwright/test": "^1.56.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",


### PR DESCRIPTION
## 概述

統一三個前端應用的 `@playwright/test` 版本至 `^1.56.1`，解決 P1 依賴版本統一任務中發現的唯一開發依賴衝突。

## 變更內容

更新以下應用的 Playwright 版本：
- **frontend-dashboard**: `^1.48.2` → `^1.56.1`
- **owner-console**: `^1.48.2` → `^1.56.1`

此變更使這兩個應用與 `frontend-dashboard-deploy` 版本一致。

## 背景

依賴版本分析顯示：
- ✅ **0 個生產依賴衝突** - 所有生產依賴已完全統一
- ✅ **59 個共同依賴** - 使用相同版本 (94.7% 一致性)
- ⚠️ **1 個開發依賴衝突** - `@playwright/test` (本 PR 修復)

詳細分析報告：`/home/ubuntu/DEPENDENCY_UNIFICATION_REPORT.md`

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 審查重點

### ⚠️ 必須檢查
1. **CI 測試結果** - 所有 Playwright E2E 測試必須通過
2. **測試行為** - 確認沒有引入新的測試失敗或不穩定性
3. **版本跳躍** - 1.48.2 → 1.56.1 跨越 8 個小版本，需確認無破壞性變更

### 風險評估

**風險等級**: 🟡 低-中

**潛在問題**:
- 未在本地驗證測試 (依賴 CI 驗證)
- 版本跳躍可能包含行為變更
- 兩個應用的測試套件都會受影響

**緩解措施**:
- 只影響開發依賴，不影響生產環境
- Playwright 通常向後兼容
- 與 frontend-dashboard-deploy 已驗證的版本一致

## 驗收標準

- [ ] 所有 CI 檢查通過
- [ ] frontend-dashboard E2E 測試通過
- [ ] owner-console E2E 測試通過
- [ ] 無新的測試失敗或警告

---

**Link to Devin run**: https://app.devin.ai/sessions/e92ff7dba2194644be2027a96e24cebb  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) - @RC918  
**Task**: P1 依賴版本統一