### PR TITLE
chore(ci): Temporarily disable LHCI jobs

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -165,7 +165,7 @@ jobs:
           fi
 
   lhci-main:
-    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    if: false  # Temporarily disabled by owner - LHCI causing CI issues
     runs-on: ubuntu-latest
     concurrency:
       group: lhci-main


### PR DESCRIPTION
## 概述

暫時停用 LHCI workflow 中的兩個 jobs (`lhci-pr` 和 `lhci-main`)，採用**層級 1** 做法（保留所有設定檔，僅停止執行）。

## 背景

LHCI workflow 自 PR #894 起持續出現問題，經過多次修復嘗試（#895-#901）後，決定暫時停用以解除 CI 阻塞。此做法：
- ✅ 保留所有 LHCI 設定檔與測試資產
- ✅ PR 可正常 merge，不再被 LHCI 阻擋
- ✅ 將來可輕鬆恢復（移除 `if: false` 即可）

## 變更內容

在 `.github/workflows/lhci.yml` 中：
- `lhci-pr` job: 將條件從 `if: github.event_name == 'pull_request'` 改為 `if: false`
- `lhci-main` job: 將條件從原條件改為 `if: false`

## 影響與取捨

**優點：**
- PR 不再被 LHCI 失敗阻擋
- 避免 CI 中的 port 衝突與 orphan process 問題
- 開發流程更順暢

**代價：**
- PR 不會自動執行 Lighthouse 效能/無障礙檢查
- 需要手動測試 UI 變更的效能影響

## 提醒
- [x] 不修改 OpenAPI/資料欄位（本 PR 僅修改 CI 設定）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯（本 PR 為 CI 設定）

## 人工審查重點

1. **決策確認**：確認暫時停用 LHCI 符合當前開發優先順序
2. **相依性檢查**：確認沒有其他 workflow 依賴這兩個 jobs 的輸出
3. **影響範圍**：理解此變更會移除自動化效能檢查，需依賴手動測試

---

**Link to Devin run:** https://app.devin.ai/sessions/5968fb96014e4b0588112c401d3aaebb  
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918