### PR TITLE
Fix Issue #963: Extend Agent Registry test coverage from 68% to 96%

### DIFF
--- a/handoff/20250928/40_App/api-backend/tests/test_agent_registry.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_agent_registry.py
@@ -440,3 +440,376 @@ def test_list_agents_without_auth(client):
     response = client.get('/api/v1/agents')
     
     assert response.status_code == 401
+
+
+def test_list_agents_invalid_page(client, admin_headers):
+    """Test GET /api/v1/agents - Invalid page parameter (page < 1)"""
+    response = client.get('/api/v1/agents?page=0', headers=admin_headers)
+    
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert data['error']['code'] == 'invalid_parameter'
+    assert 'page must be >= 1' in data['error']['message']
+
+
+def test_list_agents_invalid_page_size_too_small(client, admin_headers):
+    """Test GET /api/v1/agents - Invalid page_size (< 1)"""
+    response = client.get('/api/v1/agents?page_size=0', headers=admin_headers)
+    
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert data['error']['code'] == 'invalid_parameter'
+    assert 'page_size must be between 1 and 100' in data['error']['message']
+
+
+def test_list_agents_invalid_page_size_too_large(client, admin_headers):
+    """Test GET /api/v1/agents - Invalid page_size (> 100)"""
+    response = client.get('/api/v1/agents?page_size=101', headers=admin_headers)
+    
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert data['error']['code'] == 'invalid_parameter'
+    assert 'page_size must be between 1 and 100' in data['error']['message']
+
+
+def test_list_agents_invalid_agent_type(client, admin_headers):
+    """Test GET /api/v1/agents - Invalid agent_type filter"""
+    response = client.get('/api/v1/agents?agent_type=invalid_type', headers=admin_headers)
+    
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert data['error']['code'] == 'invalid_parameter'
+    assert 'Invalid agent_type' in data['error']['message']
+
+
+def test_list_agents_invalid_status(client, admin_headers):
+    """Test GET /api/v1/agents - Invalid status filter"""
+    response = client.get('/api/v1/agents?status=invalid_status', headers=admin_headers)
+    
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert data['error']['code'] == 'invalid_parameter'
+    assert 'Invalid status' in data['error']['message']
+
+
+def test_list_agents_invalid_permission_level(client, admin_headers):
+    """Test GET /api/v1/agents - Invalid permission_level filter"""
+    response = client.get('/api/v1/agents?permission_level=invalid_level', headers=admin_headers)
+    
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert data['error']['code'] == 'invalid_parameter'
+    assert 'Invalid permission_level' in data['error']['message']
+
+
+def test_list_agents_exception_handling(client, admin_headers):
+    """Test GET /api/v1/agents - Exception handling with Sentry"""
+    with patch('src.routes.agent_registry.AgentDB') as mock_agent_db:
+        mock_agent_db.query.count.side_effect = Exception("Database error")
+        
+        response = client.get('/api/v1/agents', headers=admin_headers)
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+        assert data['error']['code'] == 'internal_error'
+
+
+def test_register_agent_exception_handling(client, admin_headers, sample_agent_data):
+    """Test POST /api/v1/agents - Exception handling"""
+    with patch('src.routes.agent_registry.db.session.commit') as mock_commit:
+        mock_commit.side_effect = Exception("Database error")
+        
+        response = client.post(
+            '/api/v1/agents',
+            data=json.dumps(sample_agent_data),
+            headers=admin_headers
+        )
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+def test_get_agent_exception_handling(client, admin_headers):
+    """Test GET /api/v1/agents/{agent_id} - Exception handling"""
+    with patch('src.routes.agent_registry.AgentDB') as mock_agent_db:
+        mock_agent_db.query.get.side_effect = Exception("Database error")
+        
+        response = client.get(f'/api/v1/agents/{uuid.uuid4()}', headers=admin_headers)
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+def test_update_agent_not_found(client, admin_headers):
+    """Test PATCH /api/v1/agents/{agent_id} - Agent not found"""
+    response = client.patch(
+        f'/api/v1/agents/{uuid.uuid4()}',
+        data=json.dumps({"status": "active"}),
+        headers=admin_headers
+    )
+    
+    assert response.status_code == 404
+    data = json.loads(response.data)
+    assert 'error' in data
+
+
+def test_update_agent_exception_handling(client, admin_headers, sample_agent_data):
+    """Test PATCH /api/v1/agents/{agent_id} - Exception handling"""
+    create_response = client.post(
+        '/api/v1/agents',
+        data=json.dumps(sample_agent_data),
+        headers=admin_headers
+    )
+    agent_id = json.loads(create_response.data)['agent_id']
+    
+    with patch('src.routes.agent_registry.db.session.commit') as mock_commit:
+        mock_commit.side_effect = Exception("Database error")
+        
+        response = client.patch(
+            f'/api/v1/agents/{agent_id}',
+            data=json.dumps({"status": "active"}),
+            headers=admin_headers
+        )
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+def test_unregister_agent_not_found(client, admin_headers):
+    """Test DELETE /api/v1/agents/{agent_id} - Agent not found"""
+    response = client.delete(f'/api/v1/agents/{uuid.uuid4()}', headers=admin_headers)
+    
+    assert response.status_code == 404
+    data = json.loads(response.data)
+    assert 'error' in data
+
+
+def test_unregister_agent_exception_handling(client, admin_headers, sample_agent_data):
+    """Test DELETE /api/v1/agents/{agent_id} - Exception handling"""
+    create_response = client.post(
+        '/api/v1/agents',
+        data=json.dumps(sample_agent_data),
+        headers=admin_headers
+    )
+    agent_id = json.loads(create_response.data)['agent_id']
+    
+    with patch('src.routes.agent_registry.db.session.commit') as mock_commit:
+        mock_commit.side_effect = Exception("Database error")
+        
+        response = client.delete(f'/api/v1/agents/{agent_id}', headers=admin_headers)
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+def test_get_agent_health_not_found(client, admin_headers):
+    """Test GET /api/v1/agents/{agent_id}/health - Agent not found"""
+    response = client.get(f'/api/v1/agents/{uuid.uuid4()}/health', headers=admin_headers)
+    
+    assert response.status_code == 404
+    data = json.loads(response.data)
+    assert 'error' in data
+
+
+def test_get_agent_health_exception_handling(client, admin_headers):
+    """Test GET /api/v1/agents/{agent_id}/health - Exception handling"""
+    with patch('src.routes.agent_registry.AgentDB') as mock_agent_db:
+        mock_agent_db.query.get.side_effect = Exception("Database error")
+        
+        response = client.get(f'/api/v1/agents/{uuid.uuid4()}/health', headers=admin_headers)
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+def test_report_agent_health_not_found(client, admin_headers):
+    """Test POST /api/v1/agents/{agent_id}/health - Agent not found"""
+    health_data = {"status": "active", "metrics": {"cpu_usage": 45.2}}
+    response = client.post(
+        f'/api/v1/agents/{uuid.uuid4()}/health',
+        data=json.dumps(health_data),
+        headers=admin_headers
+    )
+    
+    assert response.status_code == 404
+    data = json.loads(response.data)
+    assert 'error' in data
+
+
+def test_report_agent_health_exception_handling(client, admin_headers, sample_agent_data):
+    """Test POST /api/v1/agents/{agent_id}/health - Exception handling"""
+    create_response = client.post(
+        '/api/v1/agents',
+        data=json.dumps(sample_agent_data),
+        headers=admin_headers
+    )
+    agent_id = json.loads(create_response.data)['agent_id']
+    
+    with patch('src.routes.agent_registry.db.session.commit') as mock_commit:
+        mock_commit.side_effect = Exception("Database error")
+        
+        health_data = {"status": "active", "metrics": {"cpu_usage": 45.2}}
+        response = client.post(
+            f'/api/v1/agents/{agent_id}/health',
+            data=json.dumps(health_data),
+            headers=admin_headers
+        )
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+def test_list_tasks_invalid_page(client, admin_headers):
+    """Test GET /api/v1/tasks - Invalid page parameter"""
+    response = client.get('/api/v1/tasks?page=0', headers=admin_headers)
+    
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert 'page must be >= 1' in data['error']['message']
+
+
+def test_list_tasks_invalid_page_size(client, admin_headers):
+    """Test GET /api/v1/tasks - Invalid page_size parameter"""
+    response = client.get('/api/v1/tasks?page_size=101', headers=admin_headers)
+    
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert 'page_size must be between 1 and 100' in data['error']['message']
+
+
+def test_list_tasks_invalid_status(client, admin_headers):
+    """Test GET /api/v1/tasks - Invalid status filter"""
+    response = client.get('/api/v1/tasks?status=invalid_status', headers=admin_headers)
+    
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert 'error' in data
+    assert 'Invalid status' in data['error']['message']
+
+
+def test_list_tasks_exception_handling(client, admin_headers):
+    """Test GET /api/v1/tasks - Exception handling"""
+    with patch('src.routes.agent_registry.TaskDB') as mock_task_db:
+        mock_task_db.query.count.side_effect = Exception("Database error")
+        
+        response = client.get('/api/v1/tasks', headers=admin_headers)
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+def test_create_task_exception_handling(client, admin_headers, sample_task_data):
+    """Test POST /api/v1/tasks - Exception handling"""
+    with patch('src.routes.agent_registry.db.session.commit') as mock_commit:
+        mock_commit.side_effect = Exception("Database error")
+        
+        response = client.post(
+            '/api/v1/tasks',
+            data=json.dumps(sample_task_data),
+            headers=admin_headers
+        )
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+def test_get_task_not_found(client, admin_headers):
+    """Test GET /api/v1/tasks/{task_id} - Task not found"""
+    response = client.get(f'/api/v1/tasks/{uuid.uuid4()}', headers=admin_headers)
+    
+    assert response.status_code == 404
+    data = json.loads(response.data)
+    assert 'error' in data
+
+
+def test_get_task_exception_handling(client, admin_headers):
+    """Test GET /api/v1/tasks/{task_id} - Exception handling"""
+    with patch('src.routes.agent_registry.TaskDB') as mock_task_db:
+        mock_task_db.query.get.side_effect = Exception("Database error")
+        
+        response = client.get(f'/api/v1/tasks/{uuid.uuid4()}', headers=admin_headers)
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+def test_update_task_not_found(client, admin_headers):
+    """Test PATCH /api/v1/tasks/{task_id} - Task not found"""
+    response = client.patch(
+        f'/api/v1/tasks/{uuid.uuid4()}',
+        data=json.dumps({"status": "running"}),
+        headers=admin_headers
+    )
+    
+    assert response.status_code == 404
+    data = json.loads(response.data)
+    assert 'error' in data
+
+
+def test_update_task_exception_handling(client, admin_headers, sample_task_data):
+    """Test PATCH /api/v1/tasks/{task_id} - Exception handling"""
+    task_response = client.post(
+        '/api/v1/tasks',
+        data=json.dumps(sample_task_data),
+        headers=admin_headers
+    )
+    task_id = json.loads(task_response.data)['task_id']
+    
+    with patch('src.routes.agent_registry.db.session.commit') as mock_commit:
+        mock_commit.side_effect = Exception("Database error")
+        
+        response = client.patch(
+            f'/api/v1/tasks/{task_id}',
+            data=json.dumps({"status": "running"}),
+            headers=admin_headers
+        )
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data
+
+
+def test_cancel_task_not_found(client, admin_headers):
+    """Test POST /api/v1/tasks/{task_id}/cancel - Task not found"""
+    response = client.post(f'/api/v1/tasks/{uuid.uuid4()}/cancel', headers=admin_headers)
+    
+    assert response.status_code == 404
+    data = json.loads(response.data)
+    assert 'error' in data
+
+
+def test_cancel_task_exception_handling(client, admin_headers, sample_task_data):
+    """Test POST /api/v1/tasks/{task_id}/cancel - Exception handling"""
+    task_response = client.post(
+        '/api/v1/tasks',
+        data=json.dumps(sample_task_data),
+        headers=admin_headers
+    )
+    task_id = json.loads(task_response.data)['task_id']
+    
+    with patch('src.routes.agent_registry.db.session.commit') as mock_commit:
+        mock_commit.side_effect = Exception("Database error")
+        
+        response = client.post(f'/api/v1/tasks/{task_id}/cancel', headers=admin_headers)
+        
+        assert response.status_code == 500
+        data = json.loads(response.data)
+        assert 'error' in data


