### PR TITLE
Phase 3 Stage 2 - Batch 9 Follow-up: Complete Type Definitions and Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -410,6 +410,90 @@ on:
 - [ ] 設置適當的 `timeout-minutes`
 - [ ] 有 `concurrency` 控制（如果適用）
 
+## TypeScript 類型檢查規範
+
+### 標準 TypeCheck 命令
+
+**前端專案** (frontend-dashboard, owner-console):
+```bash
+cd handoff/20250928/40_App/frontend-dashboard
+pnpm run typecheck
+```
+
+**重要說明**:
+- 錯誤數量可能因環境而異（Storybook 檔案包含/排除）
+- **標準**: PR 不得引入新的 TypeScript 錯誤
+- **驗證方式**: 比較 main 分支和 PR 分支的錯誤差異
+
+### 驗證流程
+
+1. **記錄 main 分支錯誤數**:
+```bash
+git checkout main
+cd handoff/20250928/40_App/frontend-dashboard
+pnpm run typecheck 2>&1 | grep "error TS" > /tmp/main_errors.txt
+wc -l /tmp/main_errors.txt
+```
+
+2. **記錄 PR 分支錯誤數**:
+```bash
+git checkout your-pr-branch
+cd handoff/20250928/40_App/frontend-dashboard
+pnpm run typecheck 2>&1 | grep "error TS" > /tmp/pr_errors.txt
+wc -l /tmp/pr_errors.txt
+```
+
+3. **比較差異**:
+```bash
+# 查看新增的錯誤
+diff /tmp/main_errors.txt /tmp/pr_errors.txt | grep "^>"
+
+# 查看修復的錯誤
+diff /tmp/main_errors.txt /tmp/pr_errors.txt | grep "^<"
+```
+
+### 類型標註最佳實踐
+
+1. **完整的介面定義**
+   - 避免使用 `Record<string, unknown>` 作為主要類型
+   - 為所有已知屬性定義明確的類型
+   - 使用 `unknown` 而非 `any` 處理未知類型
+
+2. **避免 `as any` 轉型**
+   - 優先擴展介面定義
+   - 使用可選屬性 (`name?: string`)
+   - 使用類型守衛 (`if ('property' in object)`)
+
+3. **函式類型標註**
+   - 所有函式參數加上類型
+   - 所有函式加上回傳類型
+   - React 元件使用 `React.ReactElement` 或 `React.FC`
+
+**範例**:
+```typescript
+// ✅ 好的類型定義
+interface MetricsReport {
+  generated_at: string
+  web_vitals?: Record<string, WebVitalData>  // 使用具體的 value 類型
+  recommendations?: Recommendation[]
+}
+
+interface WebVitalData {
+  status: 'good' | 'excellent' | 'needs_improvement' | 'poor'
+  current: number
+  average: number
+  p90: number
+  count: number
+}
+
+// ❌ 不好的類型定義
+interface MetricsReport {
+  generated_at: string
+  web_vitals?: Record<string, unknown>  // 過於泛型
+  recommendations?: unknown[]
+}
+```
+
 ## 驗收標準
 
 所有 PR 需通過：
@@ -425,7 +509,7 @@ on:
 
 3. **CI 檢查**
    - Lint 檢查通過
-   - Type 檢查通過
+   - Type 檢查通過（**不得引入新錯誤**）
    - Build 成功
 
 4. **Post-deploy Health 斷言**

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/Dashboard.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/Dashboard.tsx
@@ -25,6 +25,11 @@ interface Widget {
   id: string
   type: string
   component: React.ReactNode | null
+  name?: string
+  position?: {
+    x: number
+    y: number
+  }
 }
 
 interface DraggableWidgetProps {
@@ -271,7 +276,7 @@ const Dashboard = (): React.ReactElement => {
         method: 'POST',
         body: JSON.stringify({
           user_id: 'default',
-          layout: { widgets: dashboardLayout.map((w: Widget) => ({ id: w.id, position: (w as any).position })) }
+          layout: { widgets: dashboardLayout.map((w: Widget) => ({ id: w.id, position: w.position })) }
         })
       })
       setSaveStatus({ status: 'saved', lastSaved: new Date(), error: null })
@@ -439,7 +444,7 @@ const Dashboard = (): React.ReactElement => {
               }}
             >
               <Grid3X3 className="w-6 h-6 mb-2" />
