### PR TITLE
feat(audit): Enable all 8 audit sections with comprehensive checks

### DIFF
--- a/.github/workflows/design-system-audit.yml
+++ b/.github/workflows/design-system-audit.yml
@@ -49,6 +49,7 @@ jobs:
         id: audit
         run: |
           echo "Running design system audit in relaxed mode..."
+          echo "Note: Change --relaxed to --strict to enforce failures"
           ./audit-design-system.sh --relaxed --verbose 2>&1 | tee audit-output.txt
           EXIT_CODE=${PIPESTATUS[0]}
           echo "exit_code=$EXIT_CODE" >> $GITHUB_OUTPUT
@@ -120,15 +121,15 @@ jobs:
             - ✗ Failed: ${{ steps.parse.outputs.fail_count }} / ${{ steps.parse.outputs.total_count }}
             - ⊘ TODO: ${{ steps.parse.outputs.todo_count }} / ${{ steps.parse.outputs.total_count }}
             
-            **Audit Areas**:
-            1. ✅ Environment & Package Governance (7 checks)
-            2. ⊘ Design System Adoption (TODO - requires debugging)
-            3. ⊘ Design Token Enforcement (TODO - requires debugging)
-            4. ⊘ Accessibility Compliance (TODO - requires debugging)
-            5. ⊘ Motion Governance (TODO - requires debugging)
-            6. ⊘ Internationalization (TODO - requires debugging)
-            7. ⊘ Storybook Documentation (TODO - requires debugging)
-            8. ⊘ React Version Alignment (TODO - requires debugging)
+            **Audit Areas** (all 8 sections enabled):
+            1. Environment & Package Governance
+            2. Design System Adoption & Component Duplication
+            3. Design Tokens Enforcement
+            4. Accessibility Compliance
+            5. Motion & Animation Governance
+            6. Internationalization (i18n)
+            7. Storybook & Documentation
+            8. React Version Alignment
             
             **Notes**: ${{ steps.parse.outputs.notes }}
             
@@ -136,7 +137,7 @@ jobs:
             
             ---
             
-            ℹ️ **Relaxed Mode**: This audit runs in non-blocking mode to prevent CI failures while we debug and expand the checks. Run `./audit-design-system.sh --strict` locally to enforce all checks.
+            ℹ️ **Relaxed Mode**: This audit runs in non-blocking mode. All 8 sections are now enabled with comprehensive checks. Run `./audit-design-system.sh --strict` locally to enforce failures, or update the workflow to use `--strict` mode when ready.
       
       - name: Add job summary
         if: always()

--- a/audit-design-system.sh
+++ b/audit-design-system.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 # MorningAI Design System Audit Script
-# Simplified version with relaxed mode for CI stability
-# TODO: Expand checks in sections 2-8 after debugging
 
 set -euo pipefail
 
@@ -148,38 +146,265 @@ else
 fi
 
 log_section "2. Design System Adoption & Component Duplication"
