### PR TITLE
Fix Issue #949: Security - Whitelist substring matching vulnerability

### DIFF
--- a/ai_governance_module.py
+++ b/ai_governance_module.py
@@ -12,6 +12,7 @@ from typing import Dict, List, Optional, Any, Union
 from dataclasses import dataclass, asdict
 from enum import Enum
 from flask import Flask, request, jsonify, render_template_string
+from urllib.parse import urlparse
 import jwt
 import secrets
 
@@ -260,10 +261,38 @@ class GovernanceRuleManager:
         return any(domain in request_url for domain in domains)
     
     def _check_whitelist(self, config: Dict[str, Any], request_data: Dict[str, Any]) -> bool:
-        """檢查白名單"""
+        """檢查白名單 - 使用正確的域名匹配邏輯防止子字串攻擊
+        
+        Security Fix for Issue #949:
+        - 使用正確的域名匹配而非子字串匹配
+        - 允許精確匹配 (e.g., trusted.com)
+        - 允許子域名 (e.g., api.trusted.com, sub.api.trusted.com)
+        - 阻擋子字串攻擊 (e.g., untrusted.com, trusted.com.evil.com)
+        """
         domains = config.get('domains', [])
         request_url = request_data.get('url', '')
-        return any(domain in request_url for domain in domains)
+        
+        try:
+            parsed_url = urlparse(request_url)
+            request_domain = parsed_url.netloc.lower()
+            
+            if not request_domain:
+                return False
+            
+            for allowed_domain in domains:
+                allowed_domain = allowed_domain.lower()
+                
+                if request_domain == allowed_domain:
+                    return True
+                
+                if request_domain.endswith('.' + allowed_domain):
+                    return True
+            
+            return False
+            
+        except Exception as e:
+            logger.error(f"Error parsing URL in whitelist check: {e}")
+            return False
     
     def _apply_content_filter(self, config: Dict[str, Any], request_data: Dict[str, Any]) -> Dict[str, Any]:
         """應用內容過濾"""

--- a/tests/test_ai_governance_module.py
+++ b/tests/test_ai_governance_module.py
@@ -449,7 +449,6 @@ class TestGovernanceRuleManager:
         assert result['allowed'] is False
         assert "Allow Trusted" in result['blocked_by']
     
