### PR TITLE
Fix Issue #964: Add OpenAPI validation to CI pipeline

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -49,8 +49,39 @@ jobs:
           
           print(f"✅ Schema valid: {len(schema['fields'])} variables defined")
           EOF
+  
+  validate-openapi-spec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install OpenAPI validator
+        run: |
+          pip install openapi-spec-validator pyyaml
+      - name: Validate OpenAPI spec
+        run: |
+          python - <<'EOF'
+          from openapi_spec_validator import validate_spec
+          from openapi_spec_validator.readers import read_from_filename
+          import sys
+          
+          try:
+              spec_dict, spec_url = read_from_filename('docs/openapi.yaml')
+              validate_spec(spec_dict)
+              print("✅ OpenAPI spec is valid (OpenAPI 3.0.3)")
+              print(f"   - API: {spec_dict['info']['title']} v{spec_dict['info']['version']}")
+              print(f"   - Endpoints: {len(spec_dict['paths'])} paths")
+              print(f"   - Schemas: {len(spec_dict['components']['schemas'])} components")
+          except Exception as e:
+              print(f"❌ OpenAPI spec validation failed: {e}")
+              sys.exit(1)
+          EOF
+  
   test:
-    needs: validate-env-schema
+    needs: [validate-env-schema, validate-openapi-spec]
     runs-on: ubuntu-latest
     services:
       redis:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,1096 @@
