### PR TITLE
P1-2: Add Cache-Control headers to CSRF endpoint

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/routes/auth_enhanced.py
+++ b/handoff/20250928/40_App/api-backend/src/routes/auth_enhanced.py
@@ -40,6 +40,10 @@ def get_csrf_token():
     This endpoint allows the frontend to bootstrap CSRF protection
     before making authenticated requests.
     
+    P1 Enhancement: Cache-Control headers to prevent token caching
+    - Ensures each request generates a fresh CSRF token
+    - Prevents browsers/proxies from serving stale tokens
+    
     Response:
         {
             "csrf_token": "abc123..."
@@ -53,6 +57,12 @@ def get_csrf_token():
         }
         
         response = make_response(jsonify(response_data), 200)
+        
+        response.headers['Cache-Control'] = (
+            'no-store, no-cache, must-revalidate, max-age=0'
+        )
+        response.headers['Pragma'] = 'no-cache'
+        response.headers['Expires'] = '0'
         
         from src.services.auth_service import create_cookie_config, ACCESS_TOKEN_EXPIRY_MINUTES
         response.set_cookie(


### PR DESCRIPTION
## 描述 (Description)

此 PR 為 P1-2 後端 CSRF endpoint 強化，在 `/api/auth/v2/csrf` endpoint 新增 Cache-Control headers 以防止 CSRF token 被瀏覽器或代理伺服器快取。

### 變更內容

在 CSRF token endpoint 回應中新增三個 HTTP headers：

1. **Cache-Control**: `no-store, no-cache, must-revalidate, max-age=0`
   - 防止瀏覽器快取 CSRF tokens
   - 確保每次請求都產生新的 token
   
2. **Pragma**: `no-cache`
   - HTTP/1.0 向後相容
   - 額外的快取防止層
   
3. **Expires**: `0`
   - 明確的過期時間設定
   - 確保舊版客戶端不會快取

### 問題背景

在跨域認證場景 (admin.gm365.me → morningai-backend-v2.onrender.com) 中，若 CSRF token 被快取，可能導致：
- 使用過期的 token 造成 403/419 錯誤
- 多分頁場景下 token 不同步
- 安全性降低（舊 token 被重複使用）

### 測試建議

**手動測試（使用 curl）：**
```bash
curl -i https://morningai-backend-v2.onrender.com/api/auth/v2/csrf
```

**驗證項目：**
- ✅ Response headers 包含 `Cache-Control: no-store, no-cache, must-revalidate, max-age=0`
- ✅ Response headers 包含 `Pragma: no-cache`
- ✅ Response headers 包含 `Expires: 0`
- ✅ 多次請求回傳不同的 `csrf_token` 值（未被快取）
- ✅ 前端可正常取得 CSRF token

**人工審查重點：**
- [ ] 確認 headers 在實際部署環境中正確設定
- [ ] 驗證 CSRF token flow 仍正常運作（未破壞現有功能）
- [ ] 確認沒有效能影響（強制 no-cache 不會造成過多請求）

### 相關 PRs

- #1052 (P1-1): 前端 CSRF 防呆程式設計
- #1049 (P0): CSRF token JSON flow 修復
- P1-3 (待建立): E2E 和單元測試（將包含此 header 的自動化測試）

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 為後端 API 變更，不包含 UI 元件

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR，僅含 API/邏輯變更

---

**Note**: 此檔案存在既有的 flake8 warnings (空白、未使用的 imports 等)，但與本次變更無關。我的變更已通過 flake8 檢查（line 61-65）。

**Link to Devin run**: https://app.devin.ai/sessions/eedc97f82ced480c88c2eecb5d729878  
**Requested by**: Ryan Chen (@RC918)