### PR TITLE
fix(typescript): remove all 17 'as any' type assertions (Issue #850)

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/BrandLoader.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/BrandLoader.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { motion } from 'framer-motion'
+import { motion, type Variants } from 'framer-motion'
 import { Sparkles } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -24,7 +24,7 @@ export const BrandLoader = ({
 
   const currentSize: { container: string; icon: string; text: string } = sizes[size]
 
-  const logoVariants = {
+  const logoVariants: Variants = {
     initial: { scale: 0.8, opacity: 0 },
     animate: {
       scale: [0.8, 1.1, 1],
@@ -38,7 +38,7 @@ export const BrandLoader = ({
     }
   }
 
-  const sparkleVariants = {
+  const sparkleVariants: Variants = {
     animate: (i: number) => ({
       scale: [0, 1, 0],
       opacity: [0, 1, 0],
@@ -53,7 +53,7 @@ export const BrandLoader = ({
     })
   }
 
-  const pulseVariants = {
+  const pulseVariants: Variants = {
     animate: {
       scale: [1, 1.5, 1],
       opacity: [0.5, 0, 0.5],
@@ -69,7 +69,7 @@ export const BrandLoader = ({
     return (
       <div className="flex items-center space-x-3">
         <motion.div
-          variants={logoVariants as any}
+          variants={logoVariants}
           initial="initial"
           animate="animate"
           className={`${currentSize.container} rounded-xl flex items-center justify-center shadow-lg`}
@@ -91,7 +91,7 @@ export const BrandLoader = ({
     <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-blue-50 via-purple-50 to-pink-50">
       <div className="relative">
         <motion.div
-          variants={pulseVariants as any}
+          variants={pulseVariants}
           animate="animate"
           className={`absolute inset-0 ${currentSize.container} bg-gradient-to-br from-blue-400 to-purple-600 rounded-2xl blur-xl`}
         />
@@ -100,7 +100,7 @@ export const BrandLoader = ({
           <motion.div
             key={i}
             custom={i}
-            variants={sparkleVariants as any}
+            variants={sparkleVariants}
             animate="animate"
             className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"
           >
@@ -109,7 +109,7 @@ export const BrandLoader = ({
         ))}
 
         <motion.div
-          variants={logoVariants as any}
+          variants={logoVariants}
           initial="initial"
           animate="animate"
           className={`relative ${currentSize.container} rounded-2xl flex items-center justify-center shadow-2xl`}

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/EmptyStateLibrary.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/feedback/EmptyStateLibrary.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { motion } from 'framer-motion'
+import { motion, type Variants } from 'framer-motion'
 import { AppleButton } from '@/components/ui/apple-button'
 import { 
   FileText, 
@@ -33,7 +33,7 @@ interface EmptyStateLibraryProps {
   className?: string
 }
 
-const emptyStateVariants = {
+const emptyStateVariants: Variants = {
   hidden: { opacity: 0, y: 20, scale: 0.95 },
   visible: { 
     opacity: 1, 
@@ -46,7 +46,7 @@ const emptyStateVariants = {
   }
 }
 
-const iconVariants = {
+const iconVariants: Variants = {
   hidden: { scale: 0, rotate: -180 },
   visible: { 
     scale: 1, 
@@ -60,7 +60,7 @@ const iconVariants = {
   }
 }
 
-const floatingVariants = {
+const floatingVariants: Variants = {
   animate: {
     y: [-5, 5, -5],
     transition: {
@@ -148,7 +148,7 @@ export const EmptyStateLibrary = ({
 
   return (
     <motion.div
-      variants={emptyStateVariants as any}
+      variants={emptyStateVariants}
       initial="hidden"
       animate="visible"
       className={`flex flex-col items-center justify-center py-12 px-4 ${className}`}
@@ -160,18 +160,18 @@ export const EmptyStateLibrary = ({
           aria-hidden="true"
           role="presentation"
           className="w-64 h-64 mb-6"
-          variants={floatingVariants as any}
+          variants={floatingVariants}
           animate="animate"
         />
       ) : (
         <motion.div
-          variants={iconVariants as any}
+          variants={iconVariants}
           initial="hidden"
           animate="visible"
           className={`w-24 h-24 ${currentVariant.bgColor} rounded-2xl flex items-center justify-center mb-6 shadow-lg`}
         >
           <motion.div
-            variants={floatingVariants as any}
+            variants={floatingVariants}
             animate="animate"
           >
             <Icon className={`w-12 h-12 ${currentVariant.iconColor}`} />

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-control-center.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-control-center.tsx
@@ -192,7 +192,7 @@ const ControlCard: React.FC<{
             )}
             >
               {React.isValidElement(control.icon) 
-                ? React.cloneElement(control.icon, { className: 'w-6 h-6' } as any)
+                ? React.cloneElement(control.icon as React.ReactElement<{ className?: string }>, { className: 'w-6 h-6' })
                 : control.icon
               }
             </div>
@@ -298,7 +298,7 @@ const ControlCard: React.FC<{
                       {action.icon && (
                         <div className="text-white">
                           {React.isValidElement(action.icon)
-                            ? React.cloneElement(action.icon, { className: 'w-5 h-5' } as any)
+                            ? React.cloneElement(action.icon as React.ReactElement<{ className?: string }>, { className: 'w-5 h-5' })
                             : action.icon
                           }
                         </div>

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/ui/spring-animation.stories.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/ui/spring-animation.stories.tsx
@@ -16,6 +16,8 @@ import {
 } from '../../lib/spring-animation';
 import '../../styles/spring-animations.css';
 
+type HapticType = 'light' | 'medium' | 'heavy' | 'success' | 'warning' | 'error' | 'selection';
+
 const meta: Meta = {
   title: 'Design System/Spring Animation System',
   parameters: {
@@ -171,7 +173,7 @@ export const AnimationVariants: Story = {
 
 export const HapticFeedback: Story = {
   render: () => {
-    const haptics = [
+    const haptics: Array<{ type: HapticType; label: string; description: string; color: string }> = [
       { type: 'light', label: 'Light', description: '輕微', color: 'bg-gray-500' },
       { type: 'medium', label: 'Medium', description: '中等', color: 'bg-blue-500' },
       { type: 'heavy', label: 'Heavy', description: '重度', color: 'bg-purple-500' },
@@ -192,9 +194,9 @@ export const HapticFeedback: Story = {
           {haptics.map((haptic) => (
             <motion.button
               key={haptic.type}
-              onClick={(e) => triggerHaptic(e.currentTarget, haptic.type as any)}
+              onClick={(e) => triggerHaptic(e.currentTarget, haptic.type)}
               whileHover={{ scale: 1.05 }}
-              whileTap={getHapticAnimation(haptic.type as any)}
+              whileTap={getHapticAnimation(haptic.type)}
               className={`${haptic.color} text-white p-6 rounded-xl shadow-md`}
             >
               <h3 className="text-lg font-semibold mb-1">{haptic.label}</h3>
@@ -772,8 +774,8 @@ export const CompleteDemo: Story = {
               whileTap={{ scale: 0.95 }}
               transition={getSpringConfig('snappy')}
               onClick={(e) => {
-                const hapticType = ['medium', 'success', 'warning', 'error'][i];
-                triggerHaptic(e.currentTarget, hapticType as any);
+                const hapticType = (['medium', 'success', 'warning', 'error'] as const)[i] as HapticType;
+                triggerHaptic(e.currentTarget, hapticType);
               }}
               className={`px-6 py-3 text-white rounded-lg shadow-md ${
                 ['bg-blue-600', 'bg-green-600', 'bg-yellow-600', 'bg-red-600'][i]

--- a/handoff/20250928/40_App/frontend-dashboard/src/lib/api-client.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/src/lib/api-client.ts
@@ -1,5 +1,11 @@
+declare global {
+  interface Window {
+    __VITE_API_BASE_URL__?: string;
+  }
+}
+
 const API_BASE_URL =
-  (typeof window !== 'undefined' && (window as any).__VITE_API_BASE_URL__) ||
+  (typeof window !== 'undefined' && window.__VITE_API_BASE_URL__) ||
   (typeof process !== 'undefined' ? process.env.VITE_API_BASE_URL : '') ||
   'https://morningai-backend-v2.onrender.com';
 

--- a/handoff/20250928/40_App/frontend-dashboard/src/lib/performance-monitor.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/src/lib/performance-monitor.ts
@@ -12,6 +12,12 @@ interface PerformanceMetric {
   metadata?: Record<string, any>
 }
 
+declare global {
+  interface Window {
+    __a11yPerformance?: AccessibilityPerformanceMonitor;
+  }
+}
+
 class AccessibilityPerformanceMonitor {
   private metrics: PerformanceMetric[] = []
   private readonly maxMetrics = 100
@@ -159,7 +165,7 @@ export const a11yPerformanceMonitor = new AccessibilityPerformanceMonitor()
 
 // Development-only: Add to window for debugging
 if (typeof window !== 'undefined' && process.env.NODE_ENV === 'development') {
-  (window as any).__a11yPerformance = a11yPerformanceMonitor
+  window.__a11yPerformance = a11yPerformanceMonitor
 }
 
 /**

--- a/handoff/20250928/40_App/frontend-dashboard/src/test/setup.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/src/test/setup.ts
@@ -24,19 +24,22 @@ Object.defineProperty(window, 'matchMedia', {
   }),
 })
 
-global.IntersectionObserver = class IntersectionObserver {
+global.IntersectionObserver = class IntersectionObserver implements IntersectionObserver {
+  readonly root: Element | null = null
+  readonly rootMargin: string = ''
+  readonly thresholds: ReadonlyArray<number> = []
   constructor() {}
   disconnect() {}
   observe() {}
-  takeRecords() {
+  takeRecords(): IntersectionObserverEntry[] {
     return []
   }
   unobserve() {}
-} as any
+}
 
-global.ResizeObserver = class ResizeObserver {
+global.ResizeObserver = class ResizeObserver implements ResizeObserver {
   constructor() {}
   disconnect() {}
   observe() {}
   unobserve() {}
-} as any
+}


### PR DESCRIPTION
## Summary
移除所有 17 個 `as any` 型別斷言，提升 TypeScript 型別安全性

解決 Issue #850，系統性地將所有生產環境元件中的 `as any` 替換為正確的型別定義。

## Changes

### 1. Framer Motion Variants 型別修正 (8 instances)
**檔案：BrandLoader.tsx, EmptyStateLibrary.tsx**
- 匯入 `Variants` 型別並正確標註所有動畫變體物件
- 影響：logoVariants, sparkleVariants, pulseVariants, emptyStateVariants, iconVariants, floatingVariants

### 2. React.cloneElement 型別修正 (2 instances)
**檔案：apple-control-center.tsx**
- 將 icon 元素正確標註為 `React.ReactElement<{ className?: string }>`
- 移除 props 物件上的 `as any` 斷言

### 3. Haptic Type 型別定義 (3 instances)
**檔案：spring-animation.stories.tsx**
- 新增 `HapticType` union type: `'light' | 'medium' | 'heavy' | 'success' | 'warning' | 'error' | 'selection'`
- 正確標註 haptics 陣列型別

### 4. Test Setup 全域型別 (2 instances)
**檔案：test/setup.ts**
- IntersectionObserver 和 ResizeObserver 實作完整介面
- 新增必要的 readonly 屬性（root, rootMargin, thresholds）

### 5. Window Interface 擴展 (2 instances)
**檔案：api-client.ts, performance-monitor.ts**
- 擴展 Window 介面以支援自訂屬性：`__VITE_API_BASE_URL__` 和 `__a11yPerformance`

## Testing
✅ TypeCheck: 0 errors  
✅ Tests: 434/434 passed  
✅ Lint: passed

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## Review Focus Areas

⚠️ **重點檢查項目：**

1. **React.cloneElement 型別斷言** (apple-control-center.tsx:195, 301)
   - 確認所有 icon 元件都支援 `className` prop
   - 雖然比 `as any` 更安全，但仍是型別斷言

2. **HapticType 定義位置** (spring-animation.stories.tsx:19)
   - 型別定義在 stories 檔案而非 library 檔案
   - 若 spring-animation.js 新增 haptic 類型，需同步更新此型別定義

3. **Test Mocks 實作** (test/setup.ts:27-45)
   - IntersectionObserver 和 ResizeObserver 為最小實作（no-op methods）
   - 確認現有測試不依賴這些 observer 的實際行為

## 相關資訊
- Link to Devin run: https://app.devin.ai/sessions/0557076376624320844aac626bb67503
- Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918
- Closes #850