### PR TITLE
feat(ux): Integrate all Apple component Providers into App

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/App.jsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/App.jsx
@@ -6,6 +6,9 @@ import { TolgeeProvider } from '@tolgee/react'
 import { Toaster } from '@/components/ui/toaster'
 import { toast } from '@/lib/toast-with-announcement'
 import { AppleLiveActivity } from '@/components/ui/apple-live-activity'
+import { AppleActionSheet } from '@/components/ui/apple-action-sheet'
+import { AppleSpotlight } from '@/components/ui/apple-spotlight'
+import { AppleControlCenter } from '@/components/ui/apple-control-center'
 import ErrorBoundary from '@/components/ErrorBoundary'
 import Sidebar from '@/components/Sidebar'
 import GlobalSearch from '@/components/GlobalSearch'
@@ -308,9 +311,15 @@ function App() {
     <ThemeProvider defaultTheme="system" storageKey="morningai-theme">
       <TolgeeProvider tolgee={tolgee} fallback={<PageLoader message="Loading translations..." />}>
         <NotificationProvider>
-          <AppleLiveActivity.Provider position="top">
-            <AppContent />
-          </AppleLiveActivity.Provider>
+          <AppleActionSheet.Provider>
+            <AppleSpotlight.Provider>
+              <AppleControlCenter.Provider>
+                <AppleLiveActivity.Provider position="top">
+                  <AppContent />
+                </AppleLiveActivity.Provider>
+              </AppleControlCenter.Provider>
+            </AppleSpotlight.Provider>
+          </AppleActionSheet.Provider>
         </NotificationProvider>
       </TolgeeProvider>
     </ThemeProvider>


### PR DESCRIPTION
# feat(ux): Integrate all Apple component Providers into App

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR（僅 UI Provider 整合）

## Overview

Integrates all Phase 2 Week 6-7 Apple component Providers into the main application to enable global access to their hooks throughout the app.

## Changes

**Added 3 Provider integrations:**
1. `AppleActionSheet.Provider` - Global action sheet management
2. `AppleSpotlight.Provider` - Global spotlight search  
3. `AppleControlCenter.Provider` - Global control center UI

**Provider Nesting Order** (outer → inner):
```
ThemeProvider
└── TolgeeProvider
    └── NotificationProvider
        └── AppleActionSheet.Provider (NEW)
            └── AppleSpotlight.Provider (NEW)
                └── AppleControlCenter.Provider (NEW)
                    └── AppleLiveActivity.Provider (existing)
                        └── AppContent
```

## What This Enables

After this PR, these hooks will be available globally in any component:
- `useAppleActionSheet()` - Show action sheets from anywhere
- `useAppleSpotlight()` - Trigger spotlight search from anywhere
- `useAppleControlCenter()` - Access control center from anywhere
- `useAppleLiveActivity()` - Already available (was integrated earlier)

## Testing

✅ Build successful (`npm run build`)  
✅ No TypeScript errors  
✅ Bundle size acceptable (no new warnings)

## Critical Review Points

⚠️ **Provider Initialization** - Verify all 3 new providers can initialize without errors (none require props)

⚠️ **Provider Order** - Confirm the nesting order is correct (these providers appear independent, but verify no implicit dependencies)

⚠️ **Runtime Testing** - Build passed but **runtime behavior not tested yet**. Reviewer should:
1. Start the app and verify no console errors
2. Test that hooks are accessible (open console and try accessing context)
3. Verify no circular dependency issues

## Note

**ApplePicker** (PR #815, just merged) does NOT require a Provider as it doesn't use the Context pattern - it's a controlled component used directly where needed.

---

**Related PRs:**
- #809 AppleLiveActivity (merged)
- #810 AppleControlCenter (merged)  
- #813 AppleSpotlight (merged)
- #814 AppleActionSheet (merged)
- #815 ApplePicker (merged)

**Session:** https://app.devin.ai/sessions/66b5e754cea94168aa5d67eb51f390af  
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918