### PR TITLE
chore: Unify TypeScript version to 5.9.3 in shared-ui

### DIFF
--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -89,6 +89,6 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "tsup": "^8.0.1",
-    "typescript": "^5.3.3"
+    "typescript": "5.9.3"
   }
 }


### PR DESCRIPTION
## 📋 變更摘要

統一 `packages/shared-ui` 的 TypeScript 版本至 `5.9.3`，與 root `package.json` 對齊。

## 🎯 動機

此變更為 **Epic #994 (skipLibCheck: false 遷移) 的前置條件**：
- 確保 monorepo 中所有套件使用相同的 TypeScript 版本
- 防止 Phase 1 中 `.d.ts` 型別宣告生成不一致的問題
- 消除因版本差異導致的型別檢查誤判

## 🔧 技術細節

**變更內容**:
```diff
- "typescript": "^5.3.3"
+ "typescript": "5.9.3"
```

**影響範圍**:
- `packages/shared-ui/package.json` (1 行)
- `pnpm-lock.yaml` (lockfile 更新)

**對齊狀態**:
- ✅ Root: `typescript@5.9.3`
- ✅ shared-ui: `typescript@5.9.3` (本 PR)
- ✅ frontend-dashboard: 透過 pnpm overrides 使用 `5.9.3`

## ✅ 驗收清單

### 自動驗證 (CI)
- [ ] `pnpm --filter @morningai/shared-ui type-check` 通過
- [ ] `pnpm --filter @morningai/shared-ui build` 成功
- [ ] 所有 CI checks 綠燈

### 人工驗證
- [ ] 版本號正確：`5.9.3` (exact pin，非 `^5.9.3`)
- [ ] 與 root `package.json` 對齊
- [ ] 無新增 TypeScript 錯誤

## 提醒
- [x] 不修改 OpenAPI/資料欄位（本 PR 不涉及）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯（本 PR 僅含依賴更新）

## 🔗 相關資源

- **Epic #994**: skipLibCheck: false 遷移（待創建）
- **前置條件**: 本 PR 需先合併才能開始執行 Epic #994
- **Devin Run**: https://app.devin.ai/sessions/4af839a11c814c8191ed9983650ea5d6
- **Requested by**: @RC918

---

**⚠️ 審查重點**:
1. 確認 CI type-check 通過（尤其是 shared-ui）
2. 確認此變更為 Epic #994 的正確前置條件
3. 確認 lockfile 變更合理（僅 TypeScript 版本相關）