### PR TITLE
fix(migrations): Update 2FA migration to use auth.users and add RLS policies

### DIFF
--- a/handoff/20250928/40_App/api-backend/migrations/add_2fa_totp_tables.sql
+++ b/handoff/20250928/40_App/api-backend/migrations/add_2fa_totp_tables.sql
@@ -1,7 +1,8 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
 CREATE TABLE IF NOT EXISTS user_2fa (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     enabled BOOLEAN DEFAULT FALSE,
     secret_encrypted TEXT NOT NULL,  -- Fernet encrypted TOTP secret (AES-128-CBC + HMAC-SHA256)
     created_at TIMESTAMP DEFAULT NOW(),
@@ -21,7 +22,7 @@ COMMENT ON COLUMN user_2fa.last_used_at IS 'Last time user successfully used TOT
 
 CREATE TABLE IF NOT EXISTS totp_backup_codes (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     code_hash TEXT NOT NULL,  -- Argon2id hash
     used BOOLEAN DEFAULT FALSE,
     used_at TIMESTAMP,
@@ -38,7 +39,7 @@ COMMENT ON COLUMN totp_backup_codes.used IS 'Whether this backup code has been u
 
 CREATE TABLE IF NOT EXISTS trusted_devices (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
     device_fingerprint TEXT NOT NULL,
     device_name TEXT,
     trusted_at TIMESTAMP DEFAULT NOW(),
@@ -56,10 +57,27 @@ COMMENT ON COLUMN trusted_devices.device_fingerprint IS 'Browser/device fingerpr
 COMMENT ON COLUMN trusted_devices.expires_at IS 'When this trusted device token expires (30 days from trusted_at)';
 
 CREATE OR REPLACE FUNCTION cleanup_expired_trusted_devices()
-RETURNS void AS $$
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
 BEGIN
     DELETE FROM trusted_devices WHERE expires_at < NOW();
 END;
-$$ LANGUAGE plpgsql;
+$$;
 
 COMMENT ON FUNCTION cleanup_expired_trusted_devices IS 'Removes expired trusted device entries (should be run periodically)';
+
+ALTER TABLE user_2fa ENABLE ROW LEVEL SECURITY;
+ALTER TABLE totp_backup_codes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE trusted_devices ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY deny_all_anon_user_2fa ON user_2fa FOR ALL TO anon USING (false) WITH CHECK (false);
+CREATE POLICY deny_all_auth_user_2fa ON user_2fa FOR ALL TO authenticated USING (false) WITH CHECK (false);
+
+CREATE POLICY deny_all_anon_backup_codes ON totp_backup_codes FOR ALL TO anon USING (false) WITH CHECK (false);
+CREATE POLICY deny_all_auth_backup_codes ON totp_backup_codes FOR ALL TO authenticated USING (false) WITH CHECK (false);
+
+CREATE POLICY deny_all_anon_trusted_devices ON trusted_devices FOR ALL TO anon USING (false) WITH CHECK (false);
+CREATE POLICY deny_all_auth_trusted_devices ON trusted_devices FOR ALL TO authenticated USING (false) WITH CHECK (false);


### PR DESCRIPTION
## 描述 (Description)

修正 2FA 資料庫 migration 檔案中的關鍵錯誤，並新增安全政策。

**背景**: PR #1048 的 migration 檔案在 production 執行時失敗，因為它參照了不存在的 `users` 表格。此專案使用 Supabase 的 `auth.users` 表格（如 `migrations/005_create_user_profiles_table.sql` 所示）。使用者已在 Supabase SQL Editor 手動執行修正後的 SQL，此 PR 將 repo 中的 migration 檔案更新為與 production 一致的版本。

### 主要變更

1. **修正外鍵參照** ⭐ CRITICAL
   - 將所有 3 個表格的外鍵從 `users(id)` 改為 `auth.users(id)`
   - 影響表格：`user_2fa`, `totp_backup_codes`, `trusted_devices`

2. **新增 pgcrypto 擴展**
   - 在檔案頂部加入 `CREATE EXTENSION IF NOT EXISTS pgcrypto;`
   - 確保 `gen_random_uuid()` 函數可用

3. **啟用 Row Level Security (RLS)**
   - 在所有 3 個表格啟用 RLS
   - 新增 deny-all 政策給 `anon` 和 `authenticated` 角色
   - 只有 `service_role`（後端）可以存取這些敏感表格

4. **強化 cleanup 函數安全性**
   - 加入 `SECURITY DEFINER` 屬性
   - 設置明確的 `search_path = public`
   - 修正 Supabase Security Advisor 的 "Function Search Path Mutable" 警告

## 人工審查重點 (Critical Review Items)

1. **外鍵參照驗證** ⭐ CRITICAL
   - [ ] 確認所有 3 個 `REFERENCES` 都改為 `auth.users(id)` 而非 `users(id)`
   - [ ] Line 5: `user_2fa.user_id` → `auth.users(id)`
   - [ ] Line 25: `totp_backup_codes.user_id` → `auth.users(id)`
   - [ ] Line 42: `trusted_devices.user_id` → `auth.users(id)`

2. **RLS 政策完整性**
   - [ ] 確認 3 個表格都有 `ENABLE ROW LEVEL SECURITY`
   - [ ] 確認每個表格都有 2 個 deny-all 政策（anon + authenticated）
   - [ ] 驗證政策命名清楚且一致

3. **函數安全性**
   - [ ] 確認 `cleanup_expired_trusted_devices()` 有 `SECURITY DEFINER`
   - [ ] 確認有明確的 `SET search_path = public`

4. **Production 一致性**
   - [ ] 此 migration 已在 Supabase Production 手動執行成功
   - [ ] 此 PR 僅更新 repo 中的檔案以匹配 production 狀態
   - [ ] 如果在已有這些表格的環境重複執行，`CREATE POLICY` 可能會失敗（無 IF NOT EXISTS 選項），但這應該是低風險的邊緣案例

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 僅包含資料庫 migration 變更

## 提醒
- [x] 此為工程 PR，僅含資料庫 Schema 修正
- [x] 沒有使用已廢棄的目錄

---

**Link to Devin run**: https://app.devin.ai/sessions/04055f322bc042dea40afa8acc2f69ff  
**Requested by**: Ryan Chen (@RC918, ryan2939z@gmail.com)

**相關 PR**: #1048 (原始 2FA Backend 實作)