### PR TITLE
hotfix: Only pass ssl_cert_reqs for TLS connections (rediss://)

### DIFF
--- a/orchestrator/task_queue/redis_queue.py
+++ b/orchestrator/task_queue/redis_queue.py
@@ -81,19 +81,21 @@ class RedisQueue:
         try:
             import ssl
             
-            # Configure SSL/TLS for secure connections
-            ssl_cert_reqs = None
+            connection_kwargs = {
+                "db": self.db,
+                "decode_responses": True
+            }
+            
+            # Only add SSL config for TLS connections
             if self.redis_url.startswith("rediss://"):
-                ssl_cert_reqs = ssl.CERT_REQUIRED
+                connection_kwargs["ssl_cert_reqs"] = ssl.CERT_REQUIRED
                 logger.info("Connecting to Redis with TLS (rediss://)")
             elif self.redis_url.startswith("redis://"):
                 logger.info("Connecting to Redis without TLS (redis://)")
             
             self.redis_client = await redis.from_url(
                 self.redis_url,
-                db=self.db,
-                decode_responses=True,
-                ssl_cert_reqs=ssl_cert_reqs
+                **connection_kwargs
             )
             await self.redis_client.ping()
             


### PR DESCRIPTION
## 🚨 Hotfix: Fix ssl_cert_reqs Parameter for Non-TLS Redis Connections

### Problem
PR #697 部署後，orchestrator-api 仍然失敗，新錯誤訊息：
```
WARNING: ⚠️ REDIS_URL is not using TLS (redis://)
ERROR: AbstractConnection.__init__() got an unexpected keyword argument 'ssl_cert_reqs'
```

**Root Cause**:
- PR #697 的修復假設所有環境都使用 `rediss://` (TLS)
- 但 Render 的 `REDIS_URL` 實際設定為 `redis://` (非 TLS)
- PR #697 代碼總是傳遞 `ssl_cert_reqs` 參數（即使值為 `None`）
- redis-py 的 `AbstractConnection.__init__()` 在非 TLS 連線時不接受此參數

### Solution
修改 `connect()` 方法：
1. ✅ 動態建立 `connection_kwargs` dict
2. ✅ **只有**在使用 `rediss://` 時才加入 `ssl_cert_reqs` 參數
3. ✅ 使用 `redis://` 時完全省略該參數
4. ✅ 保持日誌和警告訊息

### Changes
**File**: `orchestrator/task_queue/redis_queue.py` (lines 79-106)
- 將固定的參數改為動態 dict
- 條件式加入 `ssl_cert_reqs` 參數
- 使用 `**connection_kwargs` 展開參數

### Impact
✅ 修復 `redis://` 連線錯誤  
✅ 保持 `rediss://` TLS 支援  
⚠️ 允許非 TLS 連線（有警告）

---

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## Review Checklist
**Critical** ⚠️
- [ ] **條件邏輯正確性**: `ssl_cert_reqs` 是否只在 `rediss://` 時加入？
- [ ] **參數展開正確性**: `**connection_kwargs` 是否正確傳遞所有參數？
- [ ] **安全考量**: 是否接受允許非 TLS 連線（雖有警告）？

**Important**
- [ ] `redis://` 和 `rediss://` 兩種情況是否都能正常連線？
- [ ] 後續是否應更新 Render 環境使用 `rediss://` (TLS)？

---

**Next Steps After Merge**:
1. 🔴 **更新 Render Environment Group**: 將 `REDIS_URL` 改為 `rediss://` (TLS)
2. ✅ 驗證所有 services 使用 TLS 連線

---

**Link to Devin run**: https://app.devin.ai/sessions/e92ff7dba2194644be2027a96e24cebb  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918