### PR TITLE
feat: Add pip-audit to CI security scanning (Issue #287)

### DIFF
--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -76,10 +76,67 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  pip-audit:
+    name: Python Dependency Vulnerability Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install pip-audit
+        run: |
+          pip install pip-audit
+
+      - name: Run pip-audit on api-backend
+        id: audit-backend
+        continue-on-error: true
+        run: |
+          cd handoff/20250928/40_App/api-backend
+          if [ -f "requirements.txt" ]; then
+            echo "## 🔍 API Backend Dependencies" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            pip-audit -r requirements.txt --format markdown >> $GITHUB_STEP_SUMMARY 2>&1 || echo "audit_backend_failed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No requirements.txt found in api-backend"
+          fi
+
+      - name: Run pip-audit on orchestrator
+        id: audit-orchestrator
+        continue-on-error: true
+        run: |
+          cd handoff/20250928/40_App/orchestrator
+          if [ -f "requirements.txt" ]; then
+            echo "## 🔍 Orchestrator Dependencies" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            pip-audit -r requirements.txt --format markdown >> $GITHUB_STEP_SUMMARY 2>&1 || echo "audit_orchestrator_failed=true" >> $GITHUB_OUTPUT
+          elif [ -f "pyproject.toml" ]; then
+            echo "## 🔍 Orchestrator Dependencies (pyproject.toml)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            pip-audit --format markdown >> $GITHUB_STEP_SUMMARY 2>&1 || echo "audit_orchestrator_failed=true" >> $GITHUB_OUTPUT
+          else
+            echo "No requirements.txt or pyproject.toml found in orchestrator"
+          fi
+
+      - name: Check for vulnerabilities
+        run: |
+          if [ "${{ steps.audit-backend.outputs.audit_backend_failed }}" == "true" ] || [ "${{ steps.audit-orchestrator.outputs.audit_orchestrator_failed }}" == "true" ]; then
+            echo "::warning::Vulnerabilities found in Python dependencies. Please review and update."
+            # Don't fail the workflow, just warn
+            exit 0
+          else
+            echo "✅ No vulnerabilities found in Python dependencies"
+          fi
+
   security-summary:
     name: Security Scan Summary
     runs-on: ubuntu-latest
-    needs: [gitleaks, trufflehog]
+    needs: [gitleaks, trufflehog, pip-audit]
     if: always()
     steps:
       - name: Check scan results and generate metrics
@@ -88,11 +145,12 @@ jobs:
           SCAN_START_TIME="${{ github.event.head_commit.timestamp }}"
           SCAN_END_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           
-          echo "## 🔒 Secret Scanning Results" >> $GITHUB_STEP_SUMMARY
+          echo "## 🔒 Security Scanning Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Scan Configuration:**" >> $GITHUB_STEP_SUMMARY
           echo "- TruffleHog Version: v3.82.13 (pinned)" >> $GITHUB_STEP_SUMMARY
           echo "- Gitleaks Version: v2 (latest stable)" >> $GITHUB_STEP_SUMMARY
+          echo "- pip-audit: Latest" >> $GITHUB_STEP_SUMMARY
           echo "- Scan Type: ${{ github.event_name }}" >> $GITHUB_STEP_SUMMARY
           echo "- Fetch Depth: ${{ github.event_name == 'pull_request' && '100 commits' || 'Full history' }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -111,6 +169,14 @@ jobs:
             echo "⚠️ **TruffleHog**: Potential secrets detected! Review the logs." >> $GITHUB_STEP_SUMMARY
             echo "   - Only verified secrets are reported (--only-verified)" >> $GITHUB_STEP_SUMMARY
             echo "   - Unverified secrets may still be sensitive" >> $GITHUB_STEP_SUMMARY
+          fi
+          
+          if [ "${{ needs.pip-audit.result }}" == "success" ]; then
+            echo "✅ **pip-audit**: No critical vulnerabilities in Python dependencies" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ **pip-audit**: Vulnerabilities detected in Python dependencies" >> $GITHUB_STEP_SUMMARY
+            echo "   - Review the detailed report above" >> $GITHUB_STEP_SUMMARY
+            echo "   - Update vulnerable packages when possible" >> $GITHUB_STEP_SUMMARY
           fi
           
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -138,6 +204,11 @@ jobs:
           # Warning if TruffleHog failed (but don't block - only verified secrets)
           if [ "${{ needs.trufflehog.result }}" != "success" ]; then
             echo "::warning::TruffleHog detected potential secrets - review recommended"
+          fi
+          
+          # Warning if pip-audit failed (but don't block - vulnerabilities need review)
+          if [ "${{ needs.pip-audit.result }}" != "success" ]; then
+            echo "::warning::pip-audit detected vulnerabilities - review and update recommended"
           fi
 
   # Block PR merge if secrets are detected


### PR DESCRIPTION
## 概要

實作 Issue #287 (P0: CI Secret Scanning) 中的 pip-audit 部分，為 Python 依賴套件添加漏洞掃描功能。

## 變更內容

### 新增 `pip-audit` Job
- 掃描 `api-backend/requirements.txt` 的依賴漏洞
- 掃描 `orchestrator` 的依賴（支持 requirements.txt 或 pyproject.toml）
- 使用 Python 3.12 環境
- 生成 Markdown 格式的漏洞報告（顯示在 GitHub Actions Summary）

### 更新 `security-summary` Job
- 加入 pip-audit 結果到安全掃描總結
- 顯示三個工具的掃描狀態：gitleaks、TruffleHog、pip-audit

### 安全策略
⚠️ **重要決策**：目前實作為「警告模式」而非「阻擋模式」
- 使用 `continue-on-error: true`
- 發現漏洞時發出 warning，但**不會阻擋 PR merge**
- 理由：避免因既有漏洞或誤報造成所有 PR 被阻擋

## 測試狀態
❌ **未經測試**：GitHub Actions workflows 無法在本地測試，需要 merge 後在 CI 環境驗證

## 審查重點

### 🚨 高優先級
- [ ] **確認安全策略**：Issue #287 為 P0 優先級，但目前只警告不阻擋。是否應該改為阻擋模式？
- [ ] **路徑驗證**：確認 `handoff/20250928/40_App/api-backend` 和 `handoff/20250928/40_App/orchestrator` 路徑正確
- [ ] **既有漏洞**：可能會立即發現既有的依賴漏洞，需要有處理計劃

### ✅ 低優先級
- [ ] Workflow YAML 語法正確性（GitHub 會自動驗證）
- [ ] Step Summary 格式是否清晰易讀

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 CI/邏輯變更

## 相關資訊
- **Issue**: #287 (P0: CI Secret Scanning)
- **Devin Session**: https://app.devin.ai/sessions/598547ecff214b8dbd338e29465205dc
- **Requested by**: Ryan Chen (@RC918)

---

**後續步驟**：Merge 後觀察第一次 CI run 的結果，確認是否有漏洞需要處理。