-              <span className="text-xs">{(widget as any).name}</span>
+              <span className="text-xs">{widget.name}</span>
             </AppleButton>
           ))}
         </div>

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/metrics/MetricsAnalysisDashboard.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/metrics/MetricsAnalysisDashboard.tsx
@@ -6,7 +6,7 @@
  * @component
  */
 
-import { useState, useEffect } from 'react'
+import React, { useState, useEffect } from 'react'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@morningai/shared-ui'
 import { AppleButton } from '@/components/ui/apple-button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@morningai/shared-ui'
@@ -25,26 +25,92 @@ import {
 } from 'lucide-react'
 import { getMetricsReport, exportMetricsData, MetricsCollector } from '@/lib/metrics-analysis'
 
-export function MetricsAnalysisDashboard() {
-  const [report, setReport] = useState(null)
-  const [loading, setLoading] = useState(true)
-  const [baseline, setBaseline] = useState(null)
+type MetricStatus = 'good' | 'excellent' | 'needs_improvement' | 'poor'
+
+interface WebVitalData {
+  status: MetricStatus
+  current: number
+  average: number
+  p90: number
+  count: number
+}
+
+interface UXMetricsTTV {
+  status: MetricStatus
+  average: number
+  median: number
+  p90: number
+  count: number
+}
+
+interface TaskPerformance {
+  success_rate: number
+  successful_tasks: number
+  total_tasks: number
+  avg_completion_time: number
+  avg_duration: number
+  status: MetricStatus
+  failed_tasks: number
+}
+
+interface ErrorData {
+  error_rate: number
+  total_errors: number
+}
+
+interface RegressionData {
+  baseline: number
+  current: number
+  improved: boolean
+  change_percent: number
+}
+
+interface Recommendation {
+  priority: 'high' | 'medium' | 'low'
+  message: string
+  suggestion: string
+}
+
+interface MetricsReport {
+  generated_at: string
+  summary: {
+    total_metrics: number
+    categories: string[]
+  }
+  task_performance?: TaskPerformance
+  web_vitals?: Record<string, WebVitalData>
+  ux_metrics?: {
+    ttv?: UXMetricsTTV
+  }
+  errors?: ErrorData
+  trends?: Record<string, unknown>
+  regression?: {
+    web_vitals?: Record<string, RegressionData>
+    task_success_rate?: RegressionData
+  }
+  recommendations?: Recommendation[]
+}
+
+export function MetricsAnalysisDashboard(): React.ReactElement {
+  const [report, setReport] = useState<MetricsReport | null>(null)
+  const [loading, setLoading] = useState<boolean>(true)
+  const [baseline, setBaseline] = useState<MetricsReport | null>(null)
 
   useEffect(() => {
     loadReport()
   }, [])
 
-  const loadReport = () => {
+  const loadReport = (): void => {
     setLoading(true)
     try {
-      const metrics = MetricsCollector.loadMetrics()
+      const metrics: unknown[] = MetricsCollector.loadMetrics()
       if (metrics.length === 0) {
         setReport(null)
         setLoading(false)
         return
       }
 
-      const analysisReport = getMetricsReport(baseline)
+      const analysisReport: MetricsReport = getMetricsReport(baseline)
       setReport(analysisReport)
     } catch (error) {
       console.error('Failed to generate report:', error)
@@ -53,18 +119,18 @@ export function MetricsAnalysisDashboard() {
     }
   }
 
-  const handleExport = () => {
-    const data = exportMetricsData()
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
+  const handleExport = (): void => {
+    const data: unknown = exportMetricsData()
+    const blob: Blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' })
+    const url: string = URL.createObjectURL(blob)
+    const a: HTMLAnchorElement = document.createElement('a')
     a.href = url
     a.download = `metrics-report-${Date.now()}.json`
     a.click()
     URL.revokeObjectURL(url)
   }
 
-  const handleSetBaseline = () => {
+  const handleSetBaseline = (): void => {
     if (report) {
       setBaseline(report)
       alert('Baseline set successfully! Future reports will compare against this baseline.')
@@ -72,12 +138,12 @@ export function MetricsAnalysisDashboard() {
     }
   }
 
-  const handleClearBaseline = () => {
+  const handleClearBaseline = (): void => {
     setBaseline(null)
     loadReport()
   }
 
-  const handleClearMetrics = () => {
+  const handleClearMetrics = (): void => {
     if (confirm('Are you sure you want to clear all metrics data? This cannot be undone.')) {
       MetricsCollector.clearMetrics()
       setReport(null)
@@ -85,7 +151,7 @@ export function MetricsAnalysisDashboard() {
     }
   }
 
-  const getStatusIcon = (status) => {
+  const getStatusIcon = (status: MetricStatus): React.ReactElement => {
     switch (status) {
       case 'good':
       case 'excellent':
@@ -99,8 +165,8 @@ export function MetricsAnalysisDashboard() {
     }
   }
 
-  const getStatusBadge = (status) => {
-    const variants = {
+  const getStatusBadge = (status: MetricStatus): React.ReactElement => {
+    const variants: Record<MetricStatus, string> = {
       good: 'default',
       excellent: 'default',
       needs_improvement: 'secondary',


### PR DESCRIPTION
## 概述

完成 PR #845 (Batch 9) 的後續改進，包含三個主要改進點：

1. **MetricsAnalysisDashboard.tsx**: 新增完整的 TypeScript 型別定義
2. **Dashboard.tsx**: 消除剩餘的 `as any` 型別轉換
3. **CONTRIBUTING.md**: 標準化 TypeScript typecheck 命令與驗證流程

## 型別錯誤改善

- **Main 分支**: 206 個 TypeScript 錯誤
- **此 PR**: 188 個 TypeScript 錯誤
- **淨改善**: -18 個錯誤 (8.7% 減少)

## 主要變更

### 1. MetricsAnalysisDashboard.tsx - 型別定義

新增完整的介面定義：

```typescript
type MetricStatus = 'good' | 'excellent' | 'needs_improvement' | 'poor'

interface WebVitalData {
  status: MetricStatus
  current: number
  average: number
  p90: number
  count: number
}

interface MetricsReport {
  generated_at: string
  summary: { total_metrics: number; categories: string[] }
  task_performance?: TaskPerformance
  web_vitals?: Record<string, WebVitalData>
  ux_metrics?: { ttv?: UXMetricsTTV }
  errors?: ErrorData
  regression?: {
    web_vitals?: Record<string, RegressionData>
    task_success_rate?: RegressionData
  }
  recommendations?: Recommendation[]
}
```

為所有函式新增型別標註：
- `loadReport(): void`
- `handleExport(): void`
- `getStatusIcon(status: MetricStatus): React.ReactElement`
- 所有 state 變數都有明確型別

### 2. Dashboard.tsx - 消除 'as any'

擴展 Widget 介面以支援可選屬性：

```typescript
interface Widget {
  id: string
  type: string
  component: React.ReactNode | null
  name?: string          // 新增
  position?: {           // 新增
    x: number
    y: number
  }
}
```

移除兩處 `as any` 轉換：
- `(w as any).position` → `w.position` (line 276)
- `(widget as any).name` → `widget.name` (line 447)

### 3. CONTRIBUTING.md - TypeScript 規範

新增「TypeScript 類型檢查規範」章節 (83 行)，包含：

- **標準 typecheck 命令**: `pnpm run typecheck`
- **驗證流程**: 如何比較 main 分支與 PR 分支的錯誤差異
- **最佳實踐**: 完整介面定義、避免 `as any`、函式型別標註
- **CI 標準更新**: 強調「不得引入新錯誤」

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 人工審查重點 ⚠️

### 🔴 高優先級

1. **驗證型別定義準確性**: MetricsReport 的介面定義是否與 `getMetricsReport()` 實際回傳的資料結構完全一致？
   - 特別關注 `web_vitals`, `ux_metrics`, `regression` 的巢狀結構
   - 確認 `trends?: Record<string, unknown>` 是否需要更具體的型別

2. **可選屬性處理**: 元件程式碼是否正確處理所有可選屬性？
   - 檢查是否有使用 optional chaining (`?.`) 或 null checks
   - 特別關注 `report?.web_vitals`, `report?.recommendations` 等

3. **Widget 介面擴展**: 確認 `name` 和 `position` 屬性在整個 codebase 中的使用方式是否一致

### 🟡 中優先級

4. **執行時測試**: 建議在開發環境實際執行 MetricsAnalysisDashboard，確認型別定義與實際資料相符
5. **CONTRIBUTING.md 流程驗證**: 確認文件中的 typecheck 驗證流程可正常執行

### ⚪ 參考資訊

- Link to Devin run: https://app.devin.ai/sessions/aaf2b35bc0ed410a9a390d07833fb1e4
- Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918
- Build: ✅ Successful
- Lint: ✅ Passed (via pre-commit hook)

## 測試驗證

```bash
# TypeScript typecheck
cd handoff/20250928/40_App/frontend-dashboard
pnpm run typecheck  # 188 errors (down from 206)

# Build
pnpm run build  # ✅ Success
```