### PR TITLE
fix(security): Comprehensive Security Advisor fixes - RLS policies and function hardening

### DIFF
--- a/handoff/20250928/40_App/api-backend/migrations/security_advisor_fixes.sql
+++ b/handoff/20250928/40_App/api-backend/migrations/security_advisor_fixes.sql
@@ -1,0 +1,122 @@
+-- 
+
+
+CREATE OR REPLACE FUNCTION public.update_updated_at_column()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = 'pg_temp'
+AS $$
+BEGIN
+    NEW.updated_at = timezone('utc', now());
+    RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.update_updated_at_column IS 'Trigger function to auto-update updated_at column (search_path secured)';
+
+CREATE OR REPLACE FUNCTION public.cleanup_expired_trusted_devices()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = 'pg_temp'
+AS $$
+BEGIN
+    DELETE FROM public.trusted_devices WHERE expires_at < now();
+END;
+$$;
+
+COMMENT ON FUNCTION public.cleanup_expired_trusted_devices IS 'Removes expired trusted device entries (search_path secured)';
+
+
+ALTER TABLE public.agents ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public.tasks ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE public."user" ENABLE ROW LEVEL SECURITY;
+
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'agents' 
+        AND policyname = 'deny_all_anon_agents'
+    ) THEN
+        CREATE POLICY deny_all_anon_agents ON public.agents 
+        FOR ALL TO anon 
+        USING (false) 
+        WITH CHECK (false);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'agents' 
+        AND policyname = 'deny_all_auth_agents'
+    ) THEN
+        CREATE POLICY deny_all_auth_agents ON public.agents 
+        FOR ALL TO authenticated 
+        USING (false) 
+        WITH CHECK (false);
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'tasks' 
+        AND policyname = 'deny_all_anon_tasks'
+    ) THEN
+        CREATE POLICY deny_all_anon_tasks ON public.tasks 
+        FOR ALL TO anon 
+        USING (false) 
+        WITH CHECK (false);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'tasks' 
+        AND policyname = 'deny_all_auth_tasks'
+    ) THEN
+        CREATE POLICY deny_all_auth_tasks ON public.tasks 
+        FOR ALL TO authenticated 
+        USING (false) 
+        WITH CHECK (false);
+    END IF;
+END $$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'user' 
+        AND policyname = 'deny_all_anon_user'
+    ) THEN
+        CREATE POLICY deny_all_anon_user ON public."user" 
+        FOR ALL TO anon 
+        USING (false) 
+        WITH CHECK (false);
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies 
+        WHERE schemaname = 'public' 
+        AND tablename = 'user' 
+        AND policyname = 'deny_all_auth_user'
+    ) THEN
+        CREATE POLICY deny_all_auth_user ON public."user" 
+        FOR ALL TO authenticated 
+        USING (false) 
+        WITH CHECK (false);
+    END IF;
+END $$;
+
+
+COMMENT ON TABLE public.agents IS 'Agent Registry - RLS enabled, backend service_role access only';
+COMMENT ON TABLE public.tasks IS 'Task Router - RLS enabled, backend service_role access only';
+COMMENT ON TABLE public."user" IS 'User table - RLS enabled, backend service_role access only';


### PR DESCRIPTION
## 描述 (Description)

此 PR 修復 Supabase Security Advisor 顯示的 3 個錯誤和 2 個警告，強化資料庫安全性。

**修復內容：**

### 1. 函數 Search Path 安全性強化 ⭐ CRITICAL
- 重新建立 `update_updated_at_column()` 函數，設置 `SET search_path = 'pg_temp'` 並完全限定物件參照
- 重新建立 `cleanup_expired_trusted_devices()` 函數，同樣設置 `SET search_path = 'pg_temp'`
- 變更 `NOW()` 為 `timezone('utc', now())` 以確保 UTC 時區一致性

### 2. 啟用 Row Level Security (RLS) ⭐ CRITICAL  
在以下表格啟用 RLS：
- `public.agents`
- `public.tasks`
- `public."user"` （注意：user 是保留字，需要引號）

### 3. 建立 RLS 政策 ⭐ CRITICAL
為每個表格建立 deny-all 政策：
- 拒絕 `anon` 角色的所有操作
- 拒絕 `authenticated` 角色的所有操作
- 只允許 `service_role`（後端）存取這些表格
- 使用 DO 區塊確保冪等性（避免重複建立政策）

## ⚠️ 重大影響警告

**這個 migration 會立即影響資料表存取權限！**

### 必須在合併前確認：
1. **後端是否使用 `service_role` 存取這些表格？**
   - ✅ 如果是：可以安全合併
   - ❌ 如果使用 anon/authenticated JWT：會立即中斷功能

2. **前端是否直接透過 PostgREST 存取這些表格？**
   - ✅ 如果沒有：可以安全合併  
   - ❌ 如果有：需要先修改前端改用後端 API

3. **時區變更影響**
   - `NOW()` → `timezone('utc', now())`
   - 需確認現有 trigger 行為不受影響

## 人工審查重點 (Critical Review Items)

### 🔴 P0 - Production Breaking 風險
- [ ] **確認後端使用 service_role 存取 agents/tasks/user 表格**（而非 anon/authenticated）
- [ ] **確認前端沒有直接透過 PostgREST 存取這些表格**
- [ ] **在 staging 環境測試後再部署到 production**

### 🟡 P1 - 功能正確性
- [ ] 驗證 `timezone('utc', now())` 不影響現有 trigger 行為
- [ ] 確認 `"user"` 表格的引號處理正確（第 98 行檢查 `tablename = 'user'` 可能需要引號）
- [ ] 檢查函數重新建立不影響進行中的交易

### 🟢 P2 - 程式碼品質
- [ ] DO 區塊的冪等性邏輯正確
- [ ] 所有物件參照都已完全限定 schema（`public.table_name`）
- [ ] 註解清楚說明安全性增強

## 已知限制

1. **無法本地測試**：需要實際 Supabase 資料庫環境才能驗證
2. **政策不可更新**：DO 區塊只檢查政策是否存在，不會更新已存在的政策定義
3. **使用者已手動執行部分修復**：此 PR 主要是將修復標準化到 migration 檔案中

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 僅包含資料庫 migration 變更

## 提醒
- [x] 此為工程 PR，僅含資料庫安全性修正
- [x] 沒有使用已廢棄的目錄

---

**Link to Devin run**: https://app.devin.ai/sessions/560c0fcf99364ef3a0cb4290434a2eb8  
**Requested by**: Ryan Chen (@RC918, ryan2939z@gmail.com)

**相關 Issue**: Supabase Security Advisor - 3 errors, 5 warnings

**建議測試步驟**：
1. 在 staging 執行此 migration
2. 測試後端 API 是否正常存取 agents/tasks/user 表格
3. 確認前端功能不受影響
4. 檢查 Security Advisor 是否清除這些錯誤和警告
5. 通過後再部署到 production