### PR TITLE
fix(ci): Fix lhci-main by adding VITE_* env vars at job level

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -175,6 +175,9 @@ jobs:
     defaults:
       run:
         working-directory: handoff/20250928/40_App/frontend-dashboard
+    env:
+      VITE_SUPABASE_URL: ${{ secrets.SUPABASE_TEST_URL }}
+      VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_TEST_KEY }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -223,7 +226,19 @@ jobs:
       - name: Debug preview server
         run: |
           echo "Testing preview server response..."
-          curl -sS http://localhost:4173/ | head -c 500 || echo "Failed to fetch homepage"
+          curl -sS http://localhost:4173/ | head -c 1000 || echo "Failed to fetch homepage"
+          echo ""
+          echo "Checking asset URLs..."
+          curl -sS http://localhost:4173/ | sed 's/</\n</g' | grep -Eo 'src="/[^"]+\.js"|href="/[^"]+\.css"' | sed -E 's/^(src|href)=//;s/"//g' | head -10 | while read asset; do
+            echo "Testing asset: $asset"
+            curl -I "http://localhost:4173$asset" 2>&1 | head -2
+          done
+
+      - name: Verify server before Playwright
+        run: |
+          echo "Verifying preview server is still responsive..."
+          curl -I http://localhost:4173/ || echo "Homepage check failed"
+          curl -I http://localhost:4173/login || echo "Login page check failed"
 
       - name: Setup Playwright authentication
         env:
@@ -233,8 +248,9 @@ jobs:
           TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
         run: |
           mkdir -p playwright/.auth
-          pnpm exec playwright install --with-deps chromium
-          pnpm exec playwright test tests/auth.setup.spec.ts
+          echo "Working directory: $(pwd)"
+          pnpm exec playwright install chromium
+          pnpm exec playwright test tests/auth.setup.spec.ts --trace on-first-retry
         working-directory: handoff/20250928/40_App/frontend-dashboard
 
       - name: Upload Playwright test results

--- a/handoff/20250928/40_App/frontend-dashboard/tests/auth.setup.spec.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/tests/auth.setup.spec.ts
@@ -26,6 +26,23 @@ const authFile = path.join(authDir, 'storageState.json');
 setup('authenticate', async ({ page }) => {
   console.log('🔐 Starting authentication setup...');
   
+  page.on('console', msg => {
+    const type = msg.type();
+    const text = msg.text();
+    if (type === 'error' || type === 'warning') {
+      console.log(`[Browser ${type}] ${text}`);
+    }
+  });
+
+  page.on('pageerror', error => {
+    console.error(`[Page Error] ${error.message}`);
+    console.error(error.stack);
+  });
+
+  page.on('requestfailed', request => {
+    console.error(`[Request Failed] ${request.url()} - ${request.failure()?.errorText}`);
+  });
+  
   if (!fs.existsSync(authDir)) {
     fs.mkdirSync(authDir, { recursive: true });
     console.log(`✅ Created auth directory: ${authDir}`);


### PR DESCRIPTION
## 問題描述

PR #898 合併後，lhci-main 在 main branch 持續失敗，錯誤訊息為 `Found 0 username input(s) and 0 password input(s)` 和 `Page body text: (empty)`。

**根本原因**：lhci-main 缺少 job level 的 `VITE_SUPABASE_URL` 和 `VITE_SUPABASE_ANON_KEY` 環境變數，導致 `pnpm build` 編譯時這些變數為 undefined，造成應用程式無法啟動，頁面空白，Playwright 測試找不到登入表單。

**對比**：
- lhci-pr: 在 job level 設定 VITE_* 變數（第 32-33 行）→ ✅ 通過
- lhci-main: 只在 Playwright step 設定變數（第 230-233 行）→ ❌ 失敗

## 修改內容

### 1. 核心修復：在 lhci-main job level 加入環境變數
```yaml
env:
  VITE_SUPABASE_URL: ${{ secrets.SUPABASE_TEST_URL }}
  VITE_SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_TEST_KEY }}
```
確保 `pnpm build` 步驟能看到這些變數，正確編譯應用程式。

### 2. 同步 lhci-pr 的改善措施
- 移除 `--with-deps`，改用 `pnpm exec playwright install chromium`（避免 apt 問題）
- 加入 `--trace on-first-retry`（失敗時產生 trace 檔案以便除錯）
- 擴展 "Debug preview server" 步驟，檢查 JS/CSS assets 是否可訪問
- 加入 "Verify server before Playwright" 步驟，確認伺服器仍在運行

### 3. 修正 storage state 驗證路徑
- 從 `handoff/.../frontend-dashboard/playwright/.auth/storageState.json` 改為 `playwright/.auth/storageState.json`
- 原因：驗證步驟在 `handoff/.../frontend-dashboard` 目錄執行（job-level defaults），應使用相對路徑

### 4. 增強除錯能力（auth.setup.spec.ts）
```typescript
page.on('console', msg => { ... })      // 捕捉瀏覽器 console 錯誤/警告
page.on('pageerror', error => { ... })  // 捕捉執行時錯誤
page.on('requestfailed', request => { ... })  // 檢測 404 和網路問題
```

## 人工審查重點

- [ ] **⚠️ CRITICAL**: 確認 VITE_* 環境變數在 job level 設定後，build 步驟能正確使用
- [ ] **⚠️ CRITICAL**: 驗證路徑修正正確（相對路徑 vs 絕對路徑）
- [ ] 確認此修改使 lhci-main 與 lhci-pr 對稱（lhci-pr 已通過 CI）
- [ ] 驗證移除 `--with-deps` 不會破壞 Playwright 相依性
- [ ] 檢查 console logging 不會產生過多雜訊
- [ ] **注意**：lhci-main 只在 push to main 時執行，PR 階段無法完整驗證

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR（僅含 CI workflow 修復）

---

**Link to Devin run**: https://app.devin.ai/sessions/5968fb96014e4b0588112c401d3aaebb  
**Requested by**: Ryan Chen (@RC918)