### PR TITLE
CI: Gate backend health checks on backend changes + resilient version check

### DIFF
--- a/.github/workflows/post-deploy-health-assertions.yml
+++ b/.github/workflows/post-deploy-health-assertions.yml
@@ -7,8 +7,27 @@ on:
   schedule:
     - cron: "0 * * * *"
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      backend: ${{ steps.filter.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            backend:
+              - 'handoff/20250928/40_App/api-backend/**'
+              - 'handoff/20250928/40_App/orchestrator/**'
+              - 'handoff/20250928/40_App/api/**'
+              - '.github/workflows/post-deploy-health-assertions.yml'
+              - '.github/workflows/post-deploy-health.yml'
+
   validate:
     runs-on: ubuntu-latest
+    needs: changes
+    if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true' }}
     permissions:
       contents: read
       checks: write
@@ -16,14 +35,60 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Check core health (/healthz)
+        env:
+          EXPECTED_MAJOR: 8
         run: |
           set -e
-          curl -sS https://morningai-backend-v2.onrender.com/healthz | tee /tmp/health.json
-          jq -e '
-            (.phase | test("Phase 8")) and
-            ((.version // .app_version // .app_version_tag // .app_build // "") | test("^(8[.]0[.]0|1[.]0[.]0)$")) and
+          
+          # Add cache-busting and retries to curl
+          URL="https://morningai-backend-v2.onrender.com/healthz?t=${{ github.run_id }}"
+          echo "Checking backend health at: $URL"
+          
+          curl -sS --fail-with-body \
+            -H 'Cache-Control: no-cache, no-store' \
+            -H 'Pragma: no-cache' \
+            --max-time 10 \
+            --retry 5 \
+            --retry-delay 2 \
+            --retry-all-errors \
+            "$URL" | tee /tmp/health.json
+          
+          echo ""
+          echo "=== Health Check Response ==="
+          cat /tmp/health.json | jq '.'
+          echo ""
+          
+          # Extract version, phase, and status for better error messages
+          VERSION=$(jq -r '.version // .app_version // .app_version_tag // .app_build // "unknown"' /tmp/health.json)
+          PHASE=$(jq -r '.phase // "unknown"' /tmp/health.json)
+          STATUS=$(jq -r '.status // "unknown"' /tmp/health.json)
+          DATABASE=$(jq -r '.database // "unknown"' /tmp/health.json)
+          
+          echo "Extracted values:"
+          echo "  Version: $VERSION"
+          echo "  Phase: $PHASE"
+          echo "  Status: $STATUS"
+          echo "  Database: $DATABASE"
+          echo ""
+          
+          # Validate with relaxed version check (accept any 8.x.x)
+          jq -e --argjson EXP_MAJOR "$EXPECTED_MAJOR" '
+            def ver: (.version // .app_version // .app_version_tag // .app_build // "");
+            def major(v): if (v | test("^[0-9]+\\.[0-9]+\\.[0-9]+$")) then (v | capture("^(?<maj>\\d+)").maj | tonumber) else -1 end;
+            
+            (.phase | tostring | test("Phase\\s*8")) and
+            (ver as $v | (major($v) == $EXP_MAJOR)) and
             ((.status == "healthy") or (.database == "connected"))
-          ' /tmp/health.json >/dev/null
+          ' /tmp/health.json >/dev/null || {
+            echo ""
+            echo "::error::Backend health check failed!"
+            echo "::error::Expected: Phase 8, Version ${EXPECTED_MAJOR}.x.x, Status healthy or Database connected"
+            echo "::error::Got: Phase='$PHASE', Version='$VERSION', Status='$STATUS', Database='$DATABASE'"
+            echo "::error::If this is a configuration issue, ensure APP_VERSION is set correctly in Render.com and redeploy."
+            exit 1
+          }
+          
+          echo "✅ Backend health check passed!"
 
       - name: Test Phase 4–6 API endpoints (JWT optional, with retry)
         env:


### PR DESCRIPTION
## 概述

優化 CI workflow，防止 frontend-only PR 被 backend 部署問題阻擋，同時保持生產環境健康監控。

## 主要變更

### 1. 路徑過濾（Path Filters）
- 新增 `changes` job 使用 `dorny/paths-filter@v3` 偵測 backend 檔案變更
- `validate` job 僅在以下情況執行：
  - PR 中有 backend 檔案變更，或
  - 非 PR 事件（schedule、workflow_dispatch、push to main）

**Backend 路徑定義**:
```yaml
backend:
  - 'handoff/20250928/40_App/api-backend/**'
  - 'handoff/20250928/40_App/orchestrator/**'
  - 'handoff/20250928/40_App/api/**'
  - '.github/workflows/post-deploy-health-assertions.yml'
  - '.github/workflows/post-deploy-health.yml'
```

### 2. 放寬版本檢查邏輯
- **舊邏輯**: 僅接受 `8.0.0` 或 `1.0.0`（硬編碼）
- **新邏輯**: 接受任何 `8.x.x` 版本（例如：8.0.0、8.0.1、8.1.0）
- 使用 jq `capture()` 函數提取 major version 並比對

### 3. 增強錯誤訊息
- 失敗時顯示實際值：`Version='X.X.X', Phase='...', Status='...', Database='...'`
- 提供具體的修復建議（檢查 Render.com APP_VERSION 設定）

### 4. Cache-Busting & 重試機制
- URL 加上 `?t=${{ github.run_id }}` 避免快取
- curl 加上重試：5 次嘗試，間隔 2 秒
- 加上 Cache-Control headers 確保不快取

## 審查重點

### ⚠️ 高風險項目

1. **Path filters 完整性**
   - ❓ 路徑是否涵蓋所有 backend 相關目錄？
   - ❓ 是否有誤判 frontend 檔案為 backend？
   - 建議：檢查專案結構，確認沒有遺漏的 backend 目錄

2. **jq 版本檢查邏輯**
   - ❓ `capture("^(?<maj>\\d+)")` 在 GitHub Actions 環境是否正常運作？
   - ❓ 邊界情況處理：`"unknown"`、非 semver 格式、缺少欄位
   - 建議：測試以下情況：
     - ✅ `8.0.0`, `8.1.0`, `8.0.1` 應通過
     - ❌ `1.0.0`, `9.0.0`, `"unknown"` 應失敗

3. **條件執行邏輯**
   - ❓ `if: ${{ github.event_name != 'pull_request' || needs.changes.outputs.backend == 'true' }}` 是否符合需求？
   - ❓ Schedule runs 是否應該也檢查路徑？
   - 目前行為：schedule/manual 總是執行，PR 只在 backend 變更時執行

4. **第三方依賴**
   - 新增 `dorny/paths-filter@v3` 依賴
   - ❓ 是否需要鎖定版本（v3 → v3.0.2）？

### 🔍 測試建議

1. **Frontend-only PR**: 建立一個只改 frontend 的 PR，確認 `validate` job 被跳過
2. **Backend PR**: 修改 api-backend 檔案，確認 `validate` job 執行
3. **Workflow 修改**: 修改此 workflow 本身，確認 `validate` job 執行
4. **錯誤情境**: 臨時改 `EXPECTED_MAJOR: 9`，確認錯誤訊息清楚

## 提醒
- [x] 不修改 OpenAPI/資料欄位 ✅ 此 PR 僅修改 CI workflow
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯 ✅ 此為 CI 工程 PR

---

**Link to Devin run**: https://app.devin.ai/sessions/acf1bc51a2774f97b163675720e17aad  
**Requested by**: Ryan Chen (@RC918)