### PR TITLE
fix(ci): Add .tolgeerc for owner-console and simplify Tolgee workflow

### DIFF
--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -28,19 +28,15 @@ jobs:
         working-directory: handoff/20250928/40_App/frontend-dashboard
         env:
           TOLGEE_API_KEY: ${{ secrets.VITE_TOLGEE_API_KEY }}
-          TOLGEE_API_URL: ${{ secrets.VITE_TOLGEE_API_URL }}
-          TOLGEE_PROJECT_ID: ${{ secrets.VITE_TOLGEE_PROJECT_ID }}
         run: |
-          tolgee pull --api-key "$TOLGEE_API_KEY" --api-url "$TOLGEE_API_URL" --project-id "$TOLGEE_PROJECT_ID" --path ./src/i18n/locales
+          tolgee pull --api-key "$TOLGEE_API_KEY"
 
       - name: Pull translations for Owner Console
         working-directory: handoff/20250928/40_App/owner-console
         env:
           TOLGEE_API_KEY: ${{ secrets.VITE_TOLGEE_API_KEY }}
-          TOLGEE_API_URL: ${{ secrets.VITE_TOLGEE_API_URL }}
-          TOLGEE_PROJECT_ID: ${{ secrets.VITE_TOLGEE_PROJECT_ID }}
         run: |
-          tolgee pull --api-key "$TOLGEE_API_KEY" --api-url "$TOLGEE_API_URL" --project-id "$TOLGEE_PROJECT_ID" --path ./src/locales
+          tolgee pull --api-key "$TOLGEE_API_KEY"
 
       - name: Create PR if changes
         uses: peter-evans/create-pull-request@v6

--- a/handoff/20250928/40_App/owner-console/.tolgeerc
+++ b/handoff/20250928/40_App/owner-console/.tolgeerc
@@ -1,0 +1,8 @@
+{
+  "projectId": 23882,
+  "apiUrl": "https://app.tolgee.io",
+  "format": "JSON_I18NEXT",
+  "pull": {
+    "path": "./src/locales"
+  }
+}


### PR DESCRIPTION
## 概要

修復 Tolgee Translation Sync workflow 失敗問題。owner-console 缺少 `.tolgeerc` 配置檔，導致 Tolgee CLI 無法讀取 project 設定。

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 此為 CI/CD 配置修改，不涉及設計或工程邏輯

## 問題原因

Workflow 錯誤：`Missing or invalid authentication token [status: 401, code: invalid_project_api_key]`

根本原因：
1. owner-console 目錄沒有 `.tolgeerc` 配置檔（frontend-dashboard 有）
2. Workflow 嘗試從不存在的 GitHub Secrets 讀取 `VITE_TOLGEE_API_URL` 和 `VITE_TOLGEE_PROJECT_ID`，導致參數為空
3. Tolgee CLI 需要 `.tolgeerc` 來讀取 projectId 和 apiUrl

## 變更內容

### 1. 新增 owner-console/.tolgeerc
```json
{
  "projectId": 23882,
  "apiUrl": "https://app.tolgee.io",
  "format": "JSON_I18NEXT",
  "pull": {
    "path": "./src/locales"
  }
}
```

### 2. 簡化 workflow 命令
- **移除前**：`tolgee pull --api-key "$TOLGEE_API_KEY" --api-url "$TOLGEE_API_URL" --project-id "$TOLGEE_PROJECT_ID" --path ./src/i18n/locales`
- **移除後**：`tolgee pull --api-key "$TOLGEE_API_KEY"`

配置檔已包含 apiUrl、projectId 和 path，CLI 會自動讀取。

## Review Checklist

**關鍵檢查項目**：
- [ ] 確認 projectId `23882` 正確（兩個 app 使用相同 project）
- [ ] 確認 owner-console 的 pull path `./src/locales` 正確
- [ ] 確認 `.tolgeerc` 格式與 frontend-dashboard 一致
- [ ] 合併後測試 workflow 是否成功執行

## 測試

無法本地測試，需等待 CI 執行驗證。建議合併後手動觸發 workflow：
```bash
Actions → Tolgee Translation Sync → Run workflow
```

## 相關資訊

- **Devin Session**: https://app.devin.ai/sessions/2023940518f2448689213a3d61ebbd0b
- **Requested by**: Ryan Chen (@RC918)
- **Previous PR**: #680 (已合併，但未解決問題)
- **Root Cause**: owner-console 缺少 Tolgee 配置檔