### PR TITLE
fix(test): resolve 4 test type mismatches (Issue #857)

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/__tests__/LandingPage.test.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/__tests__/LandingPage.test.tsx
@@ -43,7 +43,10 @@ vi.mock('../AppleHero', () => ({
 const renderLandingPage = () => {
   return render(
     <BrowserRouter>
-      <LandingPage />
+      <LandingPage 
+        onNavigateToLogin={vi.fn()} 
+        onSSOLogin={vi.fn()} 
+      />
     </BrowserRouter>
   )
 }

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-modal.test.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-modal.test.tsx
@@ -51,7 +51,7 @@ describe('AppleModal', () => {
     it('provides modal context to children', () => {
       const TestComponent = () => {
         const modal = useAppleModal()
-        return <button onClick={() => modal.openModal({ title: 'Test' })}>Open Modal</button>
+        return <button onClick={() => modal.openModal({ title: 'Test', children: <div>Test Content</div> })}>Open Modal</button>
       }
 
       render(

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-sheet.test.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-sheet.test.tsx
@@ -51,7 +51,7 @@ describe('AppleSheet', () => {
     it('provides sheet context to children', () => {
       const TestComponent = () => {
         const sheet = useAppleSheet()
-        return <button onClick={() => sheet.openSheet({ title: 'Test' })}>Open Sheet</button>
+        return <button onClick={() => sheet.openSheet({ title: 'Test', children: <div>Test Content</div> })}>Open Sheet</button>
       }
 
       render(

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-spotlight.test.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-spotlight.test.tsx
@@ -22,7 +22,7 @@ vi.mock('@/hooks/use-accessibility', () => ({
 
 const TestWrapper = ({ children, onSearch, maxRecentSearches }: {
   children: React.ReactNode
-  onSearch?: (query: string) => SearchResult[]
+  onSearch?: (query: string) => SearchResult[] | Promise<SearchResult[]>
   maxRecentSearches?: number
 }) => (
   <AppleSpotlight.Provider onSearch={onSearch} maxRecentSearches={maxRecentSearches}>


### PR DESCRIPTION
## 概述

修復 Issue #857 中的 4 個測試型別錯誤，將 TypeScript 錯誤數從 14 降至 10（-4 errors）。

## 變更內容

### 1. LandingPage.test.tsx
**問題**：TS2739 - 缺少必要的 props
```typescript
// Before
<LandingPage />

// After  
<LandingPage 
  onNavigateToLogin={vi.fn()} 
  onSSOLogin={vi.fn()} 
/>
```
- 新增兩個必要的 callback props 使用 `vi.fn()` mock

### 2. apple-modal.test.tsx
**問題**：TS2345 - `openModal` 缺少必要的 `children` prop
```typescript
// Before
modal.openModal({ title: 'Test' })

// After
modal.openModal({ title: 'Test', children: <div>Test Content</div> })
```
- 僅修改第 54 行的測試（"provides modal context to children"）

### 3. apple-sheet.test.tsx  
**問題**：TS2345 - `openSheet` 缺少必要的 `children` prop
```typescript
// Before
sheet.openSheet({ title: 'Test' })

// After
sheet.openSheet({ title: 'Test', children: <div>Test Content</div> })
```
- 僅修改第 54 行的測試（"provides sheet context to children"）

### 4. apple-spotlight.test.tsx
**問題**：TS2322 - `onSearch` 型別不匹配（async vs sync）
```typescript
// Before
onSearch?: (query: string) => SearchResult[]

// After
onSearch?: (query: string) => SearchResult[] | Promise<SearchResult[]>
```
- 更新 `TestWrapper` 型別定義以支援 async 函數

## 測試結果

**TypeScript 型別檢查**：
- ✅ 錯誤數：14 → 10 (-4 errors)
- ✅ 所有測試相關錯誤已消除

**測試執行**：
- ✅ LandingPage.test: 1 test passing
- ✅ apple-modal.test: 10 tests passing  
- ✅ apple-sheet.test: 11 tests passing
- ✅ apple-spotlight.test: 26 tests passing

## 提醒
- [ ] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 🔍 重點審查項目

### 高優先級
1. **TestWrapper 型別變更**：確認 `AppleSpotlight.Provider` 的實際 API 是否真的支援 async `onSearch`，還是這只是為了通過型別檢查？
2. **Mock 函數行為**：`vi.fn()` mock 對於 `onNavigateToLogin` 和 `onSSOLogin` 是否足夠？這些測試是否需要驗證 callback 的具體行為？

### 中優先級  
3. **其他測試覆蓋**：apple-modal.test.tsx 有 10 個測試但只修改了 1 個，apple-sheet.test.tsx 有 11 個測試但只修改了 1 個。其他測試是否也需要 `children` prop？
4. **測試完整性**：新增的 `<div>Test Content</div>` 是否足以驗證 children 正確渲染？還是這只是為了滿足型別而已？

## 相關資訊

- **Issue**: #857
- **TypeScript 錯誤減少**: 14 → 10 (-4 errors)  
- **測試檔案**: 4 個檔案，48 個測試全部通過
- **Devin Session**: https://app.devin.ai/sessions/0557076376624320844aac626bb67503
- **請求者**: Ryan Chen (@RC918)

## 注意事項

⚠️ Issue #852 聲稱有 2 個 TS2554 錯誤，但實際基準線中並不存在這些錯誤。此 Issue 可能已在其他地方修復或不再相關。建議在合併此 PR 後關閉或重新評估 Issue #852。