### PR TITLE
fix(ci): Fix storage state verification path in lhci-main

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -266,10 +266,10 @@ jobs:
         run: |
           echo "Working directory: $(pwd)"
           echo "Checking for storage state file..."
-          ls -la handoff/20250928/40_App/frontend-dashboard/playwright/.auth/ || echo "Auth directory not found"
-          if [ -f handoff/20250928/40_App/frontend-dashboard/playwright/.auth/storageState.json ]; then
+          ls -la playwright/.auth/ || echo "Auth directory not found"
+          if [ -f playwright/.auth/storageState.json ]; then
             echo "✅ Storage state file exists"
-            node -e "const fs=require('fs');const p='handoff/20250928/40_App/frontend-dashboard/playwright/.auth/storageState.json';const s=JSON.parse(fs.readFileSync(p,'utf8'));console.log('Origins:',s.origins?.length||0);console.log('localStorage keys:',(s.origins||[]).flatMap(o=>o.localStorage?.map(i=>i.name)||[]).join(', '));"
+            node -e "const fs=require('fs');const p='playwright/.auth/storageState.json';const s=JSON.parse(fs.readFileSync(p,'utf8'));console.log('Origins:',s.origins?.length||0);console.log('localStorage keys:',(s.origins||[]).flatMap(o=>o.localStorage?.map(i=>i.name)||[]).join(', '));"
           else
             echo "❌ Storage state file not found"
             exit 1


### PR DESCRIPTION
## 問題描述

PR #899 合併後，lhci-main workflow 在執行 "Verify storage state file" 步驟時失敗，錯誤訊息為 `Auth directory not found` 和 `Storage state file not found`。

**根本原因**：驗證步驟使用了錯誤的路徑。該步驟在 `handoff/20250928/40_App/frontend-dashboard` 目錄執行（由 job-level defaults 設定），但檢查的路徑是 `handoff/20250928/40_App/frontend-dashboard/playwright/.auth/storageState.json`，從該目錄的角度看這個路徑不存在。

**實際情況**：
- Playwright 測試在 step 12 **已成功通過** ✅（logs 顯示 `1 passed (2.3s)`）
- 檔案實際寫入位置：`playwright/.auth/storageState.json`（相對於 working directory）
- 驗證步驟應該使用相對路徑：`playwright/.auth/storageState.json`

## 修改內容

將 "Verify storage state file" 步驟中的三處路徑從絕對路徑改為相對路徑：

```yaml
# 修改前
ls -la handoff/20250928/40_App/frontend-dashboard/playwright/.auth/
if [ -f handoff/20250928/40_App/frontend-dashboard/playwright/.auth/storageState.json ]; then
node -e "...p='handoff/20250928/40_App/frontend-dashboard/playwright/.auth/storageState.json'..."

# 修改後  
ls -la playwright/.auth/
if [ -f playwright/.auth/storageState.json ]; then
node -e "...p='playwright/.auth/storageState.json'..."
```

## 人工審查重點

- [ ] **⚠️ CRITICAL**: 確認 "Verify storage state file" 步驟確實在 `handoff/20250928/40_App/frontend-dashboard` 目錄執行（由 job defaults 繼承）
- [ ] **⚠️ CRITICAL**: 確認相對路徑 `playwright/.auth/storageState.json` 與 Playwright 實際寫入位置一致
- [ ] 檢查 `scripts/make-lhci-cookie.js` 是否也讀取 storage state，若是則確認其路徑邏輯不受影響（該 script 從 repo root 執行）
- [ ] **注意**：lhci-main 只在 push to main 時執行，PR 階段無法完整驗證，需要 merge 後觀察實際執行結果

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR（僅含 CI workflow 路徑修復）

---

**背景**：此為 PR #899 的後續修復。PR #899 已解決核心問題（加入 VITE_* 環境變數），Playwright 認證測試現已通過。此 PR 修正驗證步驟路徑，讓 workflow 能繼續執行後續的 LHCI 測試。

**Link to Devin run**: https://app.devin.ai/sessions/5968fb96014e4b0588112c401d3aaebb  
**Requested by**: Ryan Chen (@RC918)