### PR TITLE
feat(ux): Week 5 - Dark Mode Implementation

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/eslint.config.js
+++ b/handoff/20250928/40_App/frontend-dashboard/eslint.config.js
@@ -7,7 +7,7 @@ import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
 
-export default [{ ignores: ['dist', 'src/lib/generated'] }, {
+export default [{ ignores: ['dist', 'src/lib/generated', 'storybook-static', '.storybook', '**/*.stories.tsx'] }, {
   files: ['**/*.{js,jsx}'],
   languageOptions: {
     ecmaVersion: 2020,

--- a/handoff/20250928/40_App/frontend-dashboard/src/App.jsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/App.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, lazy, Suspense } from 'react'
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { ThemeProvider } from 'next-themes'
+import { ThemeProvider } from '@/contexts/ThemeContext'
 import { TolgeeProvider } from '@tolgee/react'
 import { Toaster } from '@/components/ui/toaster'
 import { toast } from '@/lib/toast-with-announcement'
@@ -285,7 +285,7 @@ function AppContent() {
 
 function App() {
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <ThemeProvider defaultTheme="system" storageKey="morningai-theme">
       <TolgeeProvider tolgee={tolgee} fallback={<PageLoader message="Loading translations..." />}>
         <NotificationProvider>
           <AppContent />

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/DarkModeToggle.jsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/DarkModeToggle.jsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
-import { useTheme } from 'next-themes'
+import { useTheme } from '@/contexts/ThemeContext'
 import { Moon, Sun } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useTranslation } from 'react-i18next'
 
 export const DarkModeToggle = ({ variant = 'default' }) => {
   const { t } = useTranslation()
-  const { theme, setTheme, systemTheme } = useTheme()
+  const { theme, setTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
@@ -17,7 +17,14 @@ export const DarkModeToggle = ({ variant = 'default' }) => {
     return null
   }
 
-  const currentTheme = theme === 'system' ? systemTheme : theme
+  const getSystemTheme = () => {
+    if (typeof window !== 'undefined') {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    }
+    return 'light'
+  }
+
+  const currentTheme = theme === 'system' ? getSystemTheme() : theme
   const isDark = currentTheme === 'dark'
 
   const toggleTheme = () => {

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/ui/theme-toggle.jsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/ui/theme-toggle.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Moon, Sun } from 'lucide-react';
+import { Button } from './button';
+import { useTheme } from '../../contexts/ThemeContext';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
+    >
+      <Sun className="h-[1.2rem] w-[1.2rem] rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute h-[1.2rem] w-[1.2rem] rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Toggle theme</span>
+    </Button>
+  );
+}
+
+export function ThemeSelect() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <select
+      value={theme}
+      onChange={(e) => setTheme(e.target.value)}
+      className="bg-background border border-input rounded-md px-3 py-2 text-sm"
+    >
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+      <option value="system">System</option>
+    </select>
+  );
+}

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/ui/theme-toggle.stories.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/ui/theme-toggle.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { ThemeToggle } from './theme-toggle';
+import { ThemeProvider } from '../../contexts/ThemeContext';
+
+const meta = {
+  title: 'UI/Theme Toggle',
+  component: ThemeToggle,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <ThemeProvider defaultTheme="light" storageKey="storybook-theme">
+        <div className="p-8 bg-background text-foreground rounded-lg border">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+} satisfies Meta<typeof ThemeToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+  parameters: {
+    docs: {
+      description: {
+        story: 'Default theme toggle button that switches between light and dark modes.',
+      },
+    },
+  },
+};
+
+export const WithContext: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <div className="flex items-center gap-4">
+        <ThemeToggle />
+        <span className="text-sm text-muted-foreground">
+          Click to toggle between light and dark mode
+        </span>
+      </div>
+      <div className="p-4 bg-card rounded-lg border">
+        <h3 className="font-semibold mb-2">Sample Content</h3>
+        <p className="text-sm text-muted-foreground">
+          This content will change appearance based on the selected theme.
+        </p>
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Theme toggle with sample content showing how colors adapt to the theme.',
+      },
+    },
+  },
+};

--- a/handoff/20250928/40_App/frontend-dashboard/src/contexts/ThemeContext.jsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/contexts/ThemeContext.jsx
@@ -1,0 +1,60 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext({
+  theme: 'light',
+  setTheme: () => null,
+  toggleTheme: () => null,
+});
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined) {
+    throw new Error('useTheme must be used within a ThemeProvider');
+  }
+  return context;
+};
+
+export const ThemeProvider = ({ children, defaultTheme = 'system', storageKey = 'ui-theme', ...props }) => {
+  const [theme, setTheme] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return localStorage.getItem(storageKey) || defaultTheme;
+    }
+    return defaultTheme;
+  });
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+
+    root.classList.remove('light', 'dark');
+
+    if (theme === 'system') {
+      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+
+      root.classList.add(systemTheme);
+      return;
+    }
+
+    root.classList.add(theme);
+  }, [theme]);
+
+  const value = {
+    theme,
+    setTheme: (theme) => {
+      localStorage.setItem(storageKey, theme);
+      setTheme(theme);
+    },
+    toggleTheme: () => {
+      const newTheme = theme === 'light' ? 'dark' : 'light';
+      localStorage.setItem(storageKey, newTheme);
+      setTheme(newTheme);
+    },
+  };
+
+  return (
+    <ThemeContext.Provider {...props} value={value}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};

--- a/handoff/20250928/40_App/frontend-dashboard/src/index.css
+++ b/handoff/20250928/40_App/frontend-dashboard/src/index.css
@@ -9,6 +9,25 @@
   --radius-*: initial;
   --shadow-*: initial;
   
