### PR TITLE
fix(frontend-dashboard): Unify Button and Badge variant types (Issue #855)

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/CostAnalysis.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/CostAnalysis.tsx
@@ -177,7 +177,7 @@ const CostAnalysis = (): React.ReactElement => {
                 {costData?.within_budget ? 'Within Budget' : 'Over Budget'}
               </Badge>
               {costData?.alert_level && (
-                <Badge variant={costData.alert_level === 'critical' ? 'destructive' : costData.alert_level === 'warning' ? 'warning' : 'outline'}>
+                <Badge variant={costData.alert_level === 'critical' ? 'destructive' : costData.alert_level === 'warning' ? 'secondary' : 'outline'}>
                   {costData.alert_level}
                 </Badge>
               )}

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/EmptyState.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/EmptyState.tsx
@@ -46,7 +46,7 @@ export const EmptyState = ({
       </p>
       
       {action && (
-        <AppleButton onClick={action} size="lg" variant="default" className="">
+        <AppleButton onClick={action} size="lg" variant="primary" className="">
           {actionLabel || t('feedback.emptyState.defaultPrimaryAction')}
         </AppleButton>
       )}

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/metrics/MetricsAnalysisDashboard.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/metrics/MetricsAnalysisDashboard.tsx
@@ -166,7 +166,7 @@ export function MetricsAnalysisDashboard(): React.ReactElement {
   }
 
   const getStatusBadge = (status: MetricStatus): React.ReactElement => {
-    const variants: Record<MetricStatus, string> = {
+    const variants: Record<MetricStatus, 'default' | 'secondary' | 'outline' | 'destructive'> = {
       good: 'default',
       excellent: 'default',
       needs_improvement: 'secondary',


### PR DESCRIPTION
## 概述

修復 3 個 TS2322 型別不符錯誤，統一 Button 和 Badge 的 variant 值與設計系統型別定義一致。

**TypeScript 錯誤數：21 → 18 (-3)** ✅

## 變更內容

### 1. CostAnalysis.tsx (L180)
```diff
- <Badge variant={... ? 'warning' : 'outline'}>
+ <Badge variant={... ? 'secondary' : 'outline'}>
```
**原因：** Badge 不支援 `'warning'` variant  
**可用值：** `'default' | 'secondary' | 'outline' | 'destructive'`

### 2. EmptyState.tsx (L49)
```diff
- <AppleButton variant="default">
+ <AppleButton variant="primary">
```
**原因：** AppleButton 不支援 `'default'` variant  
**可用值：** `'primary' | 'secondary' | 'destructive' | 'outline' | 'ghost' | 'link' | 'filled' | 'tinted'`

### 3. MetricsAnalysisDashboard.tsx (L169)
```diff
- const variants: Record<MetricStatus, string> = {
+ const variants: Record<MetricStatus, 'default' | 'secondary' | 'outline' | 'destructive'> = {
```
**原因：** 明確型別註記確保 Badge variant 型別安全

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## ⚠️ 需重點審查

### 視覺變更
1. **CostAnalysis 警告徽章**：`'warning'` → `'secondary'`
   - 請確認 `'secondary'` variant 是否適合表示警告狀態
   - 是否需要使用 `'outline'` 或其他 variant？
   - 原本可能預期黃色警告色，現在會是灰色中性色

2. **EmptyState 按鈕**：`'default'` → `'primary'`
   - 請確認空狀態的主要行動按鈕使用 `'primary'` 是否正確
   - 視覺上會更突出（可能是期望的效果）

### 測試覆蓋
- ⚠️ 這些元件目前**沒有測試檔案**
- 建議手動測試受影響的頁面：
  - 成本分析頁面（警告狀態）
  - 任何使用 EmptyState 的頁面
  - 效能指標儀表板

## 驗證

✅ TypeScript 檢查：18 錯誤（從 21 減少）  
✅ Build：成功  
✅ 無破壞性變更  

## 相關資訊

- **Issue #855** - Button variant 統一
- **預估時間：** 2-3 小時
- **實際時間：** ~1 小時
- **Devin 執行：** https://app.devin.ai/sessions/f416a94c87d14b39bb4cb59d00667a84
- **請求者：** Ryan Chen (@RC918)