### PR TITLE
fix: Enable RLS for public.user table (Security Advisor fix)

### DIFF
--- a/migrations/018_enable_rls_user_table.sql
+++ b/migrations/018_enable_rls_user_table.sql
@@ -24,25 +24,25 @@ COMMENT ON POLICY "service_role_user_all" ON public.user IS
 -- ============================================================================
 -- ============================================================================
 
-CREATE POLICY IF NOT EXISTS "authenticated_user_read_self" ON public.user
+CREATE POLICY IF NOT EXISTS "authenticated_user_read" ON public.user
     FOR SELECT
     TO authenticated
-    USING (id = auth.uid());
+    USING (true);
 
-COMMENT ON POLICY "authenticated_user_read_self" ON public.user IS 
-    'Authenticated users can read their own user data';
+COMMENT ON POLICY "authenticated_user_read" ON public.user IS 
+    'Authenticated users can read user data (table has no auth_user_id field for row-level filtering)';
 
 -- ============================================================================
 -- ============================================================================
 
-CREATE POLICY IF NOT EXISTS "authenticated_user_update_self" ON public.user
+CREATE POLICY IF NOT EXISTS "authenticated_user_no_write" ON public.user
     FOR UPDATE
     TO authenticated
-    USING (id = auth.uid())
-    WITH CHECK (id = auth.uid());
+    USING (false)
+    WITH CHECK (false);
 
-COMMENT ON POLICY "authenticated_user_update_self" ON public.user IS 
-    'Authenticated users can update their own user data';
+COMMENT ON POLICY "authenticated_user_no_write" ON public.user IS 
+    'Authenticated users cannot update user data directly (must use backend API with service_role)';
 
 -- ============================================================================
 -- ============================================================================
@@ -96,14 +96,19 @@ BEGIN
 ╠════════════════════════════════════════════════════════════╣
 ║  Security Model:                                           ║
 ║  - Service role: Full access (ALL operations)              ║
-║  - Authenticated: Read/Update own data only                ║
+║  - Authenticated: Read-only access                         ║
 ║  - Anonymous/Public: No access (blocked by RLS)            ║
+╠════════════════════════════════════════════════════════════╣
+║  Note:                                                     ║
+║  Table has integer ID (not UUID), so cannot use            ║
+║  auth.uid() for row-level filtering. Authenticated users   ║
+║  get read-only access. Updates must go through backend.    ║
 ╠════════════════════════════════════════════════════════════╣
 ║  Impact:                                                   ║
 ║  - Supabase Security Advisor error RESOLVED ✅             ║
 ║  - User data now protected from unauthorized access        ║
 ║  - Backend services maintain full access via service role  ║
-║  - Users can only access their own data                    ║
+║  - Users can read data but must use API for updates        ║
 ╚════════════════════════════════════════════════════════════╝
 ', policy_count;
 
@@ -114,7 +119,7 @@ END $$;
 
 GRANT ALL ON public.user TO service_role;
 
-GRANT SELECT, UPDATE ON public.user TO authenticated;
+GRANT SELECT ON public.user TO authenticated;
 
 -- ============================================================================
 -- ============================================================================
@@ -131,8 +136,8 @@ BEGIN
 ║  Next Steps:                                               ║
 ║  1. Verify in Supabase Security Advisor (should show 0)    ║
 ║  2. Test backend services still work (service_role)        ║
-║  3. Test users can read/update their own data              ║
-║  4. Verify users cannot access other users data            ║
+║  3. Test users can read data (authenticated)               ║
+║  4. Verify users cannot write directly (must use API)      ║
 ╚════════════════════════════════════════════════════════════╝
 ';
 END $$;


### PR DESCRIPTION
## 概要
修復 Supabase Security Advisor 警告：為 `public.user` 表啟用 Row Level Security (RLS)

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 變更內容
新增 migration `018_enable_rls_user_table.sql`，包含：
1. 啟用 `public.user` 表的 RLS
2. 創建 3 個安全策略：
   - `service_role_user_all`: Service role 擁有完整存取權限
   - `authenticated_user_read`: 認證用戶可讀取所有用戶資料
   - `authenticated_user_no_write`: 認證用戶無法直接更新（必須透過後端 API）

## ⚠️ 重要：安全模型設計
**此 migration 的安全模型設計需要特別注意：**

由於 `public.user` 表使用 **integer ID**（非 UUID），且**沒有** `auth_user_id` 欄位可連結到 Supabase Auth，因此無法實現基於用戶身份的 row-level 過濾。

**當前實作的安全模型：**
- ✅ Service role (後端): 完整存取權限
- ⚠️ **Authenticated (前端登入用戶): 可讀取所有用戶資料** (`USING (true)`)
- ✅ Authenticated: 無法直接更新（`USING (false)`）
- ✅ Anonymous: 無存取權限

**這意味著：任何登入的用戶都可以讀取所有其他用戶的資料。**

## 技術背景
- 原始嘗試使用 `id = auth.uid()` 進行 row-level 過濾
- 失敗原因：類型不匹配（`id` 是 `integer`，`auth.uid()` 回傳 `uuid`）
- 表結構：`id` (integer), `username` (varchar), `email` (varchar), `created_at` (timestamp), `preferences` (text)
- 沒有 UUID 欄位可以與 `auth.uid()` 匹配

## 測試指引
**在合併前必須執行：**

1. 在 Supabase SQL Editor 中執行測試檔案：`/tmp/migration_test_final.sql`
2. 確認輸出顯示：
   - ✅ TEST PASSED: RLS enabled, 3 policies created
   - ✅ ROLLBACK SUCCESSFUL
3. 確認 Security Advisor 錯誤已解決（應顯示 0 errors）

## 審查重點
1. **🔴 CRITICAL**: 確認「所有認證用戶可讀取所有用戶資料」的安全模型是否符合業務需求
2. **🔴 CRITICAL**: 在 Supabase SQL Editor 中測試 migration（使用 `/tmp/migration_test_final.sql`）
3. 檢查前端是否有直接更新 `public.user` 的程式碼（會中斷）
4. 確認後端 API 使用 `service_role` 進行用戶資料更新
5. 考慮未來是否需要新增 `auth_user_id UUID` 欄位以實現更細緻的 row-level security

## 潛在影響
- ✅ 解決 Supabase Security Advisor 警告
- ⚠️ 認證用戶無法直接更新資料（必須透過後端 API）
- ⚠️ 認證用戶可讀取所有用戶資料（安全模型限制）

---

**Link to Devin run**: https://app.devin.ai/sessions/598547ecff214b8dbd338e29465205dc  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918