+openapi: 3.0.3
+info:
+  title: MorningAI Agent Registry API
+  description: |
+    Agent Registry & Task Router API for managing AI agents and their tasks.
+    Feature Flag: MVP_AGENT_REGISTRY (Issue #760)
+  version: 8.0.0
+  contact:
+    name: MorningAI Engineering Team
+    email: ryan2939z@gmail.com
+
+servers:
+  - url: https://api.morningai.com/api/v1
+    description: Production server
+  - url: https://staging-api.morningai.com/api/v1
+    description: Staging server
+  - url: http://localhost:5000/api/v1
+    description: Local development server
+
+security:
+  - bearerAuth: []
+
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: JWT token obtained from authentication endpoint
+
+  schemas:
+    AgentType:
+      type: string
+      enum:
+        - dev_agent
+        - ops_agent
+        - pm_agent
+        - growth_strategist
+        - meta_agent
+      description: Type of agent
+
+    AgentStatus:
+      type: string
+      enum:
+        - active
+        - idle
+        - busy
+        - offline
+        - error
+      description: Current status of the agent
+
+    PermissionLevel:
+      type: string
+      enum:
+        - sandbox_only
+        - staging_access
+        - prod_low_risk
+        - prod_full_access
+      description: Permission level based on reputation score
+
+    TaskStatus:
+      type: string
+      enum:
+        - queued
+        - assigned
+        - running
+        - completed
+        - failed
+        - cancelled
+      description: Current status of the task
+
+    AgentStatistics:
+      type: object
+      properties:
+        pr_merged_count:
+          type: integer
+          minimum: 0
+          default: 0
+        pr_reverted_count:
+          type: integer
+          minimum: 0
+          default: 0
+        test_pass_count:
+          type: integer
+          minimum: 0
+          default: 0
+        test_fail_count:
+          type: integer
+          minimum: 0
+          default: 0
+        test_pass_rate:
+          type: number
+          format: float
+          minimum: 0.0
+          maximum: 1.0
+          default: 0.0
+
+    Agent:
+      type: object
+      required:
+        - agent_id
+        - agent_type
+        - status
+        - permission_level
+        - reputation_score
+        - capabilities
+        - metadata
+        - created_at
+        - last_activity
+      properties:
+        agent_id:
+          type: string
+          format: uuid
+          description: Unique agent identifier (UUID)
+        agent_type:
+          $ref: '#/components/schemas/AgentType'
+        status:
+          $ref: '#/components/schemas/AgentStatus'
+        permission_level:
+          $ref: '#/components/schemas/PermissionLevel'
+        reputation_score:
+          type: integer
+          minimum: 0
+          maximum: 999
+          description: Agent reputation score (0-999)
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: List of agent capabilities
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Additional agent metadata
+        created_at:
+          type: string
+          format: date-time
+        last_activity:
+          type: string
+          format: date-time
+        statistics:
+          $ref: '#/components/schemas/AgentStatistics'
+
+    AgentRegistrationRequest:
+      type: object
+      required:
+        - agent_type
+        - capabilities
+      properties:
+        agent_type:
+          $ref: '#/components/schemas/AgentType'
+        capabilities:
+          type: array
+          items:
+            type: string
+          minItems: 1
+          description: List of agent capabilities (must not be empty)
+        metadata:
+          type: object
+          additionalProperties: true
+          default: {}
+
+    AgentUpdateRequest:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/AgentStatus'
+        capabilities:
+          type: array
+          items:
+            type: string
+        metadata:
+          type: object
+          additionalProperties: true
+
+    AgentHealthMetrics:
+      type: object
+      properties:
+        cpu_usage:
+          type: number
+          format: float
+          minimum: 0.0
+          maximum: 100.0
+        memory_usage:
+          type: number
+          format: float
+          minimum: 0.0
+          maximum: 100.0
+        active_tasks:
+          type: integer
+          minimum: 0
+        queue_depth:
+          type: integer
+          minimum: 0
+
+    AgentHealthError:
+      type: object
+      required:
+        - timestamp
+        - error_type
+        - message
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+        error_type:
+          type: string
+        message:
+          type: string
+
+    AgentHealth:
+      type: object
+      required:
+        - agent_id
+        - status
+        - last_heartbeat
+      properties:
+        agent_id:
+          type: string
+          format: uuid
+        status:
+          $ref: '#/components/schemas/AgentStatus'
+        last_heartbeat:
+          type: string
+          format: date-time
+        metrics:
+          $ref: '#/components/schemas/AgentHealthMetrics'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/AgentHealthError'
+          default: []
+
+    AgentHealthReport:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/AgentStatus'
+        metrics:
+          $ref: '#/components/schemas/AgentHealthMetrics'
+
+    Task:
+      type: object
+      required:
+        - task_id
+        - status
+        - task_type
+        - payload
+        - created_at
+        - updated_at
+      properties:
+        task_id:
+          type: string
+          format: uuid
+          description: Unique task identifier (UUID)
+        status:
+          $ref: '#/components/schemas/TaskStatus'
+        agent_id:
+          type: string
+          format: uuid
+          description: Assigned agent UUID
+          nullable: true
+        tenant_id:
+          type: string
+          format: uuid
+          description: Tenant UUID
+          nullable: true
+        task_type:
+          type: string
+          description: Type of task (e.g., 'faq', 'bug_fix', 'deployment')
+        payload:
+          type: object
+          additionalProperties: true
+          description: Task payload
+        result:
+          type: object
+          additionalProperties: true
+          description: Task result
+          nullable: true
+        error_message:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+          format: date-time
+        assigned_at:
+          type: string
+          format: date-time
+          nullable: true
+        started_at:
+          type: string
+          format: date-time
+          nullable: true
+        completed_at:
+          type: string
+          format: date-time
+          nullable: true
+        cancelled_at:
+          type: string
+          format: date-time
+          nullable: true
+        updated_at:
+          type: string
+          format: date-time
+
+    TaskCreationRequest:
+      type: object
+      required:
+        - task_type
+        - payload
+      properties:
+        task_type:
+          type: string
+          description: Type of task (must not be empty)
+        payload:
+          type: object
+          additionalProperties: true
+          description: Task payload
+        tenant_id:
+          type: string
+          format: uuid
+          description: Tenant UUID (optional, auto-resolved from JWT)
+
+    TaskUpdateRequest:
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/TaskStatus'
+        result:
+          type: object
+          additionalProperties: true
+        error_message:
+          type: string
+
+    Pagination:
+      type: object
+      required:
+        - page
+        - page_size
+        - total_items
+        - total_pages
+      properties:
+        page:
+          type: integer
+          minimum: 1
+        page_size:
+          type: integer
+          minimum: 1
+          maximum: 100
+        total_items:
+          type: integer
+          minimum: 0
+        total_pages:
+          type: integer
+          minimum: 0
+
+    AgentListResponse:
+      type: object
+      required:
+        - agents
+        - pagination
+      properties:
+        agents:
+          type: array
+          items:
+            $ref: '#/components/schemas/Agent'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    TaskListResponse:
+      type: object
+      required:
+        - tasks
+        - pagination
+      properties:
+        tasks:
+          type: array
+          items:
+            $ref: '#/components/schemas/Task'
+        pagination:
+          $ref: '#/components/schemas/Pagination'
+
+    Error:
+      type: object
+      required:
+        - error
+      properties:
+        error:
+          type: object
+          required:
+            - code
+            - message
+          properties:
+            code:
+              type: string
+              description: Error code
+            message:
+              type: string
+              description: Human-readable error message
+
+paths:
+  /agents:
+    get:
+      summary: List all registered agents
+      description: |
+        Retrieve a paginated list of all registered agents.
+        Supports filtering by agent_type, status, and permission_level.
+      operationId: listAgents
+      tags:
+        - Agents
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agent_type
+          in: query
+          description: Filter by agent type
+          schema:
+            $ref: '#/components/schemas/AgentType'
+        - name: status
+          in: query
+          description: Filter by agent status
+          schema:
+            $ref: '#/components/schemas/AgentStatus'
+        - name: permission_level
+          in: query
+          description: Filter by permission level
+          schema:
+            $ref: '#/components/schemas/PermissionLevel'
+        - name: page
+          in: query
+          description: Page number (1-indexed)
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: page_size
+          in: query
+          description: Number of items per page
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentListResponse'
+        '400':
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    post:
+      summary: Register a new agent
+      description: Register a new agent in the system
+      operationId: registerAgent
+      tags:
+        - Agents
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentRegistrationRequest'
+      responses:
+        '201':
+          description: Agent successfully registered
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Agent'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden (requires admin or service role)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /agents/{agent_id}:
+    get:
+      summary: Get agent by ID
+      description: Retrieve details of a specific agent
+      operationId: getAgent
+      tags:
+        - Agents
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          description: Agent UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Agent'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Agent not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    patch:
+      summary: Update agent
+      description: Update agent status, capabilities, or metadata
+      operationId: updateAgent
+      tags:
+        - Agents
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          description: Agent UUID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentUpdateRequest'
+      responses:
+        '200':
+          description: Agent successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Agent'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden (requires admin or service role)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Agent not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    delete:
+      summary: Unregister agent
+      description: Remove an agent from the registry
+      operationId: unregisterAgent
+      tags:
+        - Agents
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          description: Agent UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Agent successfully unregistered
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden (requires admin role)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Agent not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /agents/{agent_id}/health:
+    get:
+      summary: Get agent health status
+      description: Retrieve current health status and metrics of an agent
+      operationId: getAgentHealth
+      tags:
+        - Agent Health
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          description: Agent UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentHealth'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Agent not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    post:
+      summary: Report agent health (heartbeat)
+      description: Agent reports its current health status and metrics
+      operationId: reportAgentHealth
+      tags:
+        - Agent Health
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: agent_id
+          in: path
+          required: true
+          description: Agent UUID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AgentHealthReport'
+      responses:
+        '200':
+          description: Health report successfully recorded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentHealth'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Agent not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /tasks:
+    get:
+      summary: List all tasks
+      description: |
+        Retrieve a paginated list of all tasks.
+        Supports filtering by status.
+      operationId: listTasks
+      tags:
+        - Tasks
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: status
+          in: query
+          description: Filter by task status
+          schema:
+            $ref: '#/components/schemas/TaskStatus'
+        - name: page
+          in: query
+          description: Page number (1-indexed)
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+        - name: page_size
+          in: query
+          description: Number of items per page
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+            default: 20
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaskListResponse'
+        '400':
+          description: Invalid parameters
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    post:
+      summary: Create a new task
+      description: Create a new task in the system
+      operationId: createTask
+      tags:
+        - Tasks
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskCreationRequest'
+      responses:
+        '201':
+          description: Task successfully created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+        '202':
+          description: Task accepted for processing
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /tasks/{task_id}:
+    get:
+      summary: Get task by ID
+      description: Retrieve details of a specific task
+      operationId: getTask
+      tags:
+        - Tasks
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: task_id
+          in: path
+          required: true
+          description: Task UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+    patch:
+      summary: Update task
+      description: Update task status, result, or error message
+      operationId: updateTask
+      tags:
+        - Tasks
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: task_id
+          in: path
+          required: true
+          description: Task UUID
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TaskUpdateRequest'
+      responses:
+        '200':
+          description: Task successfully updated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+        '400':
+          description: Invalid request body
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /tasks/{task_id}/cancel:
+    post:
+      summary: Cancel task
+      description: Cancel a running or queued task
+      operationId: cancelTask
+      tags:
+        - Tasks
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: task_id
+          in: path
+          required: true
+          description: Task UUID
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Task successfully cancelled
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Task'
+        '400':
+          description: Task cannot be cancelled (already completed/failed)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Task not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '409':
+          description: Conflict - task cannot be cancelled in current state
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+tags:
+  - name: Agents
+    description: Agent registration and management
+  - name: Agent Health
+    description: Agent health monitoring and heartbeat
+  - name: Tasks
+    description: Task creation and management


### PR DESCRIPTION
## Summary
Implements Issue #964: Adds OpenAPI 3.0.3 specification for Agent Registry API and CI validation to ensure spec remains valid on every PR.

## Changes

### 1. OpenAPI Specification (`docs/openapi.yaml`)
Created comprehensive spec documenting all 12 Agent Registry endpoints:

**API Coverage:**
- 6 paths, 12 operations (GET/POST/PATCH/DELETE)
- Agents: list, register, get, update, unregister
- Agent Health: get status, report heartbeat  
- Tasks: list, create, get, update, cancel

**Schemas (19 components):**
- Request/response models matching Pydantic types
- Enums: AgentType, AgentStatus, PermissionLevel, TaskStatus
- Pagination, Error, AgentHealth, Task schemas
- All fields include descriptions, constraints, formats

**Features:**
- JWT bearer authentication (securitySchemes)
- Rate limiting responses (429)
- Complete error responses (400/401/403/404/409/500)
- Server URLs for production/staging/local

### 2. CI Validation (`.github/workflows/backend.yml`)
Added `validate-openapi-spec` job:
- Runs `openapi-spec-validator` on every PR
- Validates YAML syntax and OpenAPI 3.0.3 compliance
- Blocks merge if spec is invalid
- Shows summary (endpoints, schemas count)

## 提醒
- [x] 此 PR 為文檔 + CI 基礎設施，不修改 API 邏輯
- [ ] **關鍵審查點**: OpenAPI spec 是手動編寫，需驗證與實際 Pydantic models 一致性
- [ ] 未來修改 API 時，必須同步更新 `docs/openapi.yaml`

## Human Review Checklist

**HIGH PRIORITY - Schema Accuracy Verification:**
- [ ] Spot-check 2-3 endpoints: compare spec schemas with actual Pydantic models in `src/models/agent_registry.py`
- [ ] Verify enum values match: `AgentType`, `AgentStatus`, `PermissionLevel`, `TaskStatus`
- [ ] Check required fields are correct (e.g., `Agent` requires `agent_id`, `agent_type`, etc.)
- [ ] Verify nullable fields match implementation (e.g., `Task.agent_id: nullable: true`)
- [ ] Confirm error response structure matches actual Flask error responses

**MEDIUM PRIORITY - Infrastructure:**
- [ ] Verify server URLs are correct: `api.morningai.com`, `staging-api.morningai.com`
- [ ] Check JWT security scheme matches actual auth implementation
- [ ] Confirm rate limiting response (429) structure matches actual rate_limit middleware

**Known Limitations:**
- ⚠️ Spec is hand-maintained, not auto-generated from code
- ⚠️ CI validates YAML syntax only, not spec-implementation alignment
- ⚠️ No contract tests (Schemathesis) verifying spec matches actual API behavior

## Testing
- ✅ Validated spec locally with `openapi-spec-validator`
- ✅ CI job successfully validates spec (6 paths, 19 schemas)
- ⚠️ No contract testing against running Flask app

---

**Link to Devin run:** https://app.devin.ai/sessions/8efae427f96e4ae9bc1c3a05768384aa  
**Requested by:** Ryan Chen (@RC918)