-log_todo "Component duplication analysis (requires debugging comm/grep pipelines)"
-log_todo "Shared-ui import analysis (requires stable grep with error handling)"
+
+SHARED_COMPONENTS=0
+if [ -d "packages/shared-ui/src/components/ui" ]; then
+  SHARED_COMPONENTS=$(find packages/shared-ui/src/components/ui -name "*.tsx" 2>/dev/null | wc -l || echo 0)
+fi
+log_info "Shared UI components: $SHARED_COMPONENTS"
+
+DASHBOARD_LOCAL=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src/components/ui" ]; then
+  DASHBOARD_LOCAL=$(find handoff/20250928/40_App/frontend-dashboard/src/components/ui -name "*.tsx" 2>/dev/null | wc -l || echo 0)
+fi
+log_info "Frontend-dashboard local components: $DASHBOARD_LOCAL"
+
+CONSOLE_LOCAL=0
+if [ -d "handoff/20250928/40_App/owner-console/src/components/ui" ]; then
+  CONSOLE_LOCAL=$(find handoff/20250928/40_App/owner-console/src/components/ui -name "*.tsx" 2>/dev/null | wc -l || echo 0)
+fi
+log_info "Owner-console local components: $CONSOLE_LOCAL"
+
+DASHBOARD_SHARED_IMPORTS=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ]; then
+  DASHBOARD_SHARED_IMPORTS=$(grep -r "from '@morningai/shared-ui'" handoff/20250928/40_App/frontend-dashboard/src --include="*.tsx" --include="*.ts" 2>/dev/null | wc -l || echo 0)
+fi
+log_info "Frontend-dashboard shared-ui imports: $DASHBOARD_SHARED_IMPORTS"
+
+CONSOLE_SHARED_IMPORTS=0
+if [ -d "handoff/20250928/40_App/owner-console/src" ]; then
+  CONSOLE_SHARED_IMPORTS=$(grep -r "from '@morningai/shared-ui'" handoff/20250928/40_App/owner-console/src --include="*.tsx" --include="*.ts" 2>/dev/null | wc -l || echo 0)
+fi
+log_info "Owner-console shared-ui imports: $CONSOLE_SHARED_IMPORTS"
+
+if [ $DASHBOARD_SHARED_IMPORTS -gt 0 ] || [ $CONSOLE_SHARED_IMPORTS -gt 0 ]; then
+  log_pass "Apps are importing from @morningai/shared-ui ($((DASHBOARD_SHARED_IMPORTS + CONSOLE_SHARED_IMPORTS)) imports)"
+else
+  log_warn "No shared-ui imports detected in apps - migration may be incomplete"
+fi
+
+if [ $SHARED_COMPONENTS -gt 0 ] && [ $DASHBOARD_LOCAL -gt 0 ]; then
+  log_warn "Frontend-dashboard has $DASHBOARD_LOCAL local components while shared-ui has $SHARED_COMPONENTS - review for duplicates"
+elif [ $DASHBOARD_LOCAL -eq 0 ] && [ $SHARED_COMPONENTS -gt 0 ]; then
+  log_pass "Frontend-dashboard has no local UI components - using shared-ui"
+else
+  log_pass "Component distribution looks reasonable"
+fi
 
 log_section "3. Design Tokens Enforcement"
-log_todo "Hard-coded hex color detection (requires stable grep patterns)"
-log_todo "Inline styles analysis (requires stable grep with wc)"
-log_todo "RGB/RGBA color detection"
+
+HEX_VIOLATIONS=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ] || [ -d "handoff/20250928/40_App/owner-console/src" ] || [ -d "packages/shared-ui/src" ]; then
+  HEX_VIOLATIONS=$(grep -r "#[0-9A-Fa-f]\{6\}" \
+    handoff/20250928/40_App/frontend-dashboard/src \
+    handoff/20250928/40_App/owner-console/src \
+    packages/shared-ui/src \
+    --include="*.tsx" --include="*.ts" \
+    --exclude="tokens.json" --exclude="*.config.*" \
+    2>/dev/null | wc -l || echo 0)
+fi
+
+if [ $HEX_VIOLATIONS -eq 0 ]; then
+  log_pass "No hard-coded hex colors in component files"
+else
+  log_warn "$HEX_VIOLATIONS instances of hard-coded hex colors found"
+fi
+
+INLINE_STYLES=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ] || [ -d "handoff/20250928/40_App/owner-console/src" ] || [ -d "packages/shared-ui/src" ]; then
+  INLINE_STYLES=$(grep -r "style={{" \
+    handoff/20250928/40_App/frontend-dashboard/src \
+    handoff/20250928/40_App/owner-console/src \
+    packages/shared-ui/src \
+    --include="*.tsx" \
+    2>/dev/null | wc -l || echo 0)
+fi
+
+if [ $INLINE_STYLES -eq 0 ]; then
+  log_pass "No inline styles found"
+elif [ $INLINE_STYLES -lt 50 ]; then
+  log_warn "$INLINE_STYLES instances of inline styles (acceptable if < 50)"
+else
+  log_fail "$INLINE_STYLES instances of inline styles (should be < 50)"
+fi
+
+RGB_VIOLATIONS=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ] || [ -d "handoff/20250928/40_App/owner-console/src" ] || [ -d "packages/shared-ui/src" ]; then
+  RGB_VIOLATIONS=$(grep -rE "rgb\(|rgba\(" \
+    handoff/20250928/40_App/frontend-dashboard/src \
+    handoff/20250928/40_App/owner-console/src \
+    packages/shared-ui/src \
+    --include="*.tsx" --include="*.ts" \
+    2>/dev/null | wc -l || echo 0)
+fi
+
+if [ $RGB_VIOLATIONS -eq 0 ]; then
+  log_pass "No rgb/rgba color values in component files"
+else
+  log_warn "$RGB_VIOLATIONS instances of rgb/rgba colors found"
+fi
 
 log_section "4. Accessibility Compliance"