### PR DESCRIPTION
## Summary
Extends Agent Registry test coverage from **68% to 96%** (28% improvement) by adding 28 comprehensive tests covering error paths, parameter validation, and exception handling.

## Changes
**Test Coverage Improvements** (21 → 49 tests, +28 new tests):
- ✅ **Parameter Validation** (9 tests): Invalid pagination (page < 1, page_size out of range), invalid filter parameters (agent_type, status, permission_level)
- ✅ **Exception Handling** (13 tests): Database errors with Sentry integration for all agent/task endpoints
- ✅ **Not Found Scenarios** (6 tests): 404 responses for GET/PATCH/DELETE operations on non-existent resources

**Coverage Details**:
- Before: 334 statements, 108 missing (68%)
- After: 334 statements, 14 missing (96%)
- All 49 tests passing

## Testing
```bash
# Run Agent Registry tests
cd handoff/20250928/40_App/api-backend
python -m pytest tests/test_agent_registry.py -v

# Check coverage
python -m pytest tests/test_agent_registry.py --cov=src.routes.agent_registry --cov-report=term
```

Expected: 49 passed, 96% coverage

## Review Checklist
**Critical Items**:
- [ ] Verify mock paths are correct (`src.routes.agent_registry.AgentDB` vs `AgentDB.query.get`)
- [ ] Confirm exception handling tests simulate realistic error scenarios
- [ ] Validate parameter validation tests match actual validation logic in `agent_registry.py`
- [ ] Ensure no existing tests were broken (all 21 original tests still pass)

**Test Categories to Review**:
- [ ] Invalid pagination parameters properly return 400 errors
- [ ] Invalid enum values (agent_type, status, permission_level) return 400 errors
- [ ] Database exceptions properly return 500 errors with Sentry integration
- [ ] 404 errors returned for non-existent agent_id/task_id

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

**Note**: This is a **test-only PR** - no production code was modified. All error handling paths already existed; we're adding test coverage for production readiness.

---

**Link to Devin run**: https://app.devin.ai/sessions/8efae427f96e4ae9bc1c3a05768384aa  
**Requested by**: Ryan Chen (ryan2939z@gmail.com, @RC918)  
**Related Issue**: #963 (HIGH priority - Extend Agent Registry test coverage)