### PR TITLE
fix(ci): add shared-ui build step to staging frontend tests

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -104,6 +104,8 @@ jobs:
         run: corepack enable
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+      - name: Build shared-ui package
+        run: pnpm --filter @morningai/shared-ui build
       - name: Run frontend tests
         run: |
           cd handoff/20250928/40_App/frontend-dashboard


### PR DESCRIPTION
## 問題

Staging CI 中的 frontend-tests job 失敗，錯誤訊息：
```
Error: Failed to resolve entry for package "@morningai/shared-ui". 
The package may have incorrect main/module/exports specified in its package.json.
```

影響的測試檔案：
- `src/components/__tests__/LandingPage.test.tsx`
- `src/components/__tests__/LoginPage.test.tsx`  
- `src/components/__tests__/SignupPage.test.tsx`

## 根本原因

`@morningai/shared-ui` package 存在於 `packages/shared-ui/`，其 `package.json` 的 exports 指向 `dist/index.mjs` 和 `dist/index.js`，但是：
1. CI 中只執行 `pnpm install --frozen-lockfile`
2. `pnpm install` 不會自動建置 workspace packages
3. 因此 `dist/` 目錄不存在，導致 Vite 無法解析模組

## 解決方案

在執行 frontend tests 之前，加入建置 shared-ui package 的步驟：
```yaml
- name: Build shared-ui package
  run: pnpm --filter @morningai/shared-ui build
```

這個修正讓 `staging-deploy.yml` 與 `test-apps.yml` 保持一致（test-apps.yml 已經有這個步驟）。

## 已驗證

✅ 本地測試通過：
```bash
pnpm --filter @morningai/shared-ui build  # 建立 dist/index.js 和 dist/index.mjs
cd handoff/20250928/40_App/frontend-dashboard && pnpm test  # 所有測試通過
```

## 提醒
- [x] 不修改 OpenAPI/資料欄位（此 PR 僅修改 CI 配置）
- [x] 工程 PR 僅含 CI 邏輯（無 UI/文案/樣式修改）

## 人工審查重點

1. **步驟順序**：確認 build shared-ui 的步驟位置正確（在 install dependencies 之後，run frontend tests 之前）
2. **其他 workflows**：檢查是否有其他 workflow 也需要這個修正（已確認 test-apps.yml 已有，frontend.yml 使用不同的建置模式）
3. **建置時間影響**：這個步驟增加約 70ms 建置時間（本地測試），CI 中可能更長
4. **錯誤處理**：build 失敗時會自動中止 workflow（pnpm 預設行為）

---

**Link to Devin run:** https://app.devin.ai/sessions/8f19eb64cca64ec69a14483b2972cefd  
**Requested by:** Ryan Chen (ryan2939z@gmail.com) @RC918