### PR TITLE
fix: Enforce LHCI configuration file and performance budgets in PR workflow

### DIFF
--- a/.github/workflows/lhci.yml
+++ b/.github/workflows/lhci.yml
@@ -121,7 +121,10 @@ jobs:
       - name: Run Lighthouse CI (PR - fast)
         env:
           DEBUG: lighthouse:*
-        run: pnpm dlx @lhci/cli collect --url=http://localhost:4173/ --url=http://localhost:4173/login --url=http://localhost:4173/pricing --numberOfRuns=1 --settings.chromeFlags="--no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer --disable-features=PaintHolding" --settings.maxWaitForFcp=60000 --settings.maxWaitForLoad=120000 --settings.throttlingMethod=provided --settings.formFactor=desktop --settings.screenEmulation.mobile=false --logLevel=verbose
+        run: pnpm dlx @lhci/cli collect --config=../../../../lighthouserc.json --url=http://localhost:4173/ --url=http://localhost:4173/login --url=http://localhost:4173/pricing --settings.chromeFlags="--no-sandbox --disable-dev-shm-usage --disable-gpu --disable-software-rasterizer --disable-features=PaintHolding" --settings.maxWaitForFcp=60000 --settings.maxWaitForLoad=120000 --logLevel=verbose
+
+      - name: Assert Lighthouse CI budgets
+        run: pnpm dlx @lhci/cli assert --config=../../../../lighthouserc.json
 
       - name: Upload LHCI artifacts
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## 概述

修復 Lighthouse CI PR workflow 配置不一致問題，並強制執行 performance budgets。PR workflow 現在使用集中式的 `lighthouserc.json` 配置文件，而非分散的 CLI flags。

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

## 主要變更

### 1. 統一使用配置文件
**文件**: `.github/workflows/lhci.yml`

**問題**: PR workflow 使用 CLI flags (`--numberOfRuns=1`, `--throttlingMethod=provided` 等)，而 main branch workflow 使用配置文件，導致：
- `lighthouserc.json` 中的 `numberOfRuns: 3` 設置在 PR 中無效
- Performance budgets 未在 PR 中強制執行
- 配置分散，難以維護

**解決方案**:
```yaml
# Before
run: pnpm dlx @lhci/cli collect --url=... --numberOfRuns=1 --settings.throttlingMethod=provided --settings.formFactor=desktop ...

# After  
run: pnpm dlx @lhci/cli collect --config=../../../../lighthouserc.json --url=... # 使用配置文件
```

### 2. 強制執行 Performance Budgets
新增明確的 assert 步驟：
```yaml
- name: Assert Lighthouse CI budgets
  run: pnpm dlx @lhci/cli assert --config=../../../../lighthouserc.json
```

**影響**:
- ✅ PR 現在運行 3 次測試（取中位數），減少 CI 環境變異
- ✅ Performance budgets 被強制執行：
  - LCP < 2.5s
  - CLS < 0.1
  - TBT < 200ms
  - Performance score ≥ 90%
- ⚠️ **超出預算時 CI 將失敗**（這是預期行為）

## 風險評估

### 🔴 高風險項目
1. **CI 將變嚴格**: 之前未檢查 budgets 的 PR 現在可能失敗
2. **未在 CI 測試**: 此變更首次在真實 CI 環境運行
3. **當前接近預算**: PR #1010 顯示 LCP = 1.40s（預算 2.5s），仍有空間但需監控

### 🟡 中風險項目
4. **配置文件路徑**: 使用相對路徑 `../../../../lighthouserc.json`，需驗證從 working directory 正確解析

## 審查檢查清單

- [ ] 驗證配置文件路徑從 `handoff/20250928/40_App/frontend-dashboard` 正確解析
- [ ] 確認當前應用效能符合 budgets（檢查最近的 LHCI 報告）
- [ ] 評估是否需要調整 budgets 或先設為 warning level 進行漸進式推出
- [ ] 檢查此 PR 的 CI 結果，確認新 workflow 正常運作

## 測試驗證

⚠️ **未本地測試**: CI workflow 變更無法在本地完整測試，將在此 PR 的 CI 中首次運行

## 連結
- Devin Session: https://app.devin.ai/sessions/9f3402808fe74c9099e710736cbed80c
- Requested by: Ryan Chen (@RC918)
- Related: PR #1010 (CTO Priority Fixes)