### PR TITLE
fix(vercel): Allow preview deployments to unblock QA and testing

### DIFF
--- a/scripts/vercel-ignore.sh
+++ b/scripts/vercel-ignore.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+
+#
+
+e="${VERCEL_ENV:-}"
+r="${VERCEL_GIT_COMMIT_REF:-}"
+
+if [ "$e" = "preview" ]; then
+  echo "✅ Allowing preview deployment for branch: $r"
+  exit 1
+fi
+
+case "$r" in
+  main|production|release/*|hotfix/*)
+    echo "✅ Allowing production deployment for branch: $r"
+    exit 1
+    ;;
+  *)
+    echo "⏭️  Skipping deployment for branch: $r"
+    exit 0
+    ;;
+esac

--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
   "buildCommand": "pnpm --filter @morningai/shared-ui build && pnpm --filter frontend-dashboard build",
   "installCommand": "pnpm install --prod=false",
   "outputDirectory": "handoff/20250928/40_App/frontend-dashboard/dist",
-  "ignoreCommand": "bash -c 'env=${VERCEL_ENV:-}; ref=${VERCEL_GIT_COMMIT_REF:-}; if [ \"$env\" = \"preview\" ]; then echo \"Allowing preview: $ref\"; exit 1; fi; case \"$ref\" in main|production|release/*|hotfix/*) echo \"Allowing deploy: $ref\"; exit 1 ;; *) echo \"Skipping deploy: $ref\"; exit 0 ;; esac'",
+  "ignoreCommand": "bash ./scripts/vercel-ignore.sh",
   "rewrites": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
## 描述 (Description)

修復 `vercel.json` 配置錯誤，解決 Vercel schema 驗證失敗問題。

**問題根源**：內聯的 `ignoreCommand` 長度為 291 字元，超過 Vercel 256 字元限制，導致所有部署在 schema 驗證階段就被拒絕。

**解決方案**：
- 創建 `scripts/vercel-ignore.sh` 腳本檔案（31 字元）
- 將部署閘門邏輯移至腳本，保持相同功能
- 更新 `vercel.json` 引用腳本而非內聯命令

**部署邏輯**（未變更）：
- ✅ 允許所有 preview 部署（用於 PR QA 測試）
- ✅ 生產環境僅允許 main/production/release/*/hotfix/* 分支
- ⏭️ 其他分支跳過部署

**相關 Issue**: #767 (Task 2)  
**Devin Session**: https://app.devin.ai/sessions/04055f322bc042dea40afa8acc2f69ff  
**Requested by**: Ryan Chen (@RC918)

---

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 僅修改部署配置，不包含 UI 元件變更

---

## 人工審查重點 (Human Review Checklist)

### 🔴 Critical - Must Review

1. **驗證 Vercel 語義正確性** ⚠️
   - [ ] 確認 `exit 1` = 繼續部署（proceed with build）
   - [ ] 確認 `exit 0` = 忽略/跳過部署（skip build）
   - [ ] 驗證 preview 環境返回 `exit 1`（允許部署）
   - [ ] 驗證 production 非允許分支返回 `exit 0`（跳過部署）
   - **風險**: 如果語義錯誤，將導致所有部署邏輯反轉

2. **安全性驗證** 🔒
   - [ ] 確認允許所有 preview 部署是可接受的（用於 QA 測試）
   - [ ] 驗證生產環境限制僅允許：main, production, release/*, hotfix/*
   - [ ] 檢查腳本不包含任何敏感資訊或硬編碼密鑰

3. **腳本執行驗證**
   - [ ] 確認腳本路徑 `./scripts/vercel-ignore.sh` 從 repo 根目錄可訪問
   - [ ] 驗證腳本有執行權限（`git ls-files -s scripts/vercel-ignore.sh` 應顯示 100755）
   - [ ] 確認 bash 語法正確（set -e, parameter expansion with defaults）

### 🟡 Medium Priority

4. **環境變數處理**
   - [ ] 驗證 `${VERCEL_ENV:-}` 和 `${VERCEL_GIT_COMMIT_REF:-}` 在變數未設定時不會失敗
   - [ ] 確認不使用 `set -u`（nounset）以避免未設定變數錯誤

5. **測試驗證**
   - [ ] 合併前：創建測試 PR 確認 Vercel 開始構建 preview
   - [ ] 檢查 Vercel 構建日誌中的 echo 訊息（✅ 或 ⏭️）
   - [ ] 驗證 main 分支仍然正常部署到 production

---

## 變更細節

**字元數對比**:
- **舊版（內聯）**: 291 字元 ❌ 超過限制
- **新版（腳本）**: 31 字元 ✅ 遠低於限制

**邏輯對照表**:
| 環境 | 分支 | 舊邏輯 | 新邏輯 | 行為 |
|------|------|--------|--------|------|
| preview | 任何分支 | ❌ 被阻擋 | ✅ exit 1 | 允許部署 |
| production | main | ✅ 允許 | ✅ exit 1 | 允許部署 |
| production | feature/* | ✅ 跳過 | ✅ exit 0 | 跳過部署 |

---

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 此 PR 僅含基礎設施配置變更
- [x] 已驗證本地測試正常
- [x] 所有 CI 檢查通過（24/24）

---

## 測試計劃

**本地測試** ✅:
```bash
# Test 1: Preview environment (should allow)
VERCEL_ENV=preview VERCEL_GIT_COMMIT_REF=test bash ./scripts/vercel-ignore.sh
# Output: ✅ Allowing preview deployment
# Exit: 1 (proceed)

# Test 2: Production main (should allow)
VERCEL_ENV=production VERCEL_GIT_COMMIT_REF=main bash ./scripts/vercel-ignore.sh
# Output: ✅ Allowing production deployment
# Exit: 1 (proceed)

# Test 3: Production feature branch (should skip)
VERCEL_ENV=production VERCEL_GIT_COMMIT_REF=feature/test bash ./scripts/vercel-ignore.sh
# Output: ⏭️ Skipping deployment
# Exit: 0 (skip)
```

**Vercel 驗證** ✅:
- Frontend Dashboard preview: https://morningai-git-devin-1762086912-mvp-p0-vercel-fix-morning-ai.vercel.app
- Owner Console preview: https://owner-console-git-devin-1762086912-mvp-p0-vercel-fix-morning-ai.vercel.app

---

## 學習重點

**診斷錯誤檢討**：
此 PR 經歷了初步誤診（判斷為環境問題），後經 CTO 技術審查指正為配置錯誤（ignoreCommand 超過 256 字元限制）。感謝 @RC918 的詳細審查報告。

**改進方向**：
1. ✅ 仔細閱讀錯誤訊息（Vercel Bot 已明確指出問題）
2. ✅ 了解平台限制（Vercel 256 字元限制）
3. ✅ 正確歸因（配置錯誤 vs 環境問題）
4. ✅ 使用腳本檔案避免字元限制