### PR TITLE
Fix Issue #962: Add production guards for Metrics Dashboard mock data

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/components/MetricsDashboard.tsx
+++ b/handoff/20250928/40_App/owner-console/src/components/MetricsDashboard.tsx
@@ -199,10 +199,58 @@ export const MetricsDashboard: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [autoRefresh, setAutoRefresh] = useState(true);
+  const [usingMockData, setUsingMockData] = useState(false);
 
   useEffect(() => {
     const fetchDashboardData = async () => {
       try {
+        const isProduction = process.env.NODE_ENV === 'production';
+        const apiBaseUrl = process.env.REACT_APP_API_BASE_URL || process.env.VITE_API_BASE_URL;
+        
+        if (isProduction && !apiBaseUrl) {
+          throw new Error(
+            'CRITICAL: Metrics Dashboard cannot use mock data in production. ' +
+            'REACT_APP_API_BASE_URL or VITE_API_BASE_URL must be configured.'
+          );
+        }
+
+        if (apiBaseUrl) {
+          try {
+            const response = await fetch(`${apiBaseUrl}/api/v1/metrics/dashboard`, {
+              headers: {
+                'Authorization': `Bearer ${localStorage.getItem('token') || ''}`,
+                'Content-Type': 'application/json'
+              }
+            });
+
+            if (response.ok) {
+              const data = await response.json();
+              setDashboardData(data);
+              setUsingMockData(false);
+              setLoading(false);
+              return;
+            } else if (response.status === 404) {
+              if (isProduction) {
+                throw new Error(
+                  'CRITICAL: Metrics Dashboard API endpoint not implemented. ' +
+                  'Cannot display metrics in production without real data.'
+                );
+              }
+            } else {
+              throw new Error(`API error: ${response.status} ${response.statusText}`);
+            }
+          } catch (apiError) {
+            if (isProduction) {
+              throw apiError;
+            }
+            console.warn('Failed to fetch real metrics data, using mock data:', apiError);
+          }
+        }
+
+        console.warn(
+          '⚠️ DEVELOPMENT MODE: Using mock data for Metrics Dashboard. ' +
+          'This data is NOT real and should not be used for production decisions.'
+        );
         
         const mockData: DashboardData = {
           system_health: {
@@ -254,6 +302,7 @@ export const MetricsDashboard: React.FC = () => {
         };
 
         setDashboardData(mockData);
+        setUsingMockData(true);
         setLoading(false);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch dashboard data');
@@ -306,6 +355,19 @@ export const MetricsDashboard: React.FC = () => {
 
   return (
     <div className="space-y-6 p-6">
+      {/* Mock Data Warning */}
+      {usingMockData && (
+        <Alert variant="default" className="border-yellow-500 bg-yellow-50">
+          <AlertCircle className="h-4 w-4 text-yellow-600" />
+          <AlertTitle className="text-yellow-800">Development Mode - Mock Data</AlertTitle>
+          <AlertDescription className="text-yellow-700">
+            This dashboard is displaying simulated data for development purposes only.
+            Real metrics will be available once the monitoring backend is deployed.
+            <strong className="block mt-1">Do not use this data for production decisions.</strong>
+          </AlertDescription>
+        </Alert>
+      )}
+
       {/* Header */}
       <div className="flex items-center justify-between">
         <div>


### PR DESCRIPTION
## Summary

Fixes Issue #962 (BLOCKER - IMMEDIATE): Adds production guards to prevent Metrics Dashboard from displaying mock data in production.

## 問題 / Problem

PR #953 merged with hardcoded mock data in the Metrics Dashboard component. In production, this would display fake metrics instead of actual system state, which is a critical issue that could lead to wrong operational decisions.

## 解決方案 / Solution

**Production Safety Guards:**
- ✅ Detects environment (`NODE_ENV === 'production'`)
- ✅ Requires `REACT_APP_API_BASE_URL` or `VITE_API_BASE_URL` in production
- ✅ Throws clear error if mock data would be used in production
- ✅ Throws error if API endpoint (404) not implemented in production

**Development Experience:**
- ✅ Attempts to fetch real data from API first: `GET /api/v1/metrics/dashboard`
- ✅ Falls back to mock data in development/staging only
- ✅ Displays prominent yellow warning banner when using mock data
- ✅ Logs console warnings in development mode

## Changes

**Modified:**
- `handoff/20250928/40_App/owner-console/src/components/MetricsDashboard.tsx` (+62 lines)
  - Added environment detection logic
  - Added API fetch with proper error handling
  - Added `usingMockData` state for UI warning
  - Added visual warning banner component

## 測試 / Testing

⚠️ **Manual testing required** - I couldn't run the owner-console locally to verify:
- Production mode blocks mock data correctly
- Development mode shows warning banner
- API call works with proper authentication
- Error messages are clear and actionable

## 重點審查 / Review Focus

🔴 **Critical items:**
1. **API endpoint path** - Is `/api/v1/metrics/dashboard` the correct path? (This endpoint doesn't exist yet per PR #953)
2. **Environment variable names** - Verify `REACT_APP_API_BASE_URL` / `VITE_API_BASE_URL` match project conventions
3. **Auth pattern** - Is `localStorage.getItem('token')` the correct way to get auth token?
4. **Production behavior** - Confirm it's desired to error (rather than degrade gracefully) when API is unavailable in production

🟡 **Consider:**
- Should we add tests for the production guard logic?
- Should we validate the API response structure matches `DashboardData`?
- Is there a feature flag that should control this behavior?

## 提醒 / Checklist
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC） - No API changes
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯 - This is UI + logic PR (mixed)

---

**Link to Devin run:** https://app.devin.ai/sessions/8efae427f96e4ae9bc1c3a05768384aa  
**Requested by:** Ryan Chen (@RC918, ryan2939z@gmail.com)