### PR TITLE
fix(ci): Use non-prefixed TOLGEE secrets and add owner-console config

### DIFF
--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -27,20 +27,16 @@ jobs:
       - name: Pull translations for Frontend Dashboard
         working-directory: handoff/20250928/40_App/frontend-dashboard
         env:
-          TOLGEE_API_KEY: ${{ secrets.VITE_TOLGEE_API_KEY }}
-          TOLGEE_API_URL: ${{ secrets.VITE_TOLGEE_API_URL }}
-          TOLGEE_PROJECT_ID: ${{ secrets.VITE_TOLGEE_PROJECT_ID }}
+          TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
         run: |
-          tolgee pull --api-key "$TOLGEE_API_KEY" --api-url "$TOLGEE_API_URL" --project-id "$TOLGEE_PROJECT_ID" --path ./src/i18n/locales
+          tolgee pull --api-key "$TOLGEE_API_KEY"
 
       - name: Pull translations for Owner Console
         working-directory: handoff/20250928/40_App/owner-console
         env:
-          TOLGEE_API_KEY: ${{ secrets.VITE_TOLGEE_API_KEY }}
-          TOLGEE_API_URL: ${{ secrets.VITE_TOLGEE_API_URL }}
-          TOLGEE_PROJECT_ID: ${{ secrets.VITE_TOLGEE_PROJECT_ID }}
+          TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
         run: |
-          tolgee pull --api-key "$TOLGEE_API_KEY" --api-url "$TOLGEE_API_URL" --project-id "$TOLGEE_PROJECT_ID" --path ./src/locales
+          tolgee pull --api-key "$TOLGEE_API_KEY"
 
       - name: Create PR if changes
         uses: peter-evans/create-pull-request@v6

--- a/handoff/20250928/40_App/owner-console/.tolgeerc
+++ b/handoff/20250928/40_App/owner-console/.tolgeerc
@@ -1,0 +1,8 @@
+{
+  "projectId": 23882,
+  "apiUrl": "https://app.tolgee.io",
+  "format": "JSON_I18NEXT",
+  "pull": {
+    "path": "./src/locales"
+  }
+}


### PR DESCRIPTION
## 概要

修復 Tolgee Translation Sync workflow，將 secrets 從 `VITE_TOLGEE_*` 改為 `TOLGEE_*`（無前綴），並為 owner-console 添加 `.tolgeerc` 配置檔。

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 此為 CI/CD 配置修改，不涉及設計或工程邏輯

## 問題背景

用戶在 GitHub Secrets 中創建了無前綴的 Tolgee secrets：
- `TOLGEE_API_KEY`
- `TOLGEE_API_URL`
- `TOLGEE_PROJECT_ID`

但 workflow 仍在使用 `VITE_TOLGEE_*` 前綴，導致無法讀取正確的 secrets，workflow 一直沒有執行成功（自 10/22 後無新的翻譯同步記錄）。

## 變更內容

### 1. Workflow 更新 (`.github/workflows/tolgee-sync.yml`)
- **修改前**：使用 `secrets.VITE_TOLGEE_API_KEY`、`secrets.VITE_TOLGEE_API_URL`、`secrets.VITE_TOLGEE_PROJECT_ID`
- **修改後**：只使用 `secrets.TOLGEE_API_KEY`
- **簡化命令**：移除 `--api-url` 和 `--project-id` 參數，改由 `.tolgeerc` 提供

### 2. Owner Console 配置檔 (`handoff/20250928/40_App/owner-console/.tolgeerc`)
- **新增**：owner-console 的 Tolgee 配置檔
- 內容與 frontend-dashboard 的配置相同（projectId: 23882, apiUrl: https://app.tolgee.io）
- 定義 pull path 為 `./src/locales`

## 技術細節

Tolgee CLI 會自動從 `.tolgeerc` 讀取 `projectId` 和 `apiUrl`，因此不需要在命令行中傳遞這些參數。Frontend-dashboard 已經使用此配置方式並正常運作。

## Review Checklist

**關鍵檢查項目**：
- [ ] 確認 GitHub repository Settings → Secrets → Actions 中存在 `TOLGEE_API_KEY`（用戶已創建）
- [ ] 確認 projectId `23882` 對於兩個應用都是正確的
- [ ] 合併後手動觸發 workflow 驗證（Actions → Tolgee Translation Sync → Run workflow）
- [ ] 監控下次定時執行（每日 10:00 台北時間）確認正常運作

## 相關資訊

- **Devin Session**: https://app.devin.ai/sessions/2023940518f2448689213a3d61ebbd0b
- **Requested by**: Ryan Chen (@RC918)
- **前置調查**: 發現自 10/22 後 Tolgee workflow 沒有執行記錄，診斷出 secrets 名稱不匹配問題