### PR TITLE
Phase 3 Stage 2 - Batch 6: Add TypeScript Type Annotations to Settings and Analysis Components

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/CostAnalysis.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/CostAnalysis.tsx
@@ -110,7 +110,7 @@ const CostAnalysis = (): React.ReactElement => {
   const displayData: CostData = costData || mockCostData
   const currentUsage: number = costData?.usage?.usd || mockCostData.currentMonth || 0
   const budgetLimit: number = costData?.limits?.usd || mockCostData.budget || 0
-  const budgetUsagePercentage: number = (currentUsage / budgetLimit) * 100
+  const budgetUsagePercentage: number = budgetLimit > 0 ? (currentUsage / budgetLimit) * 100 : 0
 
   if (loading && !costData) {
     return (

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/SettingsPageSkeleton.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/SettingsPageSkeleton.tsx
@@ -59,7 +59,7 @@ interface SettingsData {
   security_settings?: SecuritySettings
   system_config?: SystemConfig
   billing_info?: BillingInfo
-  [key: string]: any
+  [key: string]: unknown
 }
 
 const SettingsPageSkeleton = (): React.ReactElement => {
@@ -84,24 +84,24 @@ const SettingsPageSkeleton = (): React.ReactElement => {
     }
   }
 
-  const updateSetting = (category: string, key: string, value: any): void => {
+  const updateSetting = (category: string, key: string, value: unknown): void => {
     setSettings((prev: SettingsData | null) => ({
       ...prev,
       [category]: {
-        ...(prev?.[category] || {}),
+        ...(prev?.[category] as Record<string, unknown> || {}),
         [key]: value
       }
     }))
     setHasChanges(true)
   }
 
-  const updateNestedSetting = (category: string, parentKey: string, key: string, value: any): void => {
+  const updateNestedSetting = (category: string, parentKey: string, key: string, value: unknown): void => {
     setSettings((prev: SettingsData | null) => ({
       ...prev,
       [category]: {
-        ...(prev?.[category] || {}),
+        ...(prev?.[category] as Record<string, unknown> || {}),
         [parentKey]: {
-          ...(prev?.[category]?.[parentKey] || {}),
+          ...((prev?.[category] as Record<string, unknown>)?.[parentKey] as Record<string, unknown> || {}),
           [key]: value
         }
       }

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/TenantSettings.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/TenantSettings.tsx
@@ -15,6 +15,12 @@ interface TenantInfo {
   task_count?: number
 }
 
+interface ApiErrorResponse {
+  error?: {
+    message?: string
+  }
+}
+
 const TenantSettings = (): React.ReactElement => {
   const { tenant, loading: tenantLoading, error: tenantError } = useTenant();
   const [members, setMembers] = useState<Member[]>([]);
@@ -65,9 +71,9 @@ const TenantSettings = (): React.ReactElement => {
       setMembers(membersData.members || []);
       setTenantInfo(infoData);
       setLoading(false);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Error fetching tenant data:', err);
-      setError(err.message || 'Failed to load tenant data');
+      setError(err instanceof Error ? err.message : 'Failed to load tenant data');
       setLoading(false);
     }
   };
@@ -91,15 +97,15 @@ const TenantSettings = (): React.ReactElement => {
       );
 
       if (!response.ok) {
-        const errorData: any = await response.json();
+        const errorData: ApiErrorResponse = await response.json();
         throw new Error(errorData.error?.message || 'Failed to update member role');
       }
 
       await fetchTenantData();
       setUpdatingMember(null);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Error updating member role:', err);
-      alert(`Failed to update member: ${err.message}`);
+      alert(`Failed to update member: ${err instanceof Error ? err.message : 'Unknown error'}`);
       setUpdatingMember(null);
     }
   };


### PR DESCRIPTION
## 概述

Phase 3 Stage 2 - Batch 6：為 3 個設定與分析相關元件添加 TypeScript 類型註解，並改進類型安全性。

**⚠️ 重要：此 PR 包含少量行為變更**（除零保護、防禦性程式碼），不是純類型註解。

**Link to Devin run**: https://app.devin.ai/sessions/aaf2b35bc0ed410a9a390d07833fb1e4  
**Requested by**: Ryan Chen (@RC918)

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 變更內容

### 1. CostAnalysis.tsx
**類型註解：**
- 新增類型別名：`TrendType`, `AlertType`, `PeriodType`
- 新增介面：`CostBreakdownItem`, `CostAlert`, `CostDataUsage`, `CostDataLimits`, `CostData`
- 所有函數、state 變數、參數加上類型註解

**⚠️ 行為變更 - 除零保護：**
```typescript
// 之前
const budgetUsagePercentage = (currentUsage / budgetLimit) * 100

// 之後
const budgetUsagePercentage = budgetLimit > 0 ? (currentUsage / budgetLimit) * 100 : 0
```
當 `budgetLimit` 為 0 時，回傳 0 而非 NaN/Infinity。

### 2. SettingsPageSkeleton.tsx
**類型註解：**
- 新增介面：`UserPreferences`, `SecuritySettings`, `SystemConfig`, `BillingInfo`, `SettingsData`
- 將 `any` 改為 `unknown`（更安全的頂層類型）
- 函數參數 `value` 從 `any` 改為 `unknown`

**⚠️ 行為變更 - 防禦性程式碼：**
```typescript
// 之前
[category]: {
  ...prev[category],
  [key]: value
}

// 之後
[category]: {
  ...(prev?.[category] as Record<string, unknown> || {}),
  [key]: value
}
```
當 `prev` 為 null 或 `category` 不存在時，使用空物件而非崩潰。

### 3. TenantSettings.tsx
**類型註解：**
- 新增介面：`Member`, `TenantInfo`, `ApiErrorResponse`
- 所有函數、state 變數、fetch 回應加上類型註解

**類型安全改進 - 錯誤處理：**
```typescript
// 之前
} catch (err: any) {
  setError(err.message || 'Failed to load tenant data')
}

// 之後
} catch (err: unknown) {
  setError(err instanceof Error ? err.message : 'Failed to load tenant data')
}
```
使用 `unknown` 取代 `any`，並正確檢查錯誤類型。

## 🔴 高優先級檢查項目

### 1. 除零保護邏輯 (CostAnalysis.tsx L113)
- **問題**：當 `budgetLimit === 0` 時，回傳 0 是否正確？
- **影響**：進度條會顯示 0%，文字顯示 "0.0%"
- **需檢查**：UI 是否應該顯示 "N/A" 或其他提示？還是 0% 就是預期行為？

### 2. 防禦性程式碼 (SettingsPageSkeleton.tsx L91, L102-104)
- **問題**：`prev?.[category] || {}` 是否會遮蔽 bug？
- **風險**：如果 API 應該回傳完整的設定結構但實際沒有，這個防禦性程式碼會靜默處理
- **需檢查**：確認這是預期行為，而非遮蔽實際的 API 問題

### 3. API 介面定義正確性
- **CostData** (CostAnalysis.tsx L44-55)：實際 API 是否回傳 `usage.usd` 和 `limits.usd`？
- **SettingsData** (SettingsPageSkeleton.tsx L57-63)：巢狀結構是否符合實際 API？
- **Member / TenantInfo** (TenantSettings.tsx L5-16)：欄位是否完整？

### 4. 類型轉換安全性 (SettingsPageSkeleton.tsx)
```typescript
...(prev?.[category] as Record<string, unknown> || {})
```
- **風險**：如果 `prev[category]` 不是物件，`as Record<string, unknown>` 會強制轉換
- **需檢查**：執行時是否可能出現非物件的值？

## 🟡 中優先級檢查項目

### 5. 錯誤處理完整性
- TenantSettings.tsx 使用 `err instanceof Error`，但如果拋出字串或其他類型會顯示 "Unknown error"
- 確認這是可接受的 fallback 行為

### 6. Mock 資料類型轉換
```typescript
trend: 'up' as TrendType
type: 'warning' as AlertType
```
確認這些 literal 值與實際 API 回傳的格式一致。

## 測試狀態
✅ Build 通過  
✅ CI 檢查通過 (20/20)  
⚠️ 無單元測試覆蓋這些變更

## 建議測試情境
1. **CostAnalysis**: 測試 `budgetLimit = 0` 時的 UI 顯示
2. **SettingsPageSkeleton**: 測試 API 回傳不完整設定時的行為
3. **TenantSettings**: 測試 API 錯誤回應的處理