### PR TITLE
feat(infra): Add health check monitoring for morningai-backend-v2

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -10,6 +10,7 @@ services:
       cd ../orchestrator &&
       pip install -e .
     startCommand: cd handoff/20250928/40_App/api-backend && gunicorn -c gunicorn.conf.py src.main:app
+    healthCheckPath: /health
     envVars:
       - key: FLASK_ENV
         value: production


### PR DESCRIPTION
## 概述

為 `morningai-backend-v2` 服務添加健康檢查監控配置，使 Render 能夠自動監控服務狀態並在失敗時自動重啟。

## 變更內容

**render.yaml**:
- 在 `morningai-backend-v2` 服務添加 `healthCheckPath: /health`

## 技術細節

此變更使 `morningai-backend-v2` 與其他服務對齊：
- `morningai-orchestrator-api` (line 116): ✅ 已有 `healthCheckPath: /health`
- `morningai-worker-dashboard` (line 158): ✅ 已有 `healthCheckPath: /api/health`
- `morningai-backend-v2`: ❌ 之前缺少此配置 → ✅ 現在已添加

## 效益

1. **自動故障恢復**: Render 會定期檢查 `/health` endpoint，如果失敗會自動重啟服務
2. **更好的可觀測性**: 健康檢查狀態會顯示在 Render Dashboard
3. **提高生產環境可靠性**: 減少人工干預需求

## 測試驗證

已驗證 `/health` endpoint 正常運作：
```bash
# 10/10 成功測試
curl https://morningai-backend-v2.onrender.com/health
{
  "database": "connected",
  "status": "healthy",
  ...
}
```

## ⚠️ 重要提醒

**此變更會啟用自動重啟行為**：
- Render 會定期呼叫 `/health` endpoint
- 如果連續失敗，Render 會**自動重啟服務**
- 這是期望的行為，但團隊應該知道此變更會改變生產環境的故障處理方式

## 人工審查檢查清單

- [ ] 確認 `/health` endpoint 適合作為自動重啟的決策依據
- [ ] 確認希望啟用自動重啟行為
- [ ] 考慮是否需要調整健康檢查的頻率或重試邏輯
- [ ] 驗證此變更與團隊的監控策略一致

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

---

**背景**: 此 PR 是 PR #883 後續的生產環境強化措施之一，旨在提高服務可靠性。

**相關**: PR #883 (Production deployment hardening)

**Devin Run**: https://app.devin.ai/sessions/5968fb96014e4b0588112c401d3aaebb  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918