+  /* Base semantic colors for light mode */
+  --color-background: 0 0% 100%;
+  --color-foreground: 222.2 84% 4.9%;
+  --color-card: 0 0% 100%;
+  --color-card-foreground: 222.2 84% 4.9%;
+  --color-popover: 0 0% 100%;
+  --color-popover-foreground: 222.2 84% 4.9%;
+  --color-muted: 210 40% 96%;
+  --color-muted-foreground: 215.4 16.3% 46.9%;
+  --color-border: 214.3 31.8% 91.4%;
+  --color-input: 214.3 31.8% 91.4%;
+  --color-ring: 222.2 84% 4.9%;
+  --color-destructive: 0 84.2% 60.2%;
+  --color-destructive-foreground: 210 40% 98%;
+  --color-secondary: 210 40% 96%;
+  --color-secondary-foreground: 222.2 84% 4.9%;
+  --color-accent: 210 40% 96%;
+  --color-accent-foreground: 222.2 84% 4.9%;
+  
   /* Color mappings - Primary */
   --color-primary-50: var(--color-primary-50);
   --color-primary-100: var(--color-primary-100);
@@ -160,4 +179,37 @@ a:focus-visible {
   *:focus-visible {
     transition: outline-offset 0.2s ease;
   }
+}
+
+/* Dark mode overrides */
+.dark {
+  --color-background: 222.2 84% 4.9%;
+  --color-foreground: 210 40% 98%;
+  --color-card: 222.2 84% 4.9%;
+  --color-card-foreground: 210 40% 98%;
+  --color-popover: 222.2 84% 4.9%;
+  --color-popover-foreground: 210 40% 98%;
+  --color-muted: 217.2 32.6% 17.5%;
+  --color-muted-foreground: 215 20.2% 65.1%;
+  --color-border: 217.2 32.6% 17.5%;
+  --color-input: 217.2 32.6% 17.5%;
+  --color-ring: 212.7 26.8% 83.9%;
+  --color-destructive: 0 62.8% 30.6%;
+  --color-destructive-foreground: 210 40% 98%;
+  --color-secondary: 217.2 32.6% 17.5%;
+  --color-secondary-foreground: 210 40% 98%;
+  --color-accent: 217.2 32.6% 17.5%;
+  --color-accent-foreground: 210 40% 98%;
+}
+
+/* Ensure smooth theme transitions */
+* {
+  transition-property: color, background-color, border-color, text-decoration-color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+/* Disable transitions during theme change to prevent flash */
+.theme-transition * {
+  transition: none !important;
 }


### PR DESCRIPTION
## 概述

實現完整的暗色模式支持，包含主題提供者、切換組件和 Storybook 文檔。這是 Week 5-6 路線圖的第一個任務：進階功能 - 暗色主題實現。

## 主要變更

### 🎨 主題基礎設施
- **新增 `ThemeContext` 提供者**：替換 `next-themes`，支持 light/dark/system 三種模式
- **CSS 變數系統**：在 `index.css` 新增語義化顏色 token（background, foreground, card, border 等）
- **暗色模式調色板**：定義完整的暗色模式 CSS 變數覆寫

### 🔧 組件更新
- **更新 `DarkModeToggle`**：改用新的 `ThemeContext`，手動實現系統主題檢測
- **新增 `theme-toggle` 組件**：提供圖示動畫的主題切換按鈕
- **Storybook Story**：為主題切換組件新增文檔和演示

### ⚙️ 配置調整
- **ESLint**：新增忽略規則（storybook-static, .storybook, *.stories.tsx）
- **App.jsx**：更新為使用新的 `ThemeProvider`，storage key 改為 `morningai-theme`

## 技術細節

### 語義化顏色 Token
所有 UI 組件已使用語義化 token（如 `bg-background`, `text-foreground`），會根據主題自動適配：

```css
/* Light mode */
--color-background: 0 0% 100%;
--color-foreground: 222.2 84% 4.9%;

/* Dark mode */
.dark {
  --color-background: 222.2 84% 4.9%;
  --color-foreground: 210 40% 98%;
}
```

### 平滑過渡效果
新增全域過渡效果（150ms），支援顏色、背景、邊框等屬性的平滑切換。

## ⚠️ 破壞性變更

**主題偏好將重置**：由於 storage key 從 `next-themes` 預設改為 `morningai-theme`，現有使用者的主題設定會重置為預設值。

## 🧪 測試狀態

- ✅ Build 成功
- ✅ Lint 通過（僅 fast-refresh 警告）
- ⚠️ **未在完整環境中視覺驗證**（開發環境有 Supabase 配置問題）

## 📋 審查重點

### 高優先級
- [ ] 在實際運行的應用中測試主題切換功能
- [ ] 驗證系統主題偵測是否正常工作
- [ ] 確認主題設定在重新載入後保持
- [ ] 檢查所有頁面/組件的暗色模式顯示

### 中優先級  
- [ ] 檢查全域過渡效果是否影響效能
- [ ] 驗證 Sidebar 中的主題切換按鈕正常運作
- [ ] 測試 Storybook 中的主題切換文檔

### 潛在問題
1. **系統主題變更**：自訂實現可能無法即時響應 OS 主題變更
2. **效能**：全域過渡樣式可能在大型列表中造成效能問題
3. **視覺回歸**：需要完整測試所有頁面確保沒有樣式問題

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

---

**Link to Devin run**: https://app.devin.ai/sessions/66b5e754cea94168aa5d67eb51f390af  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) @RC918