### PR TITLE
Phase 3 Stage 2 - Batch 3: Add TypeScript Type Annotations to Feedback Components

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/BrandLoader.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/BrandLoader.tsx
@@ -1,21 +1,28 @@
+import React from 'react'
 import { motion } from 'framer-motion'
 import { Sparkles } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+
+interface BrandLoaderProps {
+  message?: string
+  size?: 'small' | 'default' | 'large'
+  variant?: 'full' | 'inline'
+}
 
 export const BrandLoader = ({ 
   message, 
   size = 'default',
   variant = 'full'
-}) => {
+}: BrandLoaderProps): React.ReactElement => {
   const { t } = useTranslation()
-  const displayMessage = message || t('feedback.loading')
-  const sizes = {
+  const displayMessage: string = message || t('feedback.loading')
+  const sizes: Record<'small' | 'default' | 'large', { container: string; icon: string; text: string }> = {
     small: { container: 'w-12 h-12', icon: 'w-6 h-6', text: 'text-sm' },
     default: { container: 'w-20 h-20', icon: 'w-10 h-10', text: 'text-xl' },
     large: { container: 'w-32 h-32', icon: 'w-16 h-16', text: 'text-2xl' }
   }
 
-  const currentSize = sizes[size]
+  const currentSize: { container: string; icon: string; text: string } = sizes[size]
 
   const logoVariants = {
     initial: { scale: 0.8, opacity: 0 },
@@ -32,7 +39,7 @@ export const BrandLoader = ({
   }
 
   const sparkleVariants = {
-    animate: (i) => ({
+    animate: (i: number) => ({
       scale: [0, 1, 0],
       opacity: [0, 1, 0],
       x: [0, Math.cos(i * 60 * Math.PI / 180) * 40, 0],

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/EmptyStateLibrary.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/EmptyStateLibrary.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { motion } from 'framer-motion'
 import { AppleButton } from '@/components/ui/apple-button'
 import { 
@@ -12,9 +13,25 @@ import {
   XCircle,
   Clock,
   TrendingUp,
-  Zap
+  Zap,
+  type LucideIcon
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+
+type EmptyStateVariant = 'default' | 'search' | 'noData' | 'error' | 'success' | 'warning' | 'loading' | 'premium'
+
+interface EmptyStateLibraryProps {
+  variant?: EmptyStateVariant
+  icon?: LucideIcon
+  title?: string
+  description?: string
+  primaryAction?: () => void
+  primaryActionLabel?: string
+  secondaryAction?: () => void
+  secondaryActionLabel?: string
+  illustration?: string
+  className?: string
+}
 
 const emptyStateVariants = {
   hidden: { opacity: 0, y: 20, scale: 0.95 },
@@ -65,7 +82,7 @@ export const EmptyStateLibrary = ({
   secondaryActionLabel,
   illustration,
   className = ''
-}) => {
+}: EmptyStateLibraryProps): React.ReactElement => {
   const { t } = useTranslation()
   const variants = {
     default: {
@@ -211,7 +228,7 @@ export const EmptyStateLibrary = ({
   )
 }
 
-export const NoDataState = (props) => {
+export const NoDataState = (props: Omit<EmptyStateLibraryProps, 'variant'>): React.ReactElement => {
   const { t } = useTranslation()
   return (
     <EmptyStateLibrary
@@ -223,7 +240,7 @@ export const NoDataState = (props) => {
   )
 }
 
-export const NoSearchResults = (props) => {
+export const NoSearchResults = (props: Omit<EmptyStateLibraryProps, 'variant'>): React.ReactElement => {
   const { t } = useTranslation()
   return (
     <EmptyStateLibrary
@@ -235,7 +252,7 @@ export const NoSearchResults = (props) => {
   )
 }
 
-export const ErrorState = (props) => {
+export const ErrorState = (props: Omit<EmptyStateLibraryProps, 'variant'>): React.ReactElement => {
   const { t } = useTranslation()
   return (
     <EmptyStateLibrary
@@ -247,7 +264,7 @@ export const ErrorState = (props) => {
   )
 }
 
-export const SuccessState = (props) => {
+export const SuccessState = (props: Omit<EmptyStateLibraryProps, 'variant'>): React.ReactElement => {
   const { t } = useTranslation()
   return (
     <EmptyStateLibrary
@@ -259,7 +276,7 @@ export const SuccessState = (props) => {
   )
 }
 
-export const LoadingState = (props) => {
+export const LoadingState = (props: Omit<EmptyStateLibraryProps, 'variant'>): React.ReactElement => {
   const { t } = useTranslation()
   return (
     <EmptyStateLibrary
@@ -271,7 +288,7 @@ export const LoadingState = (props) => {
   )
 }
 
-export const PremiumFeatureState = (props) => {
+export const PremiumFeatureState = (props: Omit<EmptyStateLibraryProps, 'variant'>): React.ReactElement => {
   const { t } = useTranslation()
   return (
     <EmptyStateLibrary

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/PageLoader.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/PageLoader.tsx
@@ -1,9 +1,14 @@
+import React from 'react'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
 
-export const PageLoader = ({ message }) => {
+interface PageLoaderProps {
+  message?: string
+}
+
+export const PageLoader = ({ message }: PageLoaderProps): React.ReactElement => {
   const { t } = useTranslation()
-  const displayMessage = message || t('feedback.loading')
+  const displayMessage: string = message || t('feedback.loading')
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100">
       <motion.div

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/ProgressLoader.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/ProgressLoader.tsx
@@ -1,21 +1,33 @@
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Progress } from '@morningai/shared-ui'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
+
+interface ProgressStep {
+  title: string
+  description?: string
+}
+
+interface ProgressLoaderProps {
+  steps?: ProgressStep[]
+  currentStep?: number
+  estimatedTime?: number
+}
 
 export const ProgressLoader = ({ 
   steps = [],
   currentStep = 0,
   estimatedTime = 5000 
-}) => {
+}: ProgressLoaderProps): React.ReactElement => {
   const { t } = useTranslation()
-  const [progress, setProgress] = useState(0)
+  const [progress, setProgress] = useState<number>(0)
   
   useEffect(() => {
-    let raf, mounted = true
-    const tick = () => {
+    let raf: number
+    let mounted = true
+    const tick = (): void => {
       if (!mounted) return
-      setProgress(prev => {
+      setProgress((prev: number) => {
         const target = ((currentStep + 1) / steps.length) * 100
         return Math.min(prev + 1, target)
       })


### PR DESCRIPTION
## 概述

Phase 3 Stage 2 - Batch 3：為 4 個 Feedback 元件添加 TypeScript 類型註解，提升類型安全性和開發體驗。本 PR 為純類型註解添加，無邏輯變更。

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 變更內容

### 元件類型註解

為以下 feedback 元件添加完整的 TypeScript 類型註解：

1. **BrandLoader.tsx** - 品牌載入器元件
   - 添加 `BrandLoaderProps` 介面
   - `size`: `'small' | 'default' | 'large'`
   - `variant`: `'full' | 'inline'`
   - 為 `sizes` 使用 `Record<>` 類型確保類型安全
   - 為 `sparkleVariants.animate` 函數參數添加 `number` 類型

2. **EmptyStateLibrary.tsx** - 空狀態庫元件
   - 添加 `EmptyStateVariant` 類型（8 種變體）
   - 添加 `EmptyStateLibraryProps` 介面，使用 `LucideIcon` 類型
   - 為所有輔助元件（NoDataState, NoSearchResults, ErrorState, SuccessState, LoadingState, PremiumFeatureState）添加類型註解
   - 使用 `Omit<EmptyStateLibraryProps, 'variant'>` 排除 variant 屬性

3. **PageLoader.tsx** - 頁面載入器元件
   - 添加 `PageLoaderProps` 介面
   - 為 `displayMessage` 添加 `string` 類型註解

4. **ProgressLoader.tsx** - 進度載入器元件
   - 添加 `ProgressStep` 介面（title, description?）
   - 添加 `ProgressLoaderProps` 介面
   - 為 useEffect 中的 `raf` 變數添加 `number` 類型
   - 為 `tick` 函數添加返回類型 `void`

## 測試驗證

✅ TypeScript 編譯通過（忽略現有的 framer-motion Variants 錯誤）  
✅ Build 成功（`npm run build`）  
✅ Lint 通過（pre-commit hooks）  
✅ 所有 CI 檢查通過（20/20）

## 人工審查檢查清單

- [ ] **類型準確性**：驗證所有介面屬性與實際使用模式匹配
- [ ] **EmptyStateVariant**：確認 8 種變體在代碼庫中均有使用
- [ ] **ProgressStep 結構**：確認介面與調用者傳入的實際結構一致
- [ ] **可選屬性**：檢查哪些屬性應為必需，哪些應為可選
- [ ] **無破壞性變更**：確認不會影響現有元件使用者

## 已知問題（不在此 PR 範圍）

存在 framer-motion Variants 類型錯誤（BrandLoader 和 EmptyStateLibrary），但這些是現有代碼問題，build 仍可成功完成。

---

**Devin Run**: https://app.devin.ai/sessions/aaf2b35bc0ed410a9a390d07833fb1e4  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918