### PR TITLE
fix(ci): add continue-on-error to Generate LHCI cookie step

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -267,6 +267,7 @@ jobs:
           fi
 
       - name: Generate LHCI cookie
+        continue-on-error: true
         working-directory: ${{ github.workspace }}
         run: node scripts/make-lhci-cookie.js
 


### PR DESCRIPTION
## 📋 問題描述

PR #910 合併後首次手動觸發 LHCI workflow ([run 18915690625](https://github.com/RC918/morningai/actions/runs/18915690625)) 失敗：

```
❌ Generate LHCI cookie step failed
   → Run Lighthouse CI step was SKIPPED (even with continue-on-error: true)
   → No LHCI artifacts generated
```

失敗原因：`make-lhci-cookie.js` 在 Playwright storage state 中找不到預期的 auth 資料（`supabase.auth.token` 或 `auth_token`），導致 workflow 中斷。

## 🔧 解決方案

在 "Generate LHCI cookie" step 新增 `continue-on-error: true`，使 workflow 即使在 auth 提取失敗時也能繼續執行 LHCI collect。

## ⚠️ 權衡考量

### ✅ 優點
- 允許 LHCI 在「非阻塞模式」下持續蒐集效能訊號
- 可以測試未認證頁面（`/`, `/login`, `/pricing`）
- 符合 PR #910 的「不阻塞開發流程」目標

### ⚠️ 限制
- **認證頁面將無法測試**：`/dashboard`, `/settings` 等需要登入的頁面會失敗或被跳過
- **根本原因未修復**：為何 Playwright auth setup 沒有儲存預期的 auth 資料仍不清楚

## 🧪 人工檢查重點

### 🔴 Critical
- [ ] **Auth 失敗可接受性**：「非阻塞模式」是否接受只測試公開頁面？若需要測試認證頁面，應修復 auth 提取問題而非繞過
- [ ] **失敗串聯驗證**：確認 "Generate LHCI cookie" 失敗確實會阻止 "Run LHCI" 執行（即使後者有 `continue-on-error: true`）

### 🟡 Medium  
- [ ] **執行範圍**：檢視下次 workflow run 的 LHCI 報告，確認哪些 URL 成功/失敗
- [ ] **後續修復**：若認證頁面測試重要，需另開 issue 修復 `tests/auth.setup.spec.ts` 的 auth 儲存問題

## 📝 測試計畫

1. Merge 後手動觸發 workflow
2. 驗證 workflow 完成（非中斷）
3. 檢查 LHCI artifacts 是否成功上傳
4. 查看哪些頁面成功測試、哪些失敗
5. 記錄結果至 [Issue #911](https://github.com/RC918/morningai/issues/911)

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

---

**Link to Devin run**: https://app.devin.ai/sessions/8f19eb64cca64ec69a14483b2972cefd  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918