### PR TITLE
Fix: Support HEAD Requests for Health Check Endpoints (Render Compatibility)

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/main.py
+++ b/handoff/20250928/40_App/api-backend/src/main.py
@@ -214,12 +214,16 @@ def get_health_payload():
             "timestamp": datetime.datetime.now().isoformat()
         }
 
-@app.route('/health')
-@app.route('/healthz')
-@app.route('/api/health')
-@app.route('/api/healthz')
+@app.route('/health', methods=['GET', 'HEAD'])
+@app.route('/healthz', methods=['GET', 'HEAD'])
+@app.route('/api/health', methods=['GET', 'HEAD'])
+@app.route('/api/healthz', methods=['GET', 'HEAD'])
 def health_check():
-    """Health check endpoint with comprehensive system status"""
+    """Health check endpoint with comprehensive system status
+    
+    Supports both GET and HEAD methods for compatibility with various
+    health check systems (e.g., Render, Kubernetes, load balancers).
+    """
     health_payload = get_health_payload()
     if health_payload.get("status") == "unhealthy":
         return jsonify(health_payload), 500


### PR DESCRIPTION
## 問題描述

Render 的健康檢查系統使用 HEAD 請求，但 `/health` endpoints 只支持 GET 請求，導致 405 Method Not Allowed 錯誤：

```
INFO: 10.23.143.5:59616 - "HEAD /health HTTP/1.1" 405 Method Not Allowed
```

## 解決方案

在所有健康檢查路由添加 `methods=['GET', 'HEAD']`，支持兩種 HTTP 方法：

- `/health`
- `/healthz`  
- `/api/health`
- `/api/healthz`

## 變更內容

**單一文件修改**: `handoff/20250928/40_App/api-backend/src/main.py`

1. 添加 `methods=['GET', 'HEAD']` 到四個健康檢查路由
2. 更新 docstring 說明支持 HEAD 請求
3. 無邏輯變更，僅添加 HTTP 方法支持

## 測試驗證

✅ 現有測試通過：
```bash
pytest tests/test_main_extra_endpoints.py::TestHealthEndpoints -v
# 2 passed, 1 warning
```

**Flask 行為**: Flask 自動處理 HEAD 請求，返回與 GET 相同的 headers 但不含 body，無需額外邏輯。

## 提醒

- [x] 不修改 OpenAPI/資料欄位（此 PR 不涉及）
- [x] 工程 PR 僅含 API/邏輯（無設計文件變更）
- [x] 純後端修改，不影響前端

## 審查重點

1. **HTTP 方法支持**: 確認添加 HEAD 方法的語法正確
2. **向後兼容**: GET 請求功能保持不變（已通過測試驗證）
3. **Flask 默認行為**: Flask 會自動為 HEAD 請求返回 headers（無 body）

## 風險評估

⚠️ **極低風險**：
- 單一文件，4 行代碼修改
- 只添加 HTTP 方法支持，無邏輯變更
- 現有 GET 功能完全不受影響
- Flask 框架保證 HEAD 請求的正確處理

---

**Devin Session**: https://app.devin.ai/sessions/aaf2b35bc0ed410a9a390d07833fb1e4  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918  
**Issue**: Render 健康檢查 405 錯誤修復