-log_todo "eslint-plugin-jsx-a11y verification"
-log_todo "Accessibility testing tools check (axe-core, jest-axe, vitest-axe)"
-log_todo "Accessibility test files count"
-log_todo "Image alt attribute validation"
+
+if [ -f "handoff/20250928/40_App/frontend-dashboard/package.json" ] && grep -q "eslint-plugin-jsx-a11y" handoff/20250928/40_App/frontend-dashboard/package.json 2>/dev/null; then
+  log_pass "eslint-plugin-jsx-a11y installed in frontend-dashboard"
+else
+  log_fail "eslint-plugin-jsx-a11y missing in frontend-dashboard"
+fi
+
+A11Y_TOOLS=0
+if [ -f "handoff/20250928/40_App/frontend-dashboard/package.json" ]; then
+  A11Y_TOOLS=$(grep -E "vitest-axe|jest-axe|@axe-core" handoff/20250928/40_App/frontend-dashboard/package.json 2>/dev/null | wc -l || echo 0)
+fi
+
+if [ $A11Y_TOOLS -gt 0 ]; then
+  log_pass "Accessibility testing tools installed (axe-core, jest-axe, or vitest-axe)"
+else
+  log_warn "No accessibility testing tools found"
+fi
+
+A11Y_TESTS=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ]; then
+  A11Y_TESTS=$(find handoff/20250928/40_App/frontend-dashboard/src -name "*.a11y.test.*" -o -name "*.axe.test.*" 2>/dev/null | wc -l || echo 0)
+fi
+log_info "Accessibility test files: $A11Y_TESTS"
+
+if [ $A11Y_TESTS -gt 0 ]; then
+  log_pass "$A11Y_TESTS accessibility test files found"
+else
+  log_warn "No dedicated accessibility test files found"
+fi
+
+IMG_NO_ALT=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ]; then
+  IMG_NO_ALT=$(grep -r "<img" handoff/20250928/40_App/frontend-dashboard/src --include="*.tsx" 2>/dev/null | grep -v "alt=" | wc -l || echo 0)
+fi
+
+if [ $IMG_NO_ALT -eq 0 ]; then
+  log_pass "No <img> tags without alt attributes detected"
+else
+  log_warn "$IMG_NO_ALT <img> tag(s) potentially missing alt attributes"
+fi
 
 log_section "5. Motion & Animation Governance"
-log_todo "prefers-reduced-motion support detection"
-log_todo "Framer Motion usage analysis"
-log_todo "withReducedMotion wrapper verification"
+
+REDUCED_MOTION_CSS=0
+REDUCED_MOTION_JS=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ]; then
+  REDUCED_MOTION_CSS=$(grep -r "prefers-reduced-motion" handoff/20250928/40_App/frontend-dashboard/src --include="*.css" 2>/dev/null | wc -l || echo 0)
+  REDUCED_MOTION_JS=$(grep -r "prefers-reduced-motion" handoff/20250928/40_App/frontend-dashboard/src --include="*.tsx" --include="*.ts" 2>/dev/null | wc -l || echo 0)
+fi
+
+if [ $REDUCED_MOTION_CSS -gt 0 ] || [ $REDUCED_MOTION_JS -gt 0 ]; then
+  log_pass "prefers-reduced-motion support detected (CSS: $REDUCED_MOTION_CSS, JS: $REDUCED_MOTION_JS)"
+else
+  log_fail "No prefers-reduced-motion support found"
+fi
+
+FRAMER_USAGE=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ] || [ -d "packages/shared-ui/src" ]; then
+  FRAMER_USAGE=$(grep -r "from 'framer-motion'" handoff/20250928/40_App/frontend-dashboard/src packages/shared-ui/src --include="*.tsx" --include="*.ts" 2>/dev/null | wc -l || echo 0)
+fi
+log_info "Framer Motion usage: $FRAMER_USAGE files"
+
+REDUCED_MOTION_WRAPPER=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ] || [ -d "packages/shared-ui/src" ]; then
+  REDUCED_MOTION_WRAPPER=$(grep -r "withReducedMotion" handoff/20250928/40_App/frontend-dashboard/src packages/shared-ui/src --include="*.tsx" --include="*.ts" 2>/dev/null | wc -l || echo 0)
+fi
+
+if [ $REDUCED_MOTION_WRAPPER -gt 0 ]; then
+  log_pass "withReducedMotion wrapper usage detected"
+else
+  log_warn "No withReducedMotion wrapper usage found (verify manual implementation)"
+fi
 
 log_section "6. Internationalization (i18n)"
