### PR TITLE
fix(ci): Resolve Playwright port conflict in LHCI workflow

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/playwright.config.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/playwright.config.ts
@@ -18,9 +18,9 @@ export default defineConfig({
     video: 'retain-on-failure',
   },
   webServer: {
-    command: 'npm run preview',
+    command: 'pnpm preview --port 4173',
     url: 'http://localhost:4173',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
     timeout: 120_000,
   },
   projects: [


### PR DESCRIPTION
## 概要 Summary

修復 LHCI workflow 失敗問題：Playwright 嘗試在已被使用的 port 4173 啟動第二個 server。

Fix LHCI workflow failure where Playwright attempted to start a second server on port 4173 which was already in use.

## 問題 Problem

在 LHCI workflow 的 "Setup Playwright authentication" 步驟失敗，錯誤訊息：
```
Error: http://localhost:4173 is already used, make sure that nothing is running on the port/url or set reuseExistingServer:true in config.webServer.
```

**根本原因 Root Cause:**
- CI workflow 手動啟動 preview server: `pnpm preview --port 4173 &`
- Playwright config 設定 `reuseExistingServer: !process.env.CI`，在 CI 環境中評估為 `false`
- Playwright 嘗試啟動自己的 server，造成 port 衝突

## 解決方案 Solution

**變更 1**: 設定 `reuseExistingServer: true`
- 原值：`!process.env.CI` (CI 中為 false)
- 新值：`true` (總是重用現有 server)
- 行為：若 server 已存在則重用，否則啟動新的
- 影響：CI 和本地開發環境都會重用現有 server

**變更 2**: 更新 command 為 `pnpm preview --port 4173`
- 原值：`npm run preview`
- 新值：`pnpm preview --port 4173`
- 理由：明確指定 port，與專案使用 pnpm 保持一致

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 需審查事項 Review Checklist

### 關鍵檢查點 Critical
- [ ] 確認 `reuseExistingServer: true` 的行為符合預期（重用現有 server，無則啟動）
- [ ] 驗證 CI workflow (.github/workflows/lhci.yml) 確實手動啟動 preview server
- [ ] 確認此變更不會破壞本地開發流程
- [ ] **重要**: Merge 後需手動觸發 workflow_dispatch 驗證修復是否成功

### 次要檢查點 Secondary
- [ ] `pnpm preview --port 4173` 與 `npm run preview` 行為一致
- [ ] 沒有其他地方有類似的 port 衝突風險

## 測試計畫 Testing Plan

**本地測試**（已跳過，因為需要 CI 環境）:
```bash
# 1. 啟動 server
pnpm preview --port 4173 &

# 2. 執行 Playwright 測試
pnpm exec playwright test tests/auth.setup.spec.ts

# 預期：無 EADDRINUSE 錯誤
```

**CI 測試**（Merge 後必須執行）:
1. Merge PR 到 main
2. 前往 Actions → lighthouse-ci workflow
3. 手動觸發 workflow_dispatch
4. 驗證：
   - ✅ "Setup Playwright authentication" 步驟成功
   - ✅ 無 EADDRINUSE 錯誤
   - ✅ LHCI artifacts 成功上傳
   - ✅ Baseline/trend commit 建立

## 影響範圍 Impact

- **檔案變更**: 1 個檔案，2 行變更
- **CI 行為**: Playwright 將重用 workflow 手動啟動的 server，不再嘗試啟動第二個
- **本地開發**: 行為維持不變（Playwright 會重用或啟動 server）
- **風險評估**: LOW - 最小變更，符合 Playwright 文件建議

## 背景資訊 Context

此問題在 PR #894 merge 後才出現。PR #894 移除了 lighthouserc 檔案中的 `startServerCommand`，但並未修改 Playwright config。問題源自 Playwright config 本身的設定與 CI workflow 手動啟動 server 的做法不一致。

---

**Link to Devin run**: https://app.devin.ai/sessions/5968fb96014e4b0588112c401d3aaebb  
**Requested by**: Ryan Chen (@RC918)