### PR TITLE
hotfix: Remove invalid redis_config import from orchestrator (ModuleNotFoundError)

### DIFF
--- a/orchestrator/api/main.py
+++ b/orchestrator/api/main.py
@@ -5,16 +5,12 @@ Provides HTTP endpoints for task submission and status monitoring
 """
 import logging
 import os
-import sys
 from typing import Dict, Any, Optional
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, BackgroundTasks, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '../../handoff/20250928/40_App/api-backend/src'))
-from utils.redis_config import get_secure_redis_url
 
 from orchestrator.task_queue.redis_queue import RedisQueue, create_redis_queue
 from orchestrator.schemas.task_schema import (
@@ -47,8 +43,7 @@ async def lifespan(app: FastAPI):
     
     logger.info("Starting Orchestrator API")
     
-    redis_url = get_secure_redis_url(allow_local=os.getenv("TESTING") == "true")
-    redis_queue = await create_redis_queue(redis_url=redis_url)
+    redis_queue = await create_redis_queue()
     
     orchestrator_router = OrchestratorRouter(redis_queue)
     


### PR DESCRIPTION
## 問題描述

Orchestrator 服務在生產環境無法啟動，錯誤訊息：
```
ModuleNotFoundError: No module named 'utils'
File "/app/orchestrator/api/main.py", line 17
    from utils.redis_config import get_secure_redis_url
```

**根本原因**: PR #771 在 orchestrator 中添加了對 `utils.redis_config` 的引用，但該模組位於 `api-backend/src/utils/` 目錄中，orchestrator 的 Docker 容器無法訪問。

## 解決方案

移除無效的 import，恢復使用 `create_redis_queue()` 的預設行為。此函數已經在 `orchestrator/task_queue/redis_queue.py` 中正確處理 Redis URL 選擇，包括 TLS 支援：
- 優先使用 `REDIS_URL`（rediss:// 協議）
- Fallback 到 `UPSTASH_REDIS_REST_URL`

## 變更內容

- ❌ 移除 `sys.path.insert()` 嘗試訪問 api-backend 目錄
- ❌ 移除 `from utils.redis_config import get_secure_redis_url`
- ✅ 恢復 `create_redis_queue()` 預設調用（已包含 TLS 支援）

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 審查重點

⚠️ **Critical**: 此 PR 部分回退 PR #771 的變更
1. 確認 `orchestrator/task_queue/redis_queue.py` 中的 Redis TLS 處理邏輯正確
2. 部署後驗證 orchestrator 服務正常啟動
3. 檢查生產日誌確認無新錯誤
4. 確認 Redis 連接使用 TLS（rediss:// 協議）

## 測試

⚠️ **無法在本地測試**: 需要在 staging/production 環境驗證

---

**Link to Devin run**: https://app.devin.ai/sessions/e92ff7dba2194644be2027a96e24cebb  
**Requested by**: Ryan Chen (@RC918)  
**Related**: PR #771