### PR TITLE
refactor(spring-animation): tighten type parameters by removing | string (Issue #936)

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/ui/spring-animation.stories.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/ui/spring-animation.stories.tsx
@@ -12,11 +12,11 @@ import {
   createAnimationSequence,
   getStaggerConfig,
   getAnimationMetrics,
-  trackAnimation
+  trackAnimation,
+  type AnimationVariantType,
+  type HapticType
 } from '../../lib/spring-animation';
 import '../../styles/spring-animations.css';
-
-type HapticType = 'light' | 'medium' | 'heavy' | 'success' | 'warning' | 'error' | 'selection';
 
 const meta: Meta = {
   title: 'Design System/Spring Animation System',
@@ -109,9 +109,9 @@ export const SpringPresets: Story = {
 
 export const AnimationVariants: Story = {
   render: () => {
-    const [activeVariant, setActiveVariant] = useState<string | null>(null);
+    const [activeVariant, setActiveVariant] = useState<AnimationVariantType | null>(null);
     
-    const variants = [
+    const variants: Array<{ name: AnimationVariantType; label: string; description: string }> = [
       { name: 'fade', label: 'Fade', description: '淡入淡出' },
       { name: 'scale', label: 'Scale', description: '縮放' },
       { name: 'pop', label: 'Pop', description: '彈出' },

--- a/handoff/20250928/40_App/frontend-dashboard/src/lib/spring-animation.d.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/src/lib/spring-animation.d.ts
@@ -85,30 +85,30 @@ export const hapticTypes: Record<HapticType, HapticConfig>;
  * Get spring configuration based on preset name
  * Returns Framer Motion Transition type
  */
-export function getSpringConfig(preset?: SpringPresetName | string): Transition;
+export function getSpringConfig(preset?: SpringPresetName): Transition;
 
 /**
  * Get spring-based animation variants for Framer Motion
  * Returns Framer Motion Variants type
  */
-export function getSpringVariants(type?: AnimationVariantType | string, preset?: SpringPresetName | string): Variants;
+export function getSpringVariants(type?: AnimationVariantType, preset?: SpringPresetName): Variants;
 
 /**
  * Get haptic animation properties
  * Returns Framer Motion TargetAndTransition type
  */
-export function getHapticAnimation(type?: HapticType | string): TargetAndTransition;
+export function getHapticAnimation(type?: HapticType): TargetAndTransition;
 
 /**
  * Trigger haptic feedback (visual simulation)
  * Returns a promise that resolves when animation completes
  */
-export function triggerHaptic(element: HTMLElement | null, type?: HapticType | string): Promise<void>;
+export function triggerHaptic(element: HTMLElement | null, type?: HapticType): Promise<void>;
 
 /**
  * Get animation based on context (screen size, user preferences, etc.)
  */
-export function getContextualAnimation(baseAnimation: AnimationVariantType | string, context?: UserContext): Variants;
+export function getContextualAnimation(baseAnimation: AnimationVariantType, context?: UserContext): Variants;
 
 /**
  * Detect user context
@@ -118,12 +118,12 @@ export function getUserContext(): UserContext;
 /**
  * Create a sequence of spring animations
  */
-export function createAnimationSequence(steps: AnimationStep[], preset?: SpringPresetName | string): Transition;
+export function createAnimationSequence(steps: AnimationStep[], preset?: SpringPresetName): Transition;
 
 /**
  * Get stagger configuration for children animations
  */
-export function getStaggerConfig(preset?: SpringPresetName | string, staggerDelay?: number): {
+export function getStaggerConfig(preset?: SpringPresetName, staggerDelay?: number): {
   staggerChildren: number;
   delayChildren: number;
   transition: Transition;


### PR DESCRIPTION
## 概述

收緊 spring-animation 型別參數，移除 `| string` 聯合型別，只允許已知字面量，提升型別安全性。

## 變更內容

### 1. spring-animation.d.ts - 移除 `| string` 後備選項

**6 個函式的型別簽章收緊：**

```typescript
// 之前（寬鬆）
export function getSpringConfig(preset?: SpringPresetName | string): Transition;
export function getSpringVariants(type?: AnimationVariantType | string, preset?: SpringPresetName | string): Variants;
export function getHapticAnimation(type?: HapticType | string): TargetAndTransition;
export function triggerHaptic(element: HTMLElement | null, type?: HapticType | string): Promise<void>;
export function getContextualAnimation(baseAnimation: AnimationVariantType | string, context?: UserContext): Variants;
export function createAnimationSequence(steps: AnimationStep[], preset?: SpringPresetName | string): Transition;
export function getStaggerConfig(preset?: SpringPresetName | string, staggerDelay?: number): {...};

// 之後（嚴格）
export function getSpringConfig(preset?: SpringPresetName): Transition;
export function getSpringVariants(type?: AnimationVariantType, preset?: SpringPresetName): Variants;
export function getHapticAnimation(type?: HapticType): TargetAndTransition;
export function triggerHaptic(element: HTMLElement | null, type?: HapticType): Promise<void>;
export function getContextualAnimation(baseAnimation: AnimationVariantType, context?: UserContext): Variants;
export function createAnimationSequence(steps: AnimationStep[], preset?: SpringPresetName): Transition;
export function getStaggerConfig(preset?: SpringPresetName, staggerDelay?: number): {...};
```

### 2. spring-animation.stories.tsx - 修復型別錯誤

**變更 1：移除本地型別定義，改用匯入**
```typescript
// 之前
type HapticType = 'light' | 'medium' | 'heavy' | 'success' | 'warning' | 'error' | 'selection';

// 之後
import {
  ...
  type AnimationVariantType,
  type HapticType
} from '../../lib/spring-animation';
```

**變更 2：使用嚴格型別字面量**
```typescript
// 之前
const [activeVariant, setActiveVariant] = useState<string | null>(null);
const variants = [...]

// 之後
const [activeVariant, setActiveVariant] = useState<AnimationVariantType | null>(null);
const variants: Array<{ name: AnimationVariantType; label: string; description: string }> = [...]
```

## 技術細節

**JavaScript 層的 Fallback 已存在：**
```javascript
// spring-animation.js 中已有容錯邏輯
return springPresets[preset] || springPresets.default;
return variants[type] || variants.fade;
return hapticTypes[type] || hapticTypes.light;
```

**型別安全保證：**
- TypeScript 使用者獲得嚴格的型別檢查和 IDE 自動完成
- JavaScript 使用者不受影響，執行時仍有 fallback
- 拼寫錯誤會在編譯時被立即發現

**Breaking Change：**
- ⚠️ 對 TypeScript 使用者是 breaking change
- ✅ 對 JavaScript 使用者無影響

## 預期效益

### 1. 更好的 IDE 支援
```typescript
// 之前：IDE 無法提供有用的自動完成
getSpringConfig('any-string-here'); // ✅ 型別檢查通過（錯誤）

// 之後：IDE 提供準確的自動完成列表
getSpringConfig('gentle' | 'default' | 'bouncy' | 'snappy' | 'smooth' | 'wobbly');
getSpringConfig('typo'); // ❌ 型別錯誤（正確）
```

### 2. 編譯時錯誤檢測
拼寫錯誤會被立即發現，防止執行時 bug

### 3. 更安全的重構
當新增或移除 preset 時，TypeScript 會自動標記所有需要更新的地方

## 驗證結果

```bash
# TypeScript 檢查
pnpm typecheck
✅ 0 錯誤

# 測試
pnpm test
✅ 434/434 測試通過

# 受影響的檔案
- spring-animation.d.ts（6 個函式型別簽章）
- spring-animation.stories.tsx（1 個使用點）
```

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）✅ 無 API 變更
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯 ✅ 純型別重構

## 人工審查檢查清單

⚠️ **重點審查項目：**

1. **Breaking Change 影響範圍**
   - [ ] 確認這是否為可接受的 breaking change
   - [ ] 驗證 typecheck 通過意味著所有程式碼都已更新
   - [ ] 考慮是否需要在 CHANGELOG 中記錄此變更

2. **型別簽章正確性**
   - [ ] 驗證所有 6 個函式的 `| string` 都已移除
   - [ ] 確認參數型別現在只接受字面量（SpringPresetName, AnimationVariantType, HapticType）
   - [ ] 檢查是否有遺漏的函式

3. **JavaScript Fallback 邏輯**
   - [ ] 確認 spring-animation.js 中有適當的 fallback（`|| default` 模式）
   - [ ] 驗證執行時行為對 JavaScript 使用者無影響

4. **Storybook 檔案修復**
   - [ ] 確認 spring-animation.stories.tsx 的型別修復正確
   - [ ] 驗證從本地型別定義改為匯入的變更合理
   - [ ] 檢查 `activeVariant` 和 `variants` 的型別正確

5. **與 PR #941 的關係**
   - [ ] 注意 PR #941（型別測試）尚未合併
   - [ ] 考慮是否應該先合併 #941 再合併此 PR
   - [ ] 或者考慮將兩個 PR 一起合併

## 相關資訊

- **Issue**: #936
- **相關 Issue**: #937（型別測試，PR #941）
- **路線圖**: Phase 1 - TypeScript 型別改進
- **Devin 執行**: https://app.devin.ai/sessions/0557076376624320844aac626bb67503
- **請求者**: Ryan Chen (ryan2939z@gmail.com) @RC918