-log_todo "i18n library detection (react-i18next/i18next)"
-log_todo "i18n usage analysis (useTranslation, t() calls)"
+
+if [ -f "handoff/20250928/40_App/frontend-dashboard/package.json" ] && grep -qE "react-i18next|i18next" handoff/20250928/40_App/frontend-dashboard/package.json 2>/dev/null; then
+  log_pass "i18n library (react-i18next/i18next) installed"
+else
+  log_warn "No i18n library detected"
+fi
+
+I18N_USAGE=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ]; then
+  I18N_USAGE=$(grep -rE "useTranslation|t\(" handoff/20250928/40_App/frontend-dashboard/src --include="*.tsx" --include="*.ts" 2>/dev/null | wc -l || echo 0)
+fi
+log_info "i18n usage instances: $I18N_USAGE"
+
+if [ $I18N_USAGE -gt 100 ]; then
+  log_pass "Extensive i18n usage detected ($I18N_USAGE instances)"
+elif [ $I18N_USAGE -gt 0 ]; then
+  log_warn "Limited i18n usage ($I18N_USAGE instances) - consider expanding coverage"
+else
+  log_warn "No i18n usage detected"
+fi
 
 log_section "7. Storybook & Documentation"
-log_todo "Storybook configuration verification"
-log_todo "Story files count and coverage"
-log_todo "Visual regression tests (@vrt) detection"
-log_todo "Design system documentation files check"
+
+if [ -d "handoff/20250928/40_App/frontend-dashboard/.storybook" ]; then
+  log_pass "Storybook configuration found in frontend-dashboard"
+else
+  log_warn "No Storybook configuration in frontend-dashboard"
+fi
+
+STORY_FILES=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard/src" ]; then
+  STORY_FILES=$(find handoff/20250928/40_App/frontend-dashboard/src -name "*.stories.*" 2>/dev/null | wc -l || echo 0)
+fi
+log_info "Storybook story files: $STORY_FILES"
+
+if [ $STORY_FILES -gt 20 ]; then
+  log_pass "$STORY_FILES story files found"
+elif [ $STORY_FILES -gt 0 ]; then
+  log_warn "Only $STORY_FILES story files found - consider adding more"
+else
+  log_warn "No Storybook stories found"
+fi
+
+VRT_TESTS=0
+if [ -d "handoff/20250928/40_App/frontend-dashboard" ]; then
+  VRT_TESTS=$(grep -r "@vrt" handoff/20250928/40_App/frontend-dashboard --include="*.spec.*" --include="*.test.*" 2>/dev/null | wc -l || echo 0)
+fi
+
+if [ $VRT_TESTS -gt 0 ]; then
+  log_pass "$VRT_TESTS visual regression tests (@vrt) found"
+else
+  log_warn "No visual regression tests (@vrt) found"
+fi
+
+DOCS_MISSING=0
+for doc in "DESIGN_SYSTEM_GUIDELINES.md" "CODE_DUPLICATION_ANALYSIS.md" "SHARED_COMPONENT_MIGRATION_PLAN.md"; do
+  if [ ! -f "$doc" ]; then
+    DOCS_MISSING=$((DOCS_MISSING + 1))
+    log_info "Missing: $doc"
+  fi
+done
+
+if [ $DOCS_MISSING -eq 0 ]; then
+  log_pass "All key design system documentation files present"
+else
+  log_warn "$DOCS_MISSING key documentation file(s) missing"
+fi
 
 log_section "8. React Version Alignment"
-log_todo "React version consistency check across packages"
-log_todo "React 19 adoption verification"
+
+REACT_VERSIONS=0
+if [ -f "package.json" ]; then
+  REACT_VERSIONS=$(grep -h '"react":' package.json packages/*/package.json handoff/20250928/40_App/*/package.json 2>/dev/null | sort -u | wc -l || echo 0)
+fi
+
+if [ $REACT_VERSIONS -eq 1 ]; then
+  log_pass "React version consistent across all packages"
+else
+  log_warn "Multiple React versions detected ($REACT_VERSIONS different versions)"
+fi
+
+if [ -f "package.json" ] && grep -q '"react": "\^19' package.json 2>/dev/null; then
+  log_pass "Using React 19 (latest)"
+else
+  log_warn "Not using React 19 - consider upgrading"
+fi
 
 log_section "Audit Summary"
 
