### PR TITLE
Fix super admin bypass logic in roles_required decorator

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/middleware/auth_middleware.py
+++ b/handoff/20250928/40_App/api-backend/src/middleware/auth_middleware.py
@@ -276,7 +276,7 @@ def roles_required(*allowed_roles):
                 user_role = payload.get('role', 'user')
                 normalized_role = normalize_role(user_role)
                 
-                if normalized_role not in allowed_roles and normalized_role not in ['超級管理員']:
+                if normalized_role not in allowed_roles and user_role not in ['超級管理員']:
                     return jsonify({
                         'error': 'Insufficient privileges',
                         'message': f'Access denied. Required role(s): {", ".join(allowed_roles)}'

--- a/handoff/20250928/40_App/api-backend/tests/test_auth_middleware_edge_cases.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_auth_middleware_edge_cases.py
@@ -74,6 +74,16 @@ def app():
             'role': request.current_user.get('role')
         }, 200
     
+    @app.route('/analyst-only')
+    @roles_required('analyst')
+    def analyst_only_endpoint():
+        from flask import request
+        return {
+            'message': 'analyst only success',
+            'user_id': request.current_user.get('user_id'),
+            'role': request.current_user.get('role')
+        }, 200
+    
     return app
 
 
@@ -622,3 +632,34 @@ class TestP1RecommendedTests:
         assert data['user_id'] == 888
         # The middleware normalizes '分析師' to 'analyst'
         assert data['role'] == 'analyst'
+    
+    def test_super_admin_bypass_truly_bypasses(self, app, jwt_secret):
+        """Test that '超級管理員' truly bypasses role restrictions
+        
+        This test verifies that a super admin with Chinese role '超級管理員'
+        can access analyst-only endpoints even though they are not in the
+        allowed_roles list. This tests the bypass logic fix.
+        
+        Before fix: Would fail because normalized_role was checked
+        After fix: Should pass because original user_role is checked
+        """
+        client = app.test_client()
+        
+        payload = {
+            'user_id': 999,
+            'username': 'super_admin',
+            'role': '超級管理員',  # Chinese super admin role
+            'exp': datetime.now(UTC) + timedelta(hours=1),
+            'iat': datetime.now(UTC)
+        }
+        super_admin_token = jwt.encode(payload, jwt_secret, algorithm='HS256')
+        
+        response = client.get('/analyst-only', headers={
+            'Authorization': f'Bearer {super_admin_token}'
+        })
+        
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data['message'] == 'analyst only success'
+        assert data['user_id'] == 999
+        assert data['role'] == 'admin'


### PR DESCRIPTION
## 摘要

修正 `roles_required` 裝飾器中的超級管理員繞過邏輯錯誤。此 PR 由 PR #909 的測試揭露問題，現在修正生產代碼。

## 問題描述

在 PR #909 的 P1 測試中發現，`roles_required` 裝飾器的超級管理員繞過邏輯存在錯誤：

```python
# 錯誤的邏輯 (第 279 行)
if normalized_role not in allowed_roles and normalized_role not in ['超級管理員']:
```

**問題所在**：
- 第 277 行已經將角色正規化：`normalized_role = normalize_role(user_role)`
- 中文角色 `'超級管理員'` 被正規化為 `'admin'`
- 第 279 行檢查 `normalized_role not in ['超級管理員']` 永遠為真，因為 `'admin' != '超級管理員'`
- **結果**：超級管理員繞過邏輯完全失效

## 修正方式

檢查原始的 `user_role`（JWT payload 中的值）而非正規化後的值：

```python
# 修正後的邏輯 (第 279 行)
if normalized_role not in allowed_roles and user_role not in ['超級管理員']:
```

## 測試驗證

### 新增測試路由
- `/analyst-only` - 僅允許 analyst 角色訪問

### 新增測試案例
- `test_super_admin_bypass_truly_bypasses` - 驗證中文超級管理員角色可以繞過角色限制訪問 analyst-only 端點

### 測試結果
- ✅ 所有 37 個 auth_middleware 測試通過（36 個現有 + 1 個新增）
- ✅ 完整測試套件 805 個測試全部通過
- ✅ 覆蓋率維持在 78%

## 人工審查檢查清單

- [ ] **安全性審查**：驗證繞過邏輯的安全性，確認只有真正的超級管理員能夠繞過限制
- [ ] **邏輯正確性**：確認檢查 `user_role` 而非 `normalized_role` 是正確的做法
- [ ] **測試充分性**：驗證新測試確實測試了修正的邏輯
- [ ] **副作用檢查**：確認此修正不影響其他角色的正常權限檢查

## 提醒

- [ ] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [ ] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

✅ 此 PR 為純工程 PR，僅修改 API 邏輯和測試

---

**Link to Devin run**: https://app.devin.ai/sessions/6d0f6b33601443599c4c6cfac9093934  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918