### PR TITLE
fix: Remove duplicate --fail flag from TruffleHog scan

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -65,7 +65,7 @@ jobs:
           path: ./
           base: ""
           head: HEAD
-          extra_args: --only-verified --fail
+          extra_args: --only-verified
 
       - name: Upload TruffleHog Report
         if: always()


### PR DESCRIPTION
## 概述

修復 TruffleHog secret scanning workflow 的配置錯誤，該錯誤導致 main 分支的掃描失敗。

## 問題

TruffleHog 掃描在 main 分支失敗，錯誤訊息：
```
trufflehog: error: flag 'fail' cannot be repeated
```

## 根本原因

`--fail` flag 被重複傳遞了兩次：
1. TruffleHog GitHub Action 內部自動添加 `--fail` flag
2. Workflow 配置在 `extra_args` 中也包含了 `--fail`

這導致 TruffleHog CLI 收到重複的 flag 而報錯。

## 修復方式

從 `extra_args` 中移除 `--fail` flag，只保留 `--only-verified`，讓 action 自動處理失敗行為。

```diff
- extra_args: --only-verified --fail
+ extra_args: --only-verified
```

## 影響範圍

- ✅ 只影響 main/manual 分支的 full scan
- ✅ PR incremental scan 不受影響（本來就沒有 `--fail` 在 extra_args）
- ✅ Gitleaks 掃描不受影響

## 🔴 重要審查項目

### 必須驗證

1. **Workflow 仍會失敗當偵測到 secrets**
   - 確認移除 `--fail` 後，action 仍然會讓 workflow fail
   - 檢查 trufflesecurity/trufflehog@v3.82.13 的行為

2. **與 security-summary job 的整合**
   - 確認 `needs.trufflehog.result` 仍能正確反映掃描結果
   - 驗證 security-summary 的警告訊息仍能正常顯示

### 建議測試

合併後觀察下一次 main 分支 push 的 secret scanning workflow：
- TruffleHog job 應該成功完成（如果沒有 secrets）
- 不應該出現 "flag cannot be repeated" 錯誤

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

---

**Session**: https://app.devin.ai/sessions/438417371dcc4d1f95886422404511ea  
**Requested by**: Ryan Chen (@RC918)