### PR TITLE
fix(backend): Add retry logic for database initialization

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/main.py
+++ b/handoff/20250928/40_App/api-backend/src/main.py
@@ -272,9 +272,52 @@ else:
         logger.info(f"ℹ️  Database configured: SQLite (path: {sqlite_path})")
 
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+
+app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
+    'pool_pre_ping': True,
+    'pool_recycle': 300,
+    'pool_size': 5,
+    'max_overflow': 10,
+    'pool_timeout': 10,
+}
+
 db.init_app(app)
-with app.app_context():
-    db.create_all()
+
+def init_database_with_retry(max_retries=6, initial_delay=0.5):
+    """
+    Initialize database with exponential backoff retry logic.
+    
+    This handles transient connection issues during deployment, especially
+    with Supabase Session pooler which may briefly refuse connections during
+    cold starts or network blips.
+    
+    Retry schedule: 0.5s, 1s, 2s, 4s, 8s, 16s (total ~31.5s)
+    """
+    import time
+    
+    for attempt in range(max_retries):
+        try:
+            with app.app_context():
+                db.create_all()
+            logger.info("✅ Database tables initialized successfully")
+            return
+        except Exception as e:
+            delay = initial_delay * (2 ** attempt)
+            is_last_attempt = (attempt == max_retries - 1)
+            
+            if is_last_attempt:
+                logger.critical(f"❌ FATAL: Failed to initialize database after {max_retries} attempts: {e}")
+                raise
+            else:
+                logger.warning(f"⚠️  Database initialization attempt {attempt + 1}/{max_retries} failed: {e}")
+                logger.info(f"🔄 Retrying in {delay}s...")
+                time.sleep(delay)
+
+if ENVIRONMENT == 'production':
+    init_database_with_retry()
+else:
+    with app.app_context():
+        db.create_all()
 
 @app.route('/', defaults={'path': ''})
 @app.route('/<path:path>')


### PR DESCRIPTION
## 問題描述

Production 部署時出現間歇性的 "Connection refused" 錯誤，導致部署失敗：

```
sqlalchemy.exc.OperationalError: (psycopg2.OperationalError) connection to server at 
"aws-1-us-east-1.pooler.supabase.com" (3.227.209.82), port 5432 failed: Connection refused
```

**根本原因**：
- `db.create_all()` 在模組匯入時同步執行（main.py line 277）
- Supabase Session pooler 在部署期間偶爾會短暫拒絕連接（冷啟動、網路波動）
- 沒有重試邏輯，首次連接失敗就導致整個部署失敗
- Render 會重試部署，但這造成延遲和失敗的部署記錄

## 解決方案

### 1. 新增 SQLAlchemy 連接池彈性配置
```python
app.config['SQLALCHEMY_ENGINE_OPTIONS'] = {
    'pool_pre_ping': True,      # 使用前測試連接
    'pool_recycle': 300,        # 每 5 分鐘回收連接
    'pool_size': 5,             # 連接池大小
    'max_overflow': 10,         # 最大溢出連接數
    'pool_timeout': 10,         # 連接等待超時
}
```

### 2. 新增 `init_database_with_retry()` 函數
- **指數退避重試**：0.5s, 1s, 2s, 4s, 8s, 16s（總計 ~31.5秒）
- **6 次重試機會**：處理短暫的連接問題
- **清晰的日誌**：每次嘗試都記錄，便於除錯
- **重試耗盡後 fail-fast**：避免靜默忽略持續性問題

### 3. Production 專用行為
```python
if ENVIRONMENT == 'production':
    init_database_with_retry()
else:
    with app.app_context():
        db.create_all()
```

Development/staging 維持原有的直接 `db.create_all()` 行為。

## 效益

✅ **消除部署失敗**：處理短暫的連接問題，不再因為一次性錯誤就失敗  
✅ **保持 fail-fast**：持續性問題仍會快速失敗（31.5s 後）  
✅ **更好的可觀測性**：重試日誌提供部署期間的連接狀態資訊  
✅ **符合生產最佳實踐**：外部依賴應該有重試邏輯

## 人工審查檢查清單

### 🔍 重點審查項目

1. **重試邏輯正確性**
   - ✅ 確認指數退避計算：`delay = 0.5 * (2^attempt)`
   - ✅ 確認重試次數：6 次嘗試，總計 ~31.5 秒
   - ⚠️ **風險**：捕捉所有例外 (`except Exception`)，是否應該只捕捉 `psycopg2.OperationalError`？

2. **Production-only 行為**
   - ✅ 確認 production 專用重試邏輯是合理的
   - ⚠️ **風險**：development/staging 不會測試到重試邏輯

3. **連接池設定**
   - ✅ 確認 `pool_size=5, max_overflow=10`（總計 15 連接）對 production 負載是否合理
   - ✅ 確認 `pool_recycle=300` (5 分鐘) 是否適當
   - ℹ️ `pool_pre_ping=True` 會在每次使用前測試連接（微小效能成本）

4. **模組層級初始化**
   - ℹ️ `db.create_all()` 仍在模組匯入時執行（所有 workers 都會執行）
   - ✅ Flask-SQLAlchemy 的 `create_all()` 是冪等的（CREATE TABLE IF NOT EXISTS）

5. **失敗延遲時間**
   - ✅ 確認 31.5 秒的總重試時間是可接受的（如果資料庫真的掛了）

## 測試驗證

⚠️ **無法在本地輕易測試**：此問題需要以下條件才能重現：
- ENVIRONMENT=production
- 實際的 Render 部署環境
- Supabase Session pooler 的短暫連接問題

**首次真實測試**：將在此 PR 合併並部署到 production 時進行。

已驗證：
- ✅ Production health endpoint 回傳 `"database": "connected"`
- ✅ 服務最終會自動恢復（即使初始連接失敗）

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

---

**相關**：PR #883 (Production deployment hardening)  
**修復**：部署期間的 "Connection refused" 錯誤

**Devin Run**: https://app.devin.ai/sessions/5968fb96014e4b0588112c401d3aaebb  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918