### PR TITLE
fix: add CI typecheck and spring-animation type definitions (Issues #932, #933)

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -39,3 +39,8 @@ jobs:
       
       - name: Lint frontend with Turborepo
         run: pnpm run lint --filter=frontend-dashboard
+      
+      - name: Typecheck frontend-dashboard
+        run: |
+          cd handoff/20250928/40_App/frontend-dashboard
+          pnpm run typecheck

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-button.test.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/ui/apple-button.test.tsx
@@ -240,7 +240,7 @@ describe('AppleButton', () => {
 
     it('uses spring config for animations', () => {
       const mockConfig = {
-        type: 'spring',
+        type: 'spring' as const,
         stiffness: 300,
         damping: 30,
       };

--- a/handoff/20250928/40_App/frontend-dashboard/src/lib/spring-animation.d.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/src/lib/spring-animation.d.ts
@@ -1,0 +1,167 @@
+/**
+ * Spring Animation System - Type Definitions
+ * 
+ * Type definitions for the spring-animation library that align with Framer Motion types.
+ * This ensures type compatibility when using spring animations with Framer Motion components.
+ */
+
+import type { Variants, Transition, TargetAndTransition } from 'framer-motion';
+
+/**
+ * Haptic feedback types matching iOS patterns
+ */
+export type HapticType = 'light' | 'medium' | 'heavy' | 'success' | 'warning' | 'error' | 'selection';
+
+/**
+ * Spring preset names
+ */
+export type SpringPresetName = 'gentle' | 'default' | 'bouncy' | 'snappy' | 'smooth' | 'wobbly';
+
+/**
+ * Animation variant types
+ */
+export type AnimationVariantType = 
+  | 'fade' 
+  | 'scale' 
+  | 'pop' 
+  | 'bounce' 
+  | 'slideUp' 
+  | 'slideDown' 
+  | 'slideLeft' 
+  | 'slideRight' 
+  | 'expand' 
+  | 'rotate' 
+  | 'shake' 
+  | 'pulse';
+
+/**
+ * User context for contextual animations
+ */
+export interface UserContext {
+  isMobile?: boolean;
+  isLowPower?: boolean;
+  connectionSpeed?: 'slow' | 'medium' | 'fast';
+  userPreference?: 'default' | 'playful' | 'minimal';
+}
+
+/**
+ * Animation sequence step
+ */
+export interface AnimationStep {
+  duration?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * Animation performance metrics
+ */
+export interface AnimationMetrics {
+  totalAnimations: number;
+  activeAnimations: number;
+  droppedFrames: number;
+  averageFPS: number;
+}
+
+/**
+ * Haptic configuration
+ */
+export interface HapticConfig {
+  intensity: number;
+  duration: number;
+  pattern?: number[];
+}
+
+/**
+ * Spring presets object
+ */
+export const springPresets: Record<SpringPresetName, Transition>;
+
+/**
+ * Haptic types object
+ */
+export const hapticTypes: Record<HapticType, HapticConfig>;
+
+/**
+ * Get spring configuration based on preset name
+ * Returns Framer Motion Transition type
+ */
+export function getSpringConfig(preset?: SpringPresetName | string): Transition;
+
+/**
+ * Get spring-based animation variants for Framer Motion
+ * Returns Framer Motion Variants type
+ */
+export function getSpringVariants(type?: AnimationVariantType | string, preset?: SpringPresetName | string): Variants;
+
+/**
+ * Get haptic animation properties
+ * Returns Framer Motion TargetAndTransition type
+ */
+export function getHapticAnimation(type?: HapticType | string): TargetAndTransition;
+
+/**
+ * Trigger haptic feedback (visual simulation)
+ * Returns a promise that resolves when animation completes
+ */
+export function triggerHaptic(element: HTMLElement | null, type?: HapticType | string): Promise<void>;
+
+/**
+ * Get animation based on context (screen size, user preferences, etc.)
+ */
+export function getContextualAnimation(baseAnimation: AnimationVariantType | string, context?: UserContext): Variants;
+
+/**
+ * Detect user context
+ */
+export function getUserContext(): UserContext;
+
+/**
+ * Create a sequence of spring animations
+ */
+export function createAnimationSequence(steps: AnimationStep[], preset?: SpringPresetName | string): Transition;
+
+/**
+ * Get stagger configuration for children animations
+ */
+export function getStaggerConfig(preset?: SpringPresetName | string, staggerDelay?: number): {
+  staggerChildren: number;
+  delayChildren: number;
+  transition: Transition;
+};
+
+/**
+ * Track animation performance
+ * Returns a cleanup function to prevent memory leaks
+ */
+export function trackAnimation(animationId: string): () => void;
+
+/**
+ * Get animation performance metrics
+ */
+export function getAnimationMetrics(): AnimationMetrics;
+
+/**
+ * Reset animation metrics
+ */
+export function resetAnimationMetrics(): void;
+
+/**
+ * Default export with all functions
+ */
+declare const springAnimation: {
+  springPresets: typeof springPresets;
+  getSpringConfig: typeof getSpringConfig;
+  getSpringVariants: typeof getSpringVariants;
+  hapticTypes: typeof hapticTypes;
+  getHapticAnimation: typeof getHapticAnimation;
+  triggerHaptic: typeof triggerHaptic;
+  getContextualAnimation: typeof getContextualAnimation;
+  getUserContext: typeof getUserContext;
+  createAnimationSequence: typeof createAnimationSequence;
+  getStaggerConfig: typeof getStaggerConfig;
+  trackAnimation: typeof trackAnimation;
+  getAnimationMetrics: typeof getAnimationMetrics;
+  resetAnimationMetrics: typeof resetAnimationMetrics;
+};
+
+export default springAnimation;


### PR DESCRIPTION
## 概述

此 PR 解決 Issues #932 和 #933，為 frontend-dashboard 新增 CI typecheck 步驟並建立正確的 spring-animation 型別定義。

**背景**: PR #931 因導入 49 個 TypeScript 錯誤而被關閉，根本原因是 spring-animation.d.ts 與 Framer Motion 型別不相容。此 PR 採用正確方法重新實作。

## 變更內容

### 1. CI Workflow 新增 Typecheck (Issue #932)
- 在 `.github/workflows/frontend.yml` 新增 TypeScript typecheck 步驟
- 於 lint 後執行，確保所有 PR 都必須通過型別檢查
- 防止未來 TypeScript 錯誤通過 CI 未被發現

### 2. Spring Animation 型別定義 (Issue #933)
- 建立 `src/lib/spring-animation.d.ts` 提供完整型別定義
- **關鍵**: 直接使用 Framer Motion 的原生型別 (`Variants`, `Transition`, `TargetAndTransition`)
- 定義 7 種 haptic 類型、6 種 spring preset、12 種動畫變體類型
- 涵蓋所有 13 個匯出函式的型別簽章

### 3. 測試修正
- 修正 `apple-button.test.tsx` 中的 mock，使用 `as const` 確保型別字面量正確

## 驗證結果

✅ **本地驗證**:
- TypeScript typecheck: **0 errors**
- 測試: **434/434 passed**
- Lint: **0 errors**

## 審查重點

### 🔴 高優先級
1. **型別定義正確性**: 請檢查 `spring-animation.d.ts` 中的型別簽章是否準確反映 `spring-animation.js` 的實作
   - 特別注意返回型別是否與 Framer Motion 相容
   - 確認 `HapticType`, `SpringPresetName`, `AnimationVariantType` 的字面量與 JS 實作一致

2. **CI Typecheck 步驟**: 確認 CI 中的 typecheck 步驟能正常執行
   - 檢查是否會影響其他 workflow
   - 確認執行時間合理

### 🟡 中優先級
3. **測試覆蓋**: 確認其他測試檔案是否需要類似的 const assertion 修正
4. **型別使用**: 檢查 codebase 中使用 spring-animation 函式的地方是否都能正確型別推導

## 提醒
- [x] 不修改 OpenAPI/資料欄位（此 PR 不涉及）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯（此 PR 為工程類型，僅含型別定義與 CI 配置）

## 相關 Issues
- Fixes #932: Add TypeScript typecheck to CI pipeline for frontend-dashboard
- Fixes #933: Rework spring-animation.d.ts to align with framer-motion types
- Related: Closed PR #931 (因 49 個 TypeScript 錯誤被關閉)

---

**Link to Devin run**: https://app.devin.ai/sessions/59958bc5bfbb4e8c9116b88a1e4385bb

**Requested by**: Ryan Chen (@RC918)