-    @pytest.mark.xfail(strict=True, reason="Tracking: #949 - Security: Whitelist substring matching allows untrusted domains")
     def test_whitelist_substring_attack_prevention(self):
         """Test that whitelist prevents substring matching attacks (SECURITY TEST)
         


### PR DESCRIPTION
## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 工程 PR：僅含安全修復、邏輯修正

## 概要

修復 Issue #949 的高優先級安全漏洞：白名單子字串匹配允許未授權域名繞過安全檢查。

**連結**: [Devin Session](https://app.devin.ai/sessions/8efae427f96e4ae9bc1c3a05768384aa) | 請求者: Ryan Chen (@RC918)

## 問題描述

**安全漏洞**: 原本的 `_check_whitelist()` 使用簡單的子字串匹配 (`domain in request_url`)，導致攻擊者可以通過註冊包含白名單域名作為子字串的惡意域名來繞過安全檢查。

**攻擊範例**:
- 如果白名單包含 `trusted.com`
- 攻擊者可以註冊 `untrusted.com` 或 `trusted.com.evil.com` 來繞過檢查
- 原因：`"trusted.com" in "untrusted.com"` 返回 `True`

## 解決方案

實現正確的域名匹配邏輯：

1. **添加依賴**: `from urllib.parse import urlparse` 用於 URL 解析
2. **域名提取**: 使用 `urlparse(request_url).netloc` 提取域名
3. **匹配邏輯**:
   - ✅ 精確匹配：`request_domain == allowed_domain`
   - ✅ 子域名匹配：`request_domain.endswith('.' + allowed_domain)`
   - ❌ 阻擋子字串攻擊：不匹配 `untrusted.com` 或 `trusted.com.evil.com`
4. **錯誤處理**: 捕獲 URL 解析錯誤並返回 `False`
5. **大小寫處理**: 使用 `.lower()` 進行不區分大小寫比較

## 測試結果

```bash
# 移除 xfail marker 後測試通過
test_whitelist_substring_attack_prevention PASSED

# 全部測試結果
43 passed, 1 xfailed (Issue #950)
```

**安全測試涵蓋 5 個場景**:
1. ✅ 精確匹配 (`trusted.com` → 允許)
2. ✅ 子域名 (`api.trusted.com` → 允許)
3. ✅ 子字串攻擊 (`untrusted.com` → 阻擋)
4. ✅ 前綴攻擊 (`trusted.com.evil.com` → 阻擋)
5. ✅ 後綴攻擊 (`not-trusted.com` → 阻擋)

## 變更內容

**ai_governance_module.py** (lines 263-295):
- 替換 1 行簡單子字串檢查為 33 行安全的域名匹配邏輯
- 添加 URL 解析、域名提取、錯誤處理

**tests/test_ai_governance_module.py** (line 452):
- 移除 `@pytest.mark.xfail` marker（bug 已修復）

## 審查重點

### 🔴 Critical (必須仔細審查)

1. **域名提取邏輯** (line 276-277)
   ```python
   parsed_url = urlparse(request_url)
   request_domain = parsed_url.netloc.lower()
   ```
   - ⚠️ `urlparse().netloc` 會包含 port（如 `trusted.com:8080`）
   - ⚠️ 需確認這是否符合預期行為
   - ⚠️ 是否需要處理 userinfo（如 `user:pass@trusted.com`）
   - ⚠️ IP 地址如何處理？

2. **子域名匹配邏輯** (line 288-289)
   ```python
   if request_domain.endswith('.' + allowed_domain):
       return True
   ```
   - ✅ 正確：`api.trusted.com` 匹配 `trusted.com`（以 `.trusted.com` 結尾）
   - ✅ 正確：`untrusted.com` 不匹配 `trusted.com`（不以 `.trusted.com` 結尾）
   - ⚠️ 邊界情況：如果 `request_domain` 是 `"trusted.com."` (trailing dot) 會如何？
   - ⚠️ 國際化域名 (IDN) 是否正確處理？

3. **錯誤處理** (line 293-295)
   ```python
   except Exception as e:
       logger.error(f"Error parsing URL in whitelist check: {e}")
       return False
   ```
   - ⚠️ 返回 `False` 意味著阻擋請求
   - ⚠️ 這是否是正確的 fail-safe 行為？
   - ⚠️ 是否應該更具體地捕獲異常（如 `ValueError`）？

### 🟡 Important (建議審查)

4. **測試覆蓋度** (tests/test_ai_governance_module.py:452-495)
   - 5 個測試場景是否涵蓋所有攻擊向量？
   - 是否需要測試：
     - 帶 port 的 URL (`https://trusted.com:8080/api`)
     - IP 地址 (`https://192.168.1.1/api`)
     - 空 URL / 格式錯誤的 URL
     - 國際化域名
     - Trailing dots

5. **向後兼容性**
   - 新邏輯比舊的子字串匹配更嚴格
   - 如果現有白名單依賴子字串匹配，會被破壞（但這是預期行為）
   - ⚠️ 需要文檔說明行為變更

### 🟢 Low Risk (快速檢查)

6. **Blacklist 未修復**
   - `_check_blacklist()` (line 260) 仍使用子字串匹配
   - 不在此 PR 範圍內，但可能有類似問題
   - 建議創建 follow-up issue

## 後續行動

- [ ] 審查並合併此 PR
- [ ] 考慮是否需要修復 `_check_blacklist()` 的子字串匹配問題
- [ ] 繼續修復 Issue #950 (Enum serialization bug)

---

**Closes**: #949  
**Session**: https://app.devin.ai/sessions/8efae427f96e4ae9bc1c3a05768384aa  
**Requester**: Ryan Chen (ryan2939z@gmail.com) @RC918