### PR TITLE
Phase 3: Continuous Improvement - Issue #871 (pnpm standardization)

### DIFF
--- a/tools/frontend-lab/frontend-dashboard-deploy/package.json
+++ b/tools/frontend-lab/frontend-dashboard-deploy/package.json
@@ -110,5 +110,5 @@
     "vite": "^6.3.5",
     "vitest": "^4.0.2"
   },
-  "packageManager": "pnpm@10.4.1+sha512.c753b6c3ad7afa13af388fa6d808035a008e30ea9993f58c6663e2bc5ff21679aa834db094987129aa4d488b86df57f7b634981b2f827cdcacc698cc0cfb88af"
+  "packageManager": "pnpm@9.15.1"
 }


### PR DESCRIPTION
## 概要 Summary

Phase 3 開始：標準化 pnpm 版本至 9.15.1（Issue #871）

Phase 3 begins: Standardize pnpm version to 9.15.1 (Issue #871)

## 變更內容 Changes

更新 `tools/frontend-lab/frontend-dashboard-deploy/package.json` 的 `packageManager` 欄位從 `pnpm@10.4.1` 改為 `pnpm@9.15.1`，與專案其他 package.json 檔案保持一致。

Updated `packageManager` field in `tools/frontend-lab/frontend-dashboard-deploy/package.json` from `pnpm@10.4.1` to `pnpm@9.15.1` to match all other package.json files in the project.

**影響範圍 Impact:**
- 單一檔案變更 (Single file change)
- 無功能性影響 (No functional impact)
- 確保 pnpm 版本一致性 (Ensures pnpm version consistency)

## 技術債務路線圖 Technical Debt Roadmap

此 PR 為 [Technical Debt Roadmap](../blob/main/docs/TECHNICAL_DEBT_ROADMAP.md) Phase 3 的第一個任務：

- ✅ **Issue #871**: pnpm 版本標準化 (10 分鐘，LOW RISK)
- ⏳ **Issue #868**: Orchestrator 目錄重構 (1 週，HIGH RISK)
- ⏳ **Issue #869**: Phase API 重構 (2-3 天，MEDIUM RISK)
- ⏳ **Issue #870**: 測試覆蓋率 60% → 70% (10 週，ongoing)

## 審查重點 Review Checklist

### 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

### 需確認事項
- [ ] 確認 pnpm@9.15.1 是專案標準版本
- [ ] 確認 `tools/frontend-lab/` 目錄是否應該保留（此目錄為 deprecated）
- [ ] 檢查是否有 CI workflow 依賴此目錄

## 測試 Testing

無需測試 - 此為 package manager 版本規範變更，不影響程式執行。

No testing required - this is a package manager version specification change that doesn't affect runtime behavior.

---

**Link to Devin run**: https://app.devin.ai/sessions/8f19eb64cca64ec69a14483b2972cefd  
**Requested by**: Ryan Chen (@RC918)