### PR TITLE
fix(frontend-dashboard): Add jest-axe type definitions for Vitest (Issue #857)

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/test/jest-axe.d.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/src/test/jest-axe.d.ts
@@ -1,0 +1,20 @@
+import 'vitest'
+import type { JestAxeConfigureOptions, AxeResults } from 'jest-axe'
+
+declare module 'vitest' {
+  interface Assertion<T = any> {
+    /**
+     * Assert that the given HTML element has no accessibility violations
+     * @param options - Optional jest-axe configuration options
+     */
+    toHaveNoViolations(options?: JestAxeConfigureOptions): T
+  }
+
+  interface AsymmetricMatchersContaining {
+    /**
+     * Assert that the given HTML element has no accessibility violations
+     * @param options - Optional jest-axe configuration options
+     */
+    toHaveNoViolations(options?: JestAxeConfigureOptions): any
+  }
+}

--- a/handoff/20250928/40_App/frontend-dashboard/src/test/setup.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/src/test/setup.ts
@@ -1,6 +1,10 @@
 import '@testing-library/jest-dom'
 import { cleanup } from '@testing-library/react'
 import { afterEach } from 'vitest'
+import { toHaveNoViolations } from 'jest-axe'
+import { expect } from 'vitest'
+
+expect.extend(toHaveNoViolations)
 
 afterEach(() => {
   cleanup()


### PR DESCRIPTION
## 概述

修復 4 個 TS2339 型別錯誤，為 jest-axe 的 `toHaveNoViolations` matcher 新增 Vitest TypeScript 型別定義。

**TypeScript 錯誤數：18 → 14 (-4)** ✅

## 變更內容

### 1. 新增 `src/test/jest-axe.d.ts` (NEW FILE)
```typescript
declare module 'vitest' {
  interface Assertion<T = any> {
    toHaveNoViolations(options?: JestAxeConfigureOptions): T
  }
  interface AsymmetricMatchersContaining {
    toHaveNoViolations(options?: JestAxeConfigureOptions): any
  }
}
```
- 擴展 Vitest 的 `Assertion` 介面，新增 `toHaveNoViolations` 方法
- 提供完整的 TypeScript 型別安全性
- 包含 JSDoc 文件以支援 IDE 自動完成

### 2. 修改 `src/test/setup.ts`
```typescript
import { toHaveNoViolations } from 'jest-axe'
import { expect } from 'vitest'

expect.extend(toHaveNoViolations)
```
- 在測試設定中全域註冊 jest-axe matcher
- 確保所有測試檔案都能使用 `toHaveNoViolations`
- 遵循 Vitest 最佳實踐

## 影響範圍

**修復的測試檔案（全部通過）：**
- ✅ apple-action-sheet.a11y.test.tsx (4 tests)
- ✅ apple-control-center.a11y.test.tsx (3 tests)  
- ✅ apple-live-activity.a11y.test.tsx (4 tests)
- ✅ apple-picker.a11y.test.tsx (5 tests)

**驗證結果：**
- TypeScript 檢查：18 → 14 錯誤 ✅
- 無障礙測試：16/16 通過 ✅
- 建置：成功 ✅

## 技術細節

### 為什麼需要這個修復？
- jest-axe 已安裝且在執行時正常運作
- 但缺少 Vitest 的 TypeScript 型別定義
- Vitest 使用 `Assertion` 介面（與 Jest 的 `Matchers` 不同）
- TypeScript 無法識別自訂 matcher，導致 TS2339 錯誤

### 實作方式
1. **型別宣告檔案**：擴展 Vitest 的型別系統
2. **全域設定**：在 setup.ts 中註冊 matcher
3. **自動發現**：TypeScript 自動載入 .d.ts 檔案

## 人工審查重點

### ⚠️ 關鍵檢查項目
- [ ] 確認 `Assertion` 介面擴展語法正確（Vitest 非 Jest）
- [ ] 驗證 4 個 a11y 測試檔案不再有 TS2339 錯誤
- [ ] 檢查 setup.ts 的全域 extend 不影響其他測試
- [ ] 確認 TypeScript 自動發現 jest-axe.d.ts

### 🔍 次要檢查項目
- [ ] jest-axe 套件版本相容性 (v10.0.0)
- [ ] 型別宣告檔案位置正確 (src/test/)
- [ ] 無其他測試受到影響

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 API/邏輯（無 UI/文案/樣式變更）

---

**Session**: https://app.devin.ai/sessions/f416a94c87d14b39bb4cb59d00667a84  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) @RC918  
**Issue**: #857