### PR TITLE
fix(ci): Add missing auth.setup.spec.ts for LHCI workflow

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -204,6 +204,7 @@ jobs:
           TEST_EMAIL: ${{ secrets.TEST_EMAIL }}
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
         run: |
+          mkdir -p playwright/.auth
           pnpm exec playwright install --with-deps chromium
           pnpm exec playwright test tests/auth.setup.spec.ts
         working-directory: handoff/20250928/40_App/frontend-dashboard

--- a/handoff/20250928/40_App/frontend-dashboard/tests/auth.setup.spec.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/tests/auth.setup.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Playwright Authentication Setup for Lighthouse CI
+ * 
+ * This test:
+ * 1. Logs in to the application using mock credentials
+ * 2. Saves the authenticated session state (including localStorage)
+ * 3. Allows Lighthouse CI to reuse this session for testing protected pages
+ * 
+ * Environment variables required:
+ * - VITE_SUPABASE_URL: Supabase project URL (optional, falls back to mock auth)
+ * - VITE_SUPABASE_ANON_KEY: Supabase anonymous key (optional, falls back to mock auth)
+ * - TEST_EMAIL: Test account email (optional, uses admin for mock auth)
+ * - TEST_PASSWORD: Test account password (optional, uses admin123 for mock auth)
+ */
+
+import { test as setup, expect } from '@playwright/test';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import fs from 'fs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const authDir = path.join(__dirname, '../playwright/.auth');
+const authFile = path.join(authDir, 'storageState.json');
+
+setup('authenticate', async ({ page }) => {
+  console.log('🔐 Starting authentication setup...');
+  
+  if (!fs.existsSync(authDir)) {
+    fs.mkdirSync(authDir, { recursive: true });
+    console.log(`✅ Created auth directory: ${authDir}`);
+  }
+
+  const username = process.env.TEST_EMAIL || 'admin';
+  const password = process.env.TEST_PASSWORD || 'admin123';
+  console.log(`   Using credentials: ${username}/${password.replace(/./g, '*')}`);
+
+  await page.goto('http://localhost:4173/login');
+  console.log('   Navigated to login page');
+
+  await page.waitForLoadState('networkidle');
+
+  await page.fill('input[name="username"]', username);
+  await page.fill('input[name="password"]', password);
+  console.log('   Filled in credentials');
+
+  await page.click('button[type="submit"]');
+  console.log('   Submitted login form');
+
+  await page.waitForURL(/\/(dashboard|home|\/)/, { timeout: 15000 });
+
+  const currentUrl = page.url();
+  console.log(`✅ Authentication successful, current URL: ${currentUrl}`);
+
+  await page.context().storageState({ path: authFile });
+
+  console.log(`✅ Session saved to: ${authFile}`);
+  
+  if (fs.existsSync(authFile)) {
+    const state = JSON.parse(fs.readFileSync(authFile, 'utf8'));
+    const localStorageCount = state.origins?.reduce((sum: number, origin: any) => 
+      sum + (origin.localStorage?.length || 0), 0) || 0;
+    console.log(`✅ Storage state contains ${localStorageCount} localStorage items`);
+  }
+});


### PR DESCRIPTION
## 概要 Summary

修復 LHCI workflow "Error: No tests found" 失敗問題。

Fix LHCI workflow "Error: No tests found" failure by adding missing authentication test file.

## 問題 Problem

PR #895 合併後，LHCI workflow 仍然失敗，錯誤訊息：
```
Error: No tests found.
Make sure that arguments are regular expressions matching test files.
```

**根本原因 Root Cause:**
- 當 frontend 從 `tools/frontend-lab/frontend-dashboard-deploy/` 整合到 `handoff/20250928/40_App/frontend-dashboard/` 時，`auth.setup.spec.ts` 檔案沒有被複製過來
- Workflow 試圖執行 `pnpm exec playwright test tests/auth.setup.spec.ts` 但檔案不存在
- 這個測試負責建立認證 session state，讓 LHCI 可以測試需要登入的頁面（如 /dashboard, /settings）

## 變更 Changes

1. **新增 `tests/auth.setup.spec.ts`**
   - 使用正確的 selector：`input[name="username"]` 和 `input[name="password"]`
   - 使用 mock 認證：admin/admin123（符合 LoginPage.tsx 的 fallback 邏輯）
   - 將 storageState 儲存到 `playwright/.auth/storageState.json`
   - 路徑與 `scripts/make-lhci-cookie.js` 預期的路徑對齊

2. **更新 LHCI workflow**
   - 新增 `mkdir -p playwright/.auth` 確保目錄存在
   - 避免檔案系統錯誤

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 這是 CI/infrastructure 修復，無 UI/API 變更

## 人工審查重點 Human Review Checklist

⚠️ **Critical - 未在本地測試**：此修復基於日誌分析和程式碼檢查，但未在本地實際執行過。CI 將是第一次真實測試。

請重點審查：
1. **Selector 正確性**：確認 `input[name="username"]` 和 `input[name="password"]` 與當前 LoginPage.tsx (L200, L213) 的表單欄位匹配
2. **路徑對齊**：確認 `playwright/.auth/storageState.json` 路徑與 `scripts/make-lhci-cookie.js` (L18) 預期的路徑一致
3. **等待條件**：`waitForURL(/\/(dashboard|home|\/)/)` 是否適當（登入後可能重定向到這些路徑之一）
4. **Mock 認證**：admin/admin123 與 LoginPage.tsx L66 的 fallback 邏輯一致

## 測試計畫 Testing Plan

✅ 此 PR 合併後，應：
1. 手動觸發 LHCI workflow (workflow_dispatch)
2. 驗證 "Setup Playwright authentication" 步驟成功
3. 驗證 storageState.json 正確建立
4. 驗證後續的 LHCI collect 步驟可以測試 /dashboard 和 /settings

## 相關 PR Related PRs

- PR #894: 移除 lighthouserc 的 startServerCommand ✅ 正確
- PR #895: 修復 Playwright reuseExistingServer 的 port 衝突 ✅ 正確
- 此 PR #896: 新增缺少的 auth.setup.spec.ts ✅ 修復 "No tests found"

---

**Link to Devin run**: https://app.devin.ai/sessions/5968fb96014e4b0588112c401d3aaebb  
**Requested by**: Ryan Chen (@RC918)