### PR TITLE
hotfix: Use ssl_cert_reqs='none' for TLS connections (redis-py compatibility)

### DIFF
--- a/orchestrator/task_queue/redis_queue.py
+++ b/orchestrator/task_queue/redis_queue.py
@@ -79,8 +79,6 @@ class RedisQueue:
     async def connect(self):
         """Connect to Redis with TLS support"""
         try:
-            import ssl
-            
             connection_kwargs = {
                 "db": self.db,
                 "decode_responses": True
@@ -88,10 +86,7 @@ class RedisQueue:
             
             # Only add SSL config for TLS connections
             if self.redis_url.startswith("rediss://"):
-                ssl_context = ssl.create_default_context()
-                ssl_context.check_hostname = False
-                ssl_context.verify_mode = ssl.CERT_NONE
-                connection_kwargs["ssl"] = ssl_context
+                connection_kwargs["ssl_cert_reqs"] = "none"
                 logger.info("Connecting to Redis with TLS (rediss://)")
             elif self.redis_url.startswith("redis://"):
                 logger.info("Connecting to Redis without TLS (redis://)")


### PR DESCRIPTION
## 🔧 Hotfix: Redis TLS SSL Parameter Compatibility

### 問題
PR #700 的 SSL context 方法在 `orchestrator-api` 正常運行，但 `ops-agent-worker` 失敗：
```
ERROR: AbstractConnection.__init__() got an unexpected keyword argument 'ssl'
```

### 解決方案
簡化 SSL 配置，使用字串參數 `ssl_cert_reqs = "none"` 取代自定義 SSL context：

**之前 (PR #700)**:
```python
ssl_context = ssl.create_default_context()
ssl_context.check_hostname = False
ssl_context.verify_mode = ssl.CERT_NONE
connection_kwargs["ssl"] = ssl_context
```

**現在**:
```python
connection_kwargs["ssl_cert_reqs"] = "none"
```

### ⚠️ 重要提醒
- [ ] **未經測試**: 此修改基於錯誤訊息分析，尚未本地驗證
- [ ] **第四次 hotfix**: 這是連續第四個 Redis TLS 修復 (PR #697, #698, #700, 現在這個)
- [ ] **可能破壞現有服務**: orchestrator-api 目前使用 PR #700 正常運行，此變更可能影響
- [ ] **需要驗證**: 確認 `ssl_cert_reqs = "none"` 是否為 redis-py 有效參數

### 檢查清單
- [ ] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [ ] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
- [ ] **部署前測試**: 在 `orchestrator-api` 和 `ops-agent-worker` 上驗證
- [ ] **確認版本**: 檢查所有服務是否使用相同 redis-py 版本
- [ ] **監控部署**: 部署後立即檢查所有服務日誌

### 建議
考慮調查根本原因：為什麼不同 services 對 SSL 參數有不同期望？可能需要統一 redis-py 版本。

---

**Link to Devin run**: https://app.devin.ai/sessions/e92ff7dba2194644be2027a96e24cebb  
**Requested by**: Ryan Chen (@RC918)