### PR TITLE
fix(frontend-dashboard): Fix apple-toast.tsx ToastProps id mismatch (Issue #853)

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-toast.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-toast.tsx
@@ -240,7 +240,7 @@ export const AppleToastProvider = ({ children }: { children: React.ReactNode }) 
         <AnimatePresence mode="popLayout">
           {toasts.map((toast) => (
             <div key={toast.id} className="pointer-events-auto">
-              <Toast {...toast} onDismiss={dismiss} />
+              <Toast {...toast} id={toast.id!} onDismiss={dismiss} />
             </div>
           ))}
         </AnimatePresence>


### PR DESCRIPTION
## 概述

修復 `apple-toast.tsx` 中的 TypeScript TS2322 錯誤：`id` 屬性在展開的 props 中是可選的，但在 `ToastProps` 介面中是必需的。

## 變更內容

**檔案：** `handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-toast.tsx:243`

```diff
- <Toast {...toast} onDismiss={dismiss} />
+ <Toast {...toast} id={toast.id!} onDismiss={dismiss} />
```

## 技術細節

**根本原因：**
- `ToastProps` 介面定義 `id: string`（必需）
- `ToastOptions` 介面定義 `id?: string`（可選）
- 使用 `{...toast}` 展開時，TypeScript 推斷 `id` 為可選屬性
- 導致型別不匹配錯誤

**解決方案：**
- 明確傳遞 `id={toast.id!}` 確保符合 `ToastProps` 要求
- 使用非空斷言 (`!`) 安全，因為 `toast` 函數（第 193 行）始終生成 id

**影響：**
- ✅ TypeScript 錯誤：22 → 21（-1 錯誤）
- ✅ 無 toast 相關 TypeScript 錯誤
- ✅ 保留所有 toast 功能

## 驗證結果

```bash
# TypeScript 檢查
pnpm exec tsc --noEmit
錯誤數：22 → 21 ✅

# Toast 相關錯誤
grep -i "toast" /tmp/ts-errors.txt
無錯誤 ✅

# shared-ui TypeScript 檢查
cd packages/shared-ui && pnpm exec tsc --noEmit
0 錯誤 ✅
```

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯（✅ 僅修復型別）

## 人工審查檢查清單

⚠️ **重點審查項目：**
1. **非空斷言安全性**：確認 `toast.id!` 安全
   - 檢查第 193 行：`toast` 函數始終設置 `id = Math.random().toString(36).substr(2, 9)`
   - 驗證沒有其他方式可以創建不帶 id 的 toast

2. **執行時測試**：手動測試 toast 功能
   - [ ] 觸發各種類型的 toast（success, error, warning, info, default）
   - [ ] 驗證 toast 正常顯示和關閉
   - [ ] 檢查沒有控制台錯誤

3. **型別正確性**：確認修復符合預期
   - [ ] TypeScript 編譯通過
   - [ ] 無新增錯誤

## 相關資訊

- **Issue**: #853
- **路線圖**: 第 1 週任務（19 → 16 錯誤）
- **規格文件**: `github_issues/ISSUE_4_fix_toast_props.md`
- **Devin 執行**: https://app.devin.ai/sessions/f416a94c87d14b39bb4cb59d00667a84
- **請求者**: Ryan Chen (ryan2939z@gmail.com) @RC918