### PR TITLE
Phase 3 Stage 2 - Batch 4: Add TypeScript Type Annotations to Utility Components

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/DarkModeToggle.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/DarkModeToggle.tsx
@@ -1,13 +1,17 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useTheme } from '@/contexts/ThemeContext'
 import { Moon, Sun } from 'lucide-react'
 import { AppleButton } from '@/components/ui/apple-button'
 import { useTranslation } from 'react-i18next'
 
-export const DarkModeToggle = ({ variant = 'default' }) => {
+interface DarkModeToggleProps {
+  variant?: 'default' | 'compact'
+}
+
+export const DarkModeToggle = ({ variant = 'default' }: DarkModeToggleProps): React.ReactElement | null => {
   const { t } = useTranslation()
   const { theme, setTheme } = useTheme()
-  const [mounted, setMounted] = useState(false)
+  const [mounted, setMounted] = useState<boolean>(false)
 
   useEffect(() => {
     setMounted(true)
@@ -17,17 +21,17 @@ export const DarkModeToggle = ({ variant = 'default' }) => {
     return null
   }
 
-  const getSystemTheme = () => {
+  const getSystemTheme = (): 'dark' | 'light' => {
     if (typeof window !== 'undefined') {
       return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
     }
     return 'light'
   }
 
-  const currentTheme = theme === 'system' ? getSystemTheme() : theme
-  const isDark = currentTheme === 'dark'
+  const currentTheme: string = theme === 'system' ? getSystemTheme() : theme
+  const isDark: boolean = currentTheme === 'dark'
 
-  const toggleTheme = () => {
+  const toggleTheme = (): void => {
     setTheme(isDark ? 'light' : 'dark')
   }
 

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/LanguageSwitcher.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/LanguageSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import React, { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Globe, Check } from 'lucide-react'
 import { AppleButton } from '@/components/ui/apple-button'
@@ -10,18 +10,29 @@ import {
 } from '@morningai/shared-ui'
 import { motion, AnimatePresence } from 'framer-motion'
 
-const languages = [
+interface Language {
+  code: string
+  name: string
+  flag: string
+}
+
+interface LanguageSwitcherProps {
+  variant?: 'default' | 'compact'
+  className?: string
+}
+
+const languages: Language[] = [
   { code: 'en-US', name: 'English', flag: '🇺🇸' },
   { code: 'zh-TW', name: '繁體中文', flag: '🇹🇼' }
 ]
 
-export const LanguageSwitcher = ({ variant = 'default', className = '' }) => {
+export const LanguageSwitcher = ({ variant = 'default', className = '' }: LanguageSwitcherProps): React.ReactElement => {
   const { i18n } = useTranslation()
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState<boolean>(false)
 
-  const currentLanguage = languages.find(lang => lang.code === i18n.language) || languages[0]
+  const currentLanguage: Language = languages.find((lang: Language) => lang.code === i18n.language) || languages[0]
 
-  const changeLanguage = (langCode) => {
+  const changeLanguage = (langCode: string): void => {
     i18n.changeLanguage(langCode)
     setIsOpen(false)
   }

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/SaveStatusIndicator.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/SaveStatusIndicator.tsx
@@ -1,10 +1,20 @@
-import { Check, Loader2, AlertCircle, XCircle } from 'lucide-react'
+import React from 'react'
+import { Check, Loader2, AlertCircle, XCircle, type LucideIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { AppleButton } from '@/components/ui/apple-button'
 
-const formatRelativeTime = (date, t) => {
+type SaveStatus = 'saved' | 'saving' | 'unsaved' | 'error'
+
+interface SaveStatusIndicatorProps {
+  status: SaveStatus
+  lastSaved?: Date
+  error?: string
+  onRetry?: () => void
+}
+
+const formatRelativeTime = (date: Date, t: (key: string, options?: any) => string): string => {
   const now = new Date()
-  const diff = Math.floor((now - date) / 1000)
+  const diff = Math.floor((now.getTime() - date.getTime()) / 1000)
   
   if (diff < 60) return t('dashboard.saveStatus.timeAgo.seconds', { count: diff })
   if (diff < 3600) return t('dashboard.saveStatus.timeAgo.minutes', { count: Math.floor(diff / 60) })
@@ -12,10 +22,16 @@ const formatRelativeTime = (date, t) => {
   return t('dashboard.saveStatus.timeAgo.days', { count: Math.floor(diff / 86400) })
 }
 
-export const SaveStatusIndicator = ({ status, lastSaved, error, onRetry }) => {
+export const SaveStatusIndicator = ({ status, lastSaved, error, onRetry }: SaveStatusIndicatorProps): React.ReactElement => {
   const { t } = useTranslation()
   
-  const statusConfig = {
+  const statusConfig: Record<SaveStatus, {
+    icon: LucideIcon
+    text: string
+    className: string
+    iconClassName: string
+    action?: { label: string; onClick?: () => void }
+  }> = {
     saved: {
       icon: Check,
       text: lastSaved 
@@ -46,7 +62,7 @@ export const SaveStatusIndicator = ({ status, lastSaved, error, onRetry }) => {
   }
   
   const config = statusConfig[status] || statusConfig.saved
-  const Icon = config.icon
+  const Icon: LucideIcon = config.icon
   
   return (
     <div className="flex items-center gap-2" role="status" aria-live="polite">

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/WIPPage.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/WIPPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Clock, ArrowLeft, Target } from 'lucide-react'
 import { AppleButton } from '@/components/ui/apple-button'
@@ -7,19 +7,32 @@ import { Progress } from '@morningai/shared-ui'
 import { safeInterval } from '@/lib/safeInterval'
 import { useTranslation } from 'react-i18next'
 
+interface Milestone {
+  name: string
+  completed: boolean
+  date: string
+}
+
+interface WIPPageProps {
+  title?: string
+  description?: string
+  redirectSeconds?: number
+  milestones?: Milestone[]
+}
+
 const WIPPage = ({ 
   title, 
   description,
   redirectSeconds = 3,
   milestones = []
-}) => {
+}: WIPPageProps): React.ReactElement => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const [countdown, setCountdown] = useState(redirectSeconds)
+  const [countdown, setCountdown] = useState<number>(redirectSeconds)
 
   useEffect(() => {
     const cleanup = safeInterval(() => {
-      setCountdown(prev => {
+      setCountdown((prev: number) => {
         if (prev <= 1) {
           navigate('/dashboard')
           return 0
@@ -31,7 +44,7 @@ const WIPPage = ({
     return cleanup
   }, [navigate])
 
-  const defaultMilestones = [
+  const defaultMilestones: Milestone[] = [
     { name: t('wip.milestones.requirementAnalysis'), completed: true, date: t('wip.milestones.completed') },
     { name: t('wip.milestones.uiuxDesign'), completed: true, date: t('wip.milestones.completed') },
     { name: t('wip.milestones.backendApi'), completed: false, date: t('wip.milestones.inProgress') },
@@ -39,9 +52,9 @@ const WIPPage = ({
     { name: t('wip.milestones.testing'), completed: false, date: t('wip.milestones.pending') }
   ]
 
-  const displayMilestones = milestones.length > 0 ? milestones : defaultMilestones
-  const completedCount = displayMilestones.filter(m => m.completed).length
-  const progressPercentage = (completedCount / displayMilestones.length) * 100
+  const displayMilestones: Milestone[] = milestones.length > 0 ? milestones : defaultMilestones
+  const completedCount: number = displayMilestones.filter((m: Milestone) => m.completed).length
+  const progressPercentage: number = (completedCount / displayMilestones.length) * 100
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 flex items-center justify-center p-4">


### PR DESCRIPTION
## 概述

Phase 3 Stage 2 - Batch 4：為 4 個工具類元件添加 TypeScript 類型註解。本次變更提升了類型安全性，並修正了一處潛在的日期運算問題。

**Link to Devin run**: https://app.devin.ai/sessions/aaf2b35bc0ed410a9a390d07833fb1e4
**Requested by**: Ryan Chen (@RC918)

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 變更內容

### 1. DarkModeToggle.tsx
- 新增 `DarkModeToggleProps` 介面（variant: 'default' | 'compact'）
- 元件返回類型：`React.ReactElement | null`（SSR 渲染前返回 null）
- 為所有內部函數和變數添加類型註解

### 2. SaveStatusIndicator.tsx ⚠️
- 新增 `SaveStatus` 類型：'saved' | 'saving' | 'unsaved' | 'error'
- 新增 `SaveStatusIndicatorProps` 介面
- **重要修正**：日期運算從 `(now - date) / 1000` 改為 `(now.getTime() - date.getTime()) / 1000`
  - 原實作依賴 JavaScript 的隱式類型轉換
  - 新實作明確使用 `.getTime()` 方法，更加類型安全
- 使用 `Record<SaveStatus, {...}>` 強型別配置物件
- 從 lucide-react 匯入 `LucideIcon` 類型

### 3. LanguageSwitcher.tsx
- 新增 `Language` 介面（code, name, flag）
- 新增 `LanguageSwitcherProps` 介面（variant?, className?）
- 為 `languages` 陣列添加類型註解
- 為所有函數添加參數和返回類型

### 4. WIPPage.tsx
- 新增 `Milestone` 介面（name, completed, date）
- 新增 `WIPPageProps` 介面（所有屬性為 optional）
- 為狀態、回調函數和計算變數添加完整類型註解

## 人工審查重點

1. **SaveStatusIndicator 的日期運算變更**（第 17 行）
   - 驗證時間顯示功能是否正常
   - 確認 `.getTime()` 方法在所有情境下都能正確運作

2. **Props 介面完整性**
   - 確認 variant 類型（'default' | 'compact'）符合實際使用情境
   - 檢查所有 Props 是否涵蓋了元件的實際使用案例

3. **返回類型正確性**
   - DarkModeToggle 的 `React.ReactElement | null` 是否適當
   - 其他元件的 `React.ReactElement` 返回類型是否正確

4. **類型註解的一致性**
   - 與 Batch 1-3 的類型註解風格保持一致
   - Record<> 和 type unions 的使用是否恰當

## 測試狀態
- ✅ Build 成功
- ✅ 所有 CI 檢查通過
- ⚠️ 建議人工測試這 4 個元件的實際功能