@@ -203,7 +428,7 @@ FAIL=$FAIL_COUNT
 TODO=$TODO_COUNT
 TOTAL=$TOTAL_CHECKS
 MODE=$MODE_LABEL
-NOTES=Simplified audit for CI stability. Sections 2-8 marked as TODO pending debugging.
+NOTES=All 8 audit sections enabled. Running in $MODE_LABEL mode.
 EOF
 
 log_info "Summary written to $SUMMARY_FILE"


### PR DESCRIPTION
## 描述 (Description)

繼 PR #1039 建立 relaxed mode 審計框架後，此 PR 完成 P0/P1 行動項目的步驟 2-3：**啟用所有 8 個審計區塊並準備切換為 strict mode**。

### 變更內容

**之前狀態** (PR #1039):
- ✅ 7 個基本檢查（環境、套件管理）
- ⊘ 20 個檢查標記為 TODO（sections 2-8）

**此 PR 後**:
- ✅ 26 個檢查全部啟用（20 pass, 5 warn, 1 fail）
- ⊘ 0 個 TODO

### 啟用的檢查區塊

1. **Section 2 - 元件重複分析** (2 checks)
   - 檢查 shared-ui 匯入使用率
   - 警告潛在的元件重複

2. **Section 3 - Token 強制執行** (3 checks)
   - 硬編碼 hex 顏色檢測
   - Inline styles 檢測（**閾值 50**）
   - RGB/RGBA 顏色檢測

3. **Section 4 - 無障礙合規** (4 checks)
   - eslint-plugin-jsx-a11y 安裝檢查
   - 無障礙測試工具檢查
   - 無障礙測試檔案計數
   - `<img>` alt 屬性驗證

4. **Section 5 - Motion Governance** (3 checks)
   - prefers-reduced-motion 支援檢測
   - Framer Motion 使用分析
   - withReducedMotion wrapper 檢查

5. **Section 6 - 國際化** (2 checks)
   - i18n 函式庫檢測
   - i18n 使用率分析

6. **Section 7 - Storybook & 文件** (4 checks)
   - Storybook 配置檢查
   - Story 檔案覆蓋率
   - VRT 測試檢測
   - 設計系統文件檢查

7. **Section 8 - React 版本對齊** (2 checks)
   - React 版本一致性
   - React 19 採用檢查

### 當前審計結果

```
✓ PASSED:   20 / 26
⚠ WARNINGS:  5 / 26  
✗ FAILED:    1 / 26  (86 inline styles, threshold: 50)
⊘ TODO:      0 / 26
```

**5 個警告**:
- Frontend-dashboard 有 55 個本地元件（與 shared-ui 的 47 個元件重複？）
- 79 個硬編碼 hex 顏色
- 15 個 rgb/rgba 顏色
- 13 個可能缺少 alt 屬性的 `<img>` 標籤
- 3 個不同的 React 版本

**1 個失敗**:
- 86 個 inline styles（閾值 50）

---

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 僅修改審計腳本和 CI workflow，不包含 UI 元件變更

---

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此 PR 為基礎設施變更，不包含設計或工程邏輯

---

## 人工審查重點 (Critical Review Points)

### 1. 🔴 Inline Styles 閾值設定

**問題**: 當前 codebase 有 86 個 inline styles，但閾值設為 50，導致審計失敗。

**請確認**:
- 閾值 50 是否合理？還是應該調整為更寬鬆的值（如 100）？
- 或是應該先清理 codebase 的 inline styles 再啟用此檢查？
- 在 relaxed mode 下不會阻塞 CI，但切換到 strict mode 後會阻塞所有 PR

**相關程式碼**:
```bash
# audit-design-system.sh:228-231
elif [ $INLINE_STYLES -lt 50 ]; then
  log_warn "$INLINE_STYLES instances of inline styles (acceptable if < 50)"
else
  log_fail "$INLINE_STYLES instances of inline styles (should be < 50)"
fi
```

### 2. 🟡 Hard-coded 目錄路徑

**風險**: 腳本假設特定的目錄結構存在：
- `handoff/20250928/40_App/frontend-dashboard/`
- `handoff/20250928/40_App/owner-console/`
- `packages/shared-ui/`

**請驗證**:
- 這些路徑是否在所有環境中都正確？
- 如果 repo 結構變更（例如 date-based handoff 目錄），腳本會靜默失敗（返回 0 counts）
- 是否需要更通用的路徑發現機制？

### 3. 🟡 CI 效能影響

**問題**: 腳本現在執行大量 `grep -r` 和 `find` 操作：

```bash
# 範例：每個 section 都有多個遞迴 grep
grep -r "#[0-9A-Fa-f]\{6\}" handoff/.../src packages/.../src --include="*.tsx" --include="*.ts"
grep -r "style={{" handoff/.../src packages/.../src --include="*.tsx"
grep -rE "rgb\(|rgba\(" handoff/.../src packages/.../src --include="*.tsx" --include="*.ts"
# ... 總共 ~15 個類似操作
```

**請評估**:
- CI runtime 是否明顯增加？（本地測試約 0.5-1 秒，但 CI 可能更慢）
- 是否需要優化或快取機制？

### 4. 🟡 Heuristic 檢查的準確性

**潛在問題**:
- **False positives**: Hex colors in comments (`// Use #FF0000 for errors`)
- **False negatives**: Colors in other formats (`hsl()`, CSS variables)
- **Context-insensitive**: Can't distinguish legitimate inline styles from violations

**建議**:
- 在 PR comment 提醒 reviewer 這些是啟發式檢查，可能有誤報
- 考慮加入 `--ignore` 或 `--exclude-pattern` 選項供特殊情況使用

### 5. 🟢 Relaxed Mode 為預設

**現狀**: 
- Workflow 仍使用 `--relaxed` 模式
- 1 個失敗 + 5 個警告不會阻塞 CI
- PR comment 包含切換到 strict mode 的說明

**請確認**:
- 何時計劃切換為 `--strict` mode？
- 是否需要先修復當前的 1 fail + 5 warn？
- 或是打算長期維持 relaxed mode（只監控不阻塞）？

### 6. 🟢 錯誤處理

**優點**: 所有檢查都有適當的錯誤處理：

```bash
# 範例模式
VARIABLE=$(grep ... 2>/dev/null | wc -l || echo 0)

# 目錄存在性檢查
if [ -d "path/to/dir" ]; then
  # do check
fi
```

這確保了即使目錄不存在或 grep 失敗，腳本也能繼續執行。

---

## 測試狀態

**本地測試** ✅:
```bash
# Relaxed mode
./audit-design-system.sh --relaxed
# Exit code: 0 (always passes)
# Results: 20 pass, 5 warn, 1 fail, 0 TODO

# Strict mode  
./audit-design-system.sh --strict
# Exit code: 1 (fails due to 86 inline styles)
# Results: Same as above
```

**CI 測試** ⚠️:
- 尚未在 CI 環境中驗證
- 建議合併後密切監控第一次 CI run
- 檢查 runtime、誤報率、和 PR comment 格式

---

## 後續步驟（不在此 PR 範圍）

1. **修復 1 個失敗項目**:
   - 選項 A: 調整 inline styles 閾值（50 → 100？）
   - 選項 B: 清理 codebase 的 86 個 inline styles

2. **處理 5 個警告**:
   - 元件重複分析（55 local vs 47 shared）
   - Token 違規清理（79 hex + 15 rgb/rgba）
   - 圖片 alt 屬性補充（13 個）
   - React 版本統一（3 個不同版本）

3. **切換為 Strict Mode**:
   - 時機：當 FAIL_COUNT = 0 且 WARN_COUNT 可接受時
   - 方法：修改 workflow 的 `--relaxed` → `--strict`

---

**Devin Run**: https://app.devin.ai/sessions/a2173fe8b0654dc0b1e56cc8a0042d4e  
**Requested by**: Ryan Chen (ryan2939z@gmail.com / @RC918)

**Context**: 此 PR 完成使用者要求的「1-2-3」步驟：(1) 修復失敗檢查、(2) 啟用 sections 2-8、(3) 準備 strict mode。所有 8 個審計區塊現已啟用，但保持 relaxed mode 以避免阻塞 CI。