### PR TITLE
fix(ci): correct puppeteerScript path to be relative to working directory

### DIFF
--- a/lighthouserc.main.json
+++ b/lighthouserc.main.json
@@ -15,7 +15,7 @@
         "throttlingMethod": "simulate",
         "onlyCategories": ["performance", "accessibility", "best-practices", "seo"]
       },
-      "puppeteerScript": "handoff/20250928/40_App/frontend-dashboard/lhci-puppeteer-auth.js"
+      "puppeteerScript": "lhci-puppeteer-auth.js"
     },
     "upload": {
       "target": "filesystem",


### PR DESCRIPTION
## 問題描述

PR #917 合併後，LHCI workflow 首次執行失敗，錯誤訊息：

```
Error: Cannot find module '/home/runner/work/morningai/morningai/handoff/20250928/40_App/frontend-dashboard/handoff/20250928/40_App/frontend-dashboard/lhci-puppeteer-auth.js'
```

**根本原因**：LHCI 從 working directory 解析 `puppeteerScript` 的相對路徑，而非從 config 檔案位置。由於 workflow 設定 `working-directory: handoff/20250928/40_App/frontend-dashboard`，原本的路徑 `handoff/20250928/40_App/frontend-dashboard/lhci-puppeteer-auth.js` 會被重複解析，導致找不到檔案。

## 解決方案

將 `lighthouserc.main.json` 中的 `puppeteerScript` 路徑從：
```json
"puppeteerScript": "handoff/20250928/40_App/frontend-dashboard/lhci-puppeteer-auth.js"
```

改為：
```json
"puppeteerScript": "lhci-puppeteer-auth.js"
```

因為 LHCI 執行時的 working directory 已經是 `handoff/20250928/40_App/frontend-dashboard`，所以只需要腳本檔名即可。

## 🔍 人工檢查重點

### 🔴 Critical
- [ ] **路徑邏輯正確性**：`lhci-puppeteer-auth.js` 確實位於 `handoff/20250928/40_App/frontend-dashboard/` 目錄中
- [ ] **Merge 後手動觸發 workflow**：前往 [Actions](https://github.com/RC918/morningai/actions/workflows/lhci.yml)，點擊 "Run workflow" 驗證修復成功
- [ ] **檢查 debug 輸出**：確認 "Debug LHCI config resolution" step 顯示 `puppeteerScript exists: true`
- [ ] **檢查 LHCI 執行結果**：不應再出現 "Cannot find module" 錯誤

### 🟡 Medium
- [ ] **未經測試的修復**：此修復基於錯誤訊息分析，未能在 merge 前實際執行 LHCI 驗證
- [ ] **LHCI 行為假設**：假設 LHCI 從 working directory 解析 puppeteerScript 路徑（基於錯誤訊息推斷）

## ⚠️ 已知限制

- **無自動化測試**：無法在 PR 階段驗證此修復，必須在 merge 後手動觸發 workflow
- **關鍵修復**：此問題阻塞 LHCI workflow，必須一次修正成功

## 🔗 相關資源

- **Blocked by**: PR #917 引入此問題
- **Tracking Issue**: #911 (LHCI 觀察期)
- **Failed workflow run**: https://github.com/RC918/morningai/actions/runs/18932154247

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

---

**Link to Devin run**: https://app.devin.ai/sessions/0557076376624320844aac626bb67503  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918