### PR TITLE
Fix Issue #950: Bug - Enum serialization in create_rule endpoint

### DIFF
--- a/ai_governance_module.py
+++ b/ai_governance_module.py
@@ -299,6 +299,13 @@ class AIGovernanceModule:
         
         logger.info("AI Governance Module initialized")
     
+    def _serialize_rule(self, rule: GovernanceRule) -> Dict[str, Any]:
+        rule_dict = asdict(rule)
+        rule_dict['rule_type'] = rule.rule_type.value
+        rule_dict['created_at'] = rule.created_at.isoformat() if rule.created_at else None
+        rule_dict['updated_at'] = rule.updated_at.isoformat() if rule.updated_at else None
+        return rule_dict
+    
     def _setup_routes(self):
         """設置路由"""
         
@@ -334,7 +341,7 @@ class AIGovernanceModule:
                 rules = self.rule_manager.get_tenant_rules(user.tenant_id)
             
             return jsonify({
-                'rules': [asdict(rule) for rule in rules]
+                'rules': [self._serialize_rule(rule) for rule in rules]
             })
         
         @self.app.route('/governance/rules', methods=['POST'])
@@ -367,7 +374,7 @@ class AIGovernanceModule:
             
             return jsonify({
                 'success': True,
-                'rule': asdict(rule)
+                'rule': self._serialize_rule(rule)
             })
         
         @self.app.route('/governance/rules/<rule_id>', methods=['PUT'])

--- a/tests/test_ai_governance_module.py
+++ b/tests/test_ai_governance_module.py
@@ -643,7 +643,6 @@ class TestAIGovernanceModule:
                               json={'name': 'Test', 'rule_type': 'blacklist'})
         assert response.status_code == 401
     
-    @pytest.mark.xfail(strict=True, reason="Tracking: #950 - Enum serialization in create_rule returns 500")
     def test_create_rule_success(self):
         """Test create rule endpoint with valid data
         


### PR DESCRIPTION
## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 工程 PR：僅含 Bug 修復、測試更新

## 概要

修復 Issue #950 的 Enum 序列化 bug：`create_rule` 和 `get_rules` 端點返回 500 錯誤，原因是 Flask 的 `jsonify()` 無法序列化 Python Enum 物件。

**連結**: [Devin Session](https://app.devin.ai/sessions/8efae427f96e4ae9bc1c3a05768384aa) | 請求者: Ryan Chen (@RC918)

## 問題描述

**Bug**: `POST /governance/rules` 和 `GET /governance/rules` 端點在返回包含 `GovernanceRuleType` Enum 的規則時會拋出 500 錯誤。

**根本原因**: 
- 使用 `asdict(rule)` 將 dataclass 轉換為字典時，Enum 物件保持原樣
- Flask 的 `jsonify()` 無法序列化 Enum 物件，導致 TypeError

## 解決方案

新增 `_serialize_rule()` 輔助方法，正確處理 Enum 和 datetime 序列化：

```python
def _serialize_rule(self, rule: GovernanceRule) -> Dict[str, Any]:
    rule_dict = asdict(rule)
    rule_dict['rule_type'] = rule.rule_type.value  # Enum → string
    rule_dict['created_at'] = rule.created_at.isoformat() if rule.created_at else None
    rule_dict['updated_at'] = rule.updated_at.isoformat() if rule.updated_at else None
    return rule_dict
```

**變更內容**:
1. **ai_governance_module.py** (lines 302-307): 新增 `_serialize_rule()` 方法
2. **ai_governance_module.py** (line 344): `get_rules` 端點使用 `_serialize_rule()`
3. **ai_governance_module.py** (line 377): `create_rule` 端點使用 `_serialize_rule()`
4. **tests/test_ai_governance_module.py** (line 646): 移除 `@pytest.mark.xfail` 標記

## 測試結果

```bash
43 passed, 1 xfailed (Issue #949 in PR #952)
```

- ✅ `test_create_rule_success` 現在通過（之前預期失敗）
- ✅ 無回歸錯誤
- ✅ Enum 正確序列化為字串值

## 審查重點

### 🔴 Critical (必須仔細審查)

1. **API 契約變更** (lines 304-306)
   - ⚠️ datetime 現在序列化為 ISO 格式字串 (`2024-01-01T12:00:00`)
   - 確認這不會破壞現有的 API 消費者
   - 檢查是否需要更新 API 文檔

2. **`_serialize_rule()` 正確性** (lines 302-307)
   - 驗證 Enum 轉換邏輯：`rule.rule_type.value`
   - 檢查 None 處理：datetime 欄位可能為 None？
   - 確認所有 Enum 欄位都已處理（目前只有 `rule_type`）

### 🟡 Important (建議審查)

3. **測試覆蓋度不足**
   - `get_rules` 端點也使用了 `_serialize_rule()`，但沒有專門測試 Enum 序列化
   - 考慮新增測試驗證 `get_rules` 返回的 `rule_type` 是字串而非 Enum

4. **相似問題排查**
   - 檢查專案中是否有其他地方使用 `asdict()` + `jsonify()` 組合
   - 其他 Enum 欄位是否有相同問題？

### 🟢 Low Risk (快速檢查)

5. **xfail 標記移除** (line 646)
   - 確認測試現在確實通過
   - Bug 已修復，移除 xfail 是正確的

## 後續行動

- ✅ Issue #950 已修復
- ⏳ 等待 CI 通過
- ⏳ 考慮新增 `get_rules` 端點的 Enum 序列化測試

---

**Session**: https://app.devin.ai/sessions/8efae427f96e4ae9bc1c3a05768384aa  
**Requester**: Ryan Chen (ryan2939z@gmail.com) @RC918