### PR TITLE
fix(ci): Prevent Storybook deployment race condition

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -72,6 +72,7 @@ jobs:
           destination_dir: storybook
           cname: storybook.morningai.app
           enable_jekyll: false
+          keep_files: true
       
       - name: Upload Storybook artifact (PR only)
         if: github.event_name == 'pull_request'
@@ -145,6 +146,7 @@ jobs:
           publish_branch: gh-pages-storybook
           destination_dir: dashboard
           enable_jekyll: false
+          keep_files: true
       
       - name: Upload Storybook artifact (PR only)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## 問題描述

Storybook 部署 workflow 在同時運行兩個 job 時發生 git push 衝突：

```
! [rejected] gh-pages-storybook -> gh-pages-storybook (fetch first)
error: failed to push some refs to 'https://github.com/RC918/morningai.git'
```

**根本原因**：
- `build-and-deploy` job 部署到 `storybook/` 目錄
- `build-and-deploy-new-dashboard` job 部署到 `dashboard/` 目錄  
- 兩個 jobs 同時推送到同一個 `gh-pages-storybook` 分支，導致競態條件

## 解決方案

在兩個部署步驟中添加 `keep_files: true`，讓每個 job 只更新自己的 `destination_dir`，而不會覆蓋整個分支。

## 變更內容

- `.github/workflows/storybook-deploy.yml`: 為兩個 GitHub Pages 部署步驟添加 `keep_files: true`

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 人工審查重點

1. **驗證修復正確性**：確認 `keep_files: true` 的行為符合預期（保留其他目錄的文件）
2. **監控首次部署**：合併後需要觀察前幾次 workflow 運行，確保不再出現 push 衝突
3. **評估替代方案**：考慮是否使用 job dependency（`needs`）讓兩個 job 依序執行更穩健
4. **文件清理策略**：確認 `keep_files: true` 不會導致舊文件累積問題

## 測試限制

⚠️ 此修復無法在本地測試，只能通過實際 GitHub Actions workflow 運行來驗證。

---

**Link to Devin run**: https://app.devin.ai/sessions/2875840b710f4dc99b33a8a239ec7710  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918