### PR TITLE
Improve test coverage to 78% with comprehensive auth_middleware tests

### DIFF
--- a/handoff/20250928/40_App/api-backend/tests/test_auth_middleware_edge_cases.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_auth_middleware_edge_cases.py
@@ -567,15 +567,22 @@ class TestP1RecommendedTests:
     """P1 - Recommended before merge"""
     
     def test_roles_required_super_admin_bypass(self, app, jwt_secret):
-        """Test roles_required: '超級管理員' bypass behavior"""
+        """Test roles_required: '超級管理員' bypass behavior
+        
+        This test verifies that a token with Chinese role '超級管理員' 
+        (Super Admin) can bypass role restrictions and access endpoints.
+        The token contains the Chinese role name directly, not normalized.
+        """
         client = app.test_client()
         
-        user_data = {
-            'id': 999,
+        payload = {
+            'user_id': 999,
             'username': 'super_admin',
-            'role': '超級管理員'
+            'role': '超級管理員',  # Chinese role name in token
+            'exp': datetime.now(UTC) + timedelta(hours=1),
+            'iat': datetime.now(UTC)
         }
-        super_admin_token = generate_jwt_token(user_data)
+        super_admin_token = jwt.encode(payload, jwt_secret, algorithm='HS256')
         
         response = client.get('/roles', headers={
             'Authorization': f'Bearer {super_admin_token}'
@@ -588,15 +595,22 @@ class TestP1RecommendedTests:
         assert data['role'] == 'admin'
     
     def test_roles_required_chinese_analyst_normalized(self, app, jwt_secret):
-        """Test roles_required: '分析師' normalized to 'analyst'"""
+        """Test roles_required: '分析師' normalized to 'analyst'
+        
+        This test verifies that a token with Chinese role '分析師' 
+        (Analyst) is normalized to 'analyst' and can access analyst endpoints.
+        The token contains the Chinese role name directly, not normalized.
+        """
         client = app.test_client()
         
-        user_data = {
-            'id': 888,
+        payload = {
+            'user_id': 888,
             'username': 'chinese_analyst',
-            'role': '分析師'
+            'role': '分析師',  # Chinese role name in token
+            'exp': datetime.now(UTC) + timedelta(hours=1),
+            'iat': datetime.now(UTC)
         }
-        analyst_token = generate_jwt_token(user_data)
+        analyst_token = jwt.encode(payload, jwt_secret, algorithm='HS256')
         
         response = client.get('/roles', headers={
             'Authorization': f'Bearer {analyst_token}'
@@ -606,4 +620,5 @@ class TestP1RecommendedTests:
         data = response.get_json()
         assert data['message'] == 'roles success'
         assert data['user_id'] == 888
+        # The middleware normalizes '分析師' to 'analyst'
         assert data['role'] == 'analyst'


### PR DESCRIPTION
## 概述 (Summary)

提升測試覆蓋率從 77% 至 78%，針對 auth_middleware.py 增加全面的邊界案例測試，完成所有 P0（必須）和 P1（建議）測試需求。

Improve test coverage from 77% to 78% by adding comprehensive edge case tests for auth_middleware.py, completing all P0 (must-have) and P1 (recommended) test requirements.

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

✅ 本 PR 僅新增測試，無生產代碼變更

## 變更內容 (Changes)

### 新增測試檔案
- `tests/test_auth_middleware_edge_cases.py` (609 行, 36 個測試)

### 覆蓋率提升 (Coverage Improvements)
- **auth_middleware.py**: 68.3% → 94.0% (+25.7%)
- **整體專案**: 77% → 78% (+1%)
- **測試總數**: 790 → 804 (+14 tests)

### 測試範圍 (Test Coverage)

#### P0 - 必須在合併前完成的測試
1. **基礎認證錯誤處理**
   - `jwt_required`: missing Authorization header → 401
   - `jwt_required`: invalid authorization format → 401
   - `admin_required`: missing/invalid Authorization header → 401
   
2. **權限控制測試**
   - `admin_required`: user role → 403 (權限不足)
   - `analyst_required`: user role → 403 (權限不足)
   - `roles_required`: user role → 403 (權限不足)

3. **Happy Path 測試**
   - 所有認證裝飾器的成功路徑 (200 + request.current_user)
   - 驗證 user_id 和 role 正確設置在 request.current_user 中

#### P1 - 建議在合併前完成的測試
1. **中文角色名稱支援**
   - `roles_required`: '超級管理員' bypass behavior (超級管理員可訪問所有端點)
   - `roles_required`: '分析師' normalized to 'analyst'

2. **測試環境隔離**
   - Pin JWT_SECRET_KEY via test fixture (monkeypatch) 確保測試一致性

#### 例外處理測試 (Exception Handling)
- 過期 Token → 401 "Token expired"
- 無效 Token (錯誤 secret) → 401 "Invalid token"
- 畸形 Token → 401 "Authentication failed"
- 通用例外處理路徑覆蓋

#### 角色正規化測試 (Role Normalization)
- 中文角色名稱: 超級管理員、分析師、操作員、查看者
- 遺留角色名稱: operator → analyst, viewer → user
- 未知角色名稱保持原樣

## 測試結果 (Test Results)

```
804 passed, 5 skipped, 33 warnings
Coverage: 78% (2974 statements, 653 missing)
```

## 重點審查項目 (Review Focus)

### 🔍 高優先級
1. **中文角色名稱翻譯正確性**
   - 確認 '超級管理員'、'分析師' 等翻譯符合業務需求
   - 驗證角色正規化邏輯是否符合預期行為

2. **權限控制邏輯**
   - 驗證 403 vs 401 狀態碼使用是否正確
   - 確認各角色的訪問權限符合安全要求

3. **測試斷言完整性**
   - 檢查 happy path 測試是否正確驗證 request.current_user
   - 確認錯誤訊息斷言符合實際回應

### 🔧 測試品質
- 測試使用 monkeypatch 固定 JWT_SECRET_KEY，確保測試隔離
- 每個測試建立獨立的 Flask app，避免測試間干擾
- 涵蓋所有 P0 和 P1 需求

## 風險評估 (Risk Assessment)

- ✅ **低風險**: 僅新增測試，無生產代碼變更
- ✅ **向後相容**: 測試既有中介層行為
- ⚠️ **需確認**: 中文角色名稱是否符合業務術語

## 相關連結 (Links)

- **Link to Devin run**: https://app.devin.ai/sessions/6d0f6b33601443599c4c6cfac9093934
- **Requested by**: Ryan Chen (ryan2939z@gmail.com) - @RC918