### PR TITLE
Phase 3 Stage 2 - Batch 9: Add TypeScript Type Annotations to Metrics, Dashboard, and Usability Components

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/Dashboard.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/Dashboard.tsx
@@ -90,7 +90,9 @@ const DraggableWidget = ({ widget, index, moveWidget, onRemove, isEditMode, t }:
 
   return (
     <div
-      ref={(node) => drag(drop(node))}
+      ref={(node) => {
+        drag(drop(node))
+      }}
       className={`relative transition-all duration-200 ${isDragging ? 'opacity-50 scale-95' : 'hover:shadow-lg'} ${isEditMode ? 'cursor-move' : ''}`}
     >
       {isEditMode && (
@@ -430,7 +432,10 @@ const Dashboard = (): React.ReactElement => {
               className="h-20 flex-col"
               onClick={(): void => {
                 addWidget(widget.id)
-                document.querySelector('[data-state="open"]')?.click()
+                const element = document.querySelector('[data-state="open"]')
+                if (element && 'click' in element) {
+                  (element as HTMLElement).click()
+                }
               }}
             >
               <Grid3X3 className="w-6 h-6 mb-2" />

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/metrics/MetricsAnalysisDashboard.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/metrics/MetricsAnalysisDashboard.tsx
@@ -6,7 +6,7 @@
  * @component
  */
 
-import React, { useState, useEffect } from 'react'
+import { useState, useEffect } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@morningai/shared-ui'
 import { AppleButton } from '@/components/ui/apple-button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@morningai/shared-ui'
@@ -25,48 +25,26 @@ import {
 } from 'lucide-react'
 import { getMetricsReport, exportMetricsData, MetricsCollector } from '@/lib/metrics-analysis'
 
-type MetricStatus = 'good' | 'excellent' | 'needs_improvement' | 'poor' | string
-
-interface MetricsReport {
-  generated_at: string
-  summary: {
-    total_metrics: number
-    categories: string[]
-  }
-  task_performance?: {
-    success_rate: number
-    successful_tasks: number
-    total_tasks: number
-    avg_completion_time: number
-  }
-  web_vitals?: Record<string, unknown>
-  ux_metrics?: Record<string, unknown>
-  errors?: unknown[]
-  trends?: Record<string, unknown>
-  regression?: Record<string, unknown>
-  recommendations?: string[]
-}
-
-export function MetricsAnalysisDashboard(): React.ReactElement {
-  const [report, setReport] = useState<MetricsReport | null>(null)
-  const [loading, setLoading] = useState<boolean>(true)
-  const [baseline, setBaseline] = useState<MetricsReport | null>(null)
+export function MetricsAnalysisDashboard() {
+  const [report, setReport] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [baseline, setBaseline] = useState(null)
 
   useEffect(() => {
     loadReport()
   }, [])
 
-  const loadReport = (): void => {
+  const loadReport = () => {
     setLoading(true)
     try {
-      const metrics: unknown[] = MetricsCollector.loadMetrics()
+      const metrics = MetricsCollector.loadMetrics()
       if (metrics.length === 0) {
         setReport(null)
         setLoading(false)
         return
       }
 
-      const analysisReport: MetricsReport = getMetricsReport(baseline)
+      const analysisReport = getMetricsReport(baseline)
       setReport(analysisReport)
     } catch (error) {
       console.error('Failed to generate report:', error)
@@ -75,18 +53,18 @@ export function MetricsAnalysisDashboard(): React.ReactElement {
     }
   }
 
-  const handleExport = (): void => {
-    const data: unknown = exportMetricsData()
-    const blob: Blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
-    const url: string = URL.createObjectURL(blob)
-    const a: HTMLAnchorElement = document.createElement('a')
+  const handleExport = () => {
+    const data = exportMetricsData()
+    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
     a.href = url
     a.download = `metrics-report-${Date.now()}.json`
     a.click()
     URL.revokeObjectURL(url)
   }
 
-  const handleSetBaseline = (): void => {
+  const handleSetBaseline = () => {
     if (report) {
       setBaseline(report)
       alert('Baseline set successfully! Future reports will compare against this baseline.')
@@ -94,12 +72,12 @@ export function MetricsAnalysisDashboard(): React.ReactElement {
     }
   }
 
-  const handleClearBaseline = (): void => {
+  const handleClearBaseline = () => {
     setBaseline(null)
     loadReport()
   }
 
-  const handleClearMetrics = (): void => {
+  const handleClearMetrics = () => {
     if (confirm('Are you sure you want to clear all metrics data? This cannot be undone.')) {
       MetricsCollector.clearMetrics()
       setReport(null)
@@ -107,7 +85,7 @@ export function MetricsAnalysisDashboard(): React.ReactElement {
     }
   }
 
-  const getStatusIcon = (status: MetricStatus): React.ReactElement => {
+  const getStatusIcon = (status) => {
     switch (status) {
       case 'good':
       case 'excellent':
@@ -121,8 +99,8 @@ export function MetricsAnalysisDashboard(): React.ReactElement {
     }
   }
 
-  const getStatusBadge = (status: MetricStatus): React.ReactElement => {
-    const variants: Record<string, string> = {
+  const getStatusBadge = (status) => {
+    const variants = {
       good: 'default',
       excellent: 'default',
       needs_improvement: 'secondary',


### PR DESCRIPTION
## 概述

為 Phase 3 Stage 2 - Batch 9 的元件新增 TypeScript 型別標註，包含 Dashboard.tsx 和 UsabilityTestDashboard.tsx。此 PR 僅新增型別標註，不修改任何邏輯或功能。

## 型別錯誤改善

- **Main 分支**: 206 個 TypeScript 錯誤
- **此 PR**: 200 個 TypeScript 錯誤  
- **淨改善**: -6 個錯誤（0 個新錯誤引入）

## 變更檔案

### 1. Dashboard.tsx (616 行)

**新增介面定義**:
- `Widget`: 核心 widget 資料結構
- `DraggableWidgetProps`: 拖放元件 props
- `SaveStatus`: 儲存狀態（新增 'unsaved' 狀態）
- `SystemMetrics`: 系統指標
- `Decision`: 決策記錄
- `PerformanceDataPoint`: 效能資料點

**型別標註**:
- 所有 state 宣告加上型別
- 所有函式加上參數和回傳型別
- React DnD hooks 加上型別

**錯誤修正**:
- 修正 ref callback 型別錯誤（改為回傳 void）
- 修正 `Element.click()` 型別錯誤（加上 HTMLElement 型別轉換）

**已知限制**:
- 保留 2 個 `as any` 轉型：`(w as any).position` 和 `(widget as any).name`
- 原因：Widget 介面未包含這些屬性（可能來自外部 API 或動態新增）

### 2. UsabilityTestDashboard.tsx (603 行)

**新增介面定義**（完整型別覆蓋）:
- `Task`: 完整的任務結構（包含 errors, interactions, notes）
- `SessionSummary`: session.getSessionSummary() 回傳型別
- `Session`: 完整的 Session 類別介面（所有屬性和方法）
- `SUSResult`: SUS 問卷結果（包含 sus_score: number）
- `NPSResult`: NPS 問卷結果（包含 nps_score: number）
- `OverallSummary`: 整體統計摘要

**重大改進**:
- 移除所有 11 個 `as any` 轉型
- 修正屬性名稱不一致（id → sessionId）
- 所有 state、函式、callbacks 完整型別標註

### 3. MetricsAnalysisDashboard.tsx

**變更**: 還原至 main 分支版本（無型別標註）

**原因**: 初始版本新增的型別標註不完整，導致 30 個新錯誤：
- `web_vitals?: Record<string, unknown>` 過於泛型
- `ux_metrics?: Record<string, unknown>` 過於泛型  
- `trends?: Record<string, unknown>` 過於泛型
- `task_performance` 介面缺少實際使用的屬性（avg_duration, status, failed_tasks 等）

為符合「不引入新錯誤」的標準，選擇還原至無型別標註版本。

## 驗證結果

✅ TypeCheck: 200 個錯誤（比 main 的 206 少 6 個）
✅ Build: 成功通過
✅ 所有 CI 檢查通過 (20/20)
✅ 所有 lint-staged 檢查通過

## 審查重點

### 🔍 高優先級審查項目

1. **UsabilityTestDashboard.tsx Session 介面正確性**
   - 驗證 Session 介面與 `lib/usability-testing.js` 實作一致
   - 特別注意 `sessionId` vs `id` 屬性命名
   - 確認 `getSessionSummary()` 回傳型別正確

2. **Dashboard.tsx 剩餘的 `as any` 轉型**
   - Line 274: `(w as any).position` - Widget 介面未定義 position
   - Line 442: `(widget as any).name` - Widget 介面未定義 name
   - 確認這些是合理的過渡方案

3. **MetricsAnalysisDashboard.tsx 還原決策**
   - 確認暫時不加型別標註是可接受的
   - 未來需要補充完整的介面定義

### ⚠️ 測試建議

- 手動測試 Dashboard 拖放功能
- 測試 UsabilityTestDashboard 完整流程（開始→任務→結束→問卷）
- 驗證資料匯出功能正常

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

---

**Devin Session**: https://app.devin.ai/sessions/aaf2b35bc0ed410a9a390d07833fb1e4  
**Requested by**: Ryan Chen (@RC918, ryan2939z@gmail.com)