### PR TITLE
P1: Fix Backend uvicorn reference in ENVIRONMENTS.md

### DIFF
--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -261,7 +261,7 @@ For complete staging environment setup instructions, see:
 #### Backend API
 - **URL**: http://localhost:8000
 - **Runtime**: Python 3.12+
-- **Start Command**: `uvicorn src.main:app --reload`
+- **Start Command**: `export FLASK_APP=src.main && flask run --port 8000`
 - **Working Directory**: `handoff/20250928/40_App/api-backend`
 
 #### Orchestrator API


### PR DESCRIPTION
## 描述 (Description)

修正 `docs/ENVIRONMENTS.md` 中 Backend 本地開發啟動指令的框架錯誤。Backend 實際使用 **Flask**，但文件中誤用了 FastAPI 的 `uvicorn` 指令。

**變更內容**：
- 將 Backend 啟動指令從 `uvicorn src.main:app --reload` 改為 `export FLASK_APP=src.main && flask run --port 8000`

**背景**：此為 PR #1064 的 P1 後續修復。PR #1064 已修正 `ONBOARDING_GUIDE.md` 和 `PROJECT_STRUCTURE_REPORT.md` 中的相同問題，但遺漏了 `ENVIRONMENTS.md`。

---

## ⚠️ 人工審查重點

### 🔴 必須驗證（最高優先級）

1. **Flask 指令正確性**
   ```bash
   cd handoff/20250928/40_App/api-backend
   export FLASK_APP=src.main
   flask run --port 8000
   ```
   - [ ] 在實際本地環境測試此指令是否能成功啟動 Backend
   - [ ] 驗證 Flask app 變數名稱確實是 `app`（位於 `src/main.py:99`）
   - [ ] 確認 port 8000 是正確的 Backend 端口

2. **文件一致性**
   - [ ] 驗證此修復與 PR #1064 中 `ONBOARDING_GUIDE.md:209` 的修復一致
   - [ ] 確認 line 270 的 Orchestrator 仍使用 `uvicorn`（正確，因為 Orchestrator 是 FastAPI）

3. **Backend 框架驗證**
   ```bash
   # 再次確認 Backend 確實使用 Flask
   grep -n "from flask import" handoff/20250928/40_App/api-backend/src/main.py
   # 應該在 line 27 看到 Flask import
   ```

---

## 🚨 已知風險

1. **未經本地測試**: Flask 指令未在實際環境執行過，僅透過程式碼審查驗證
2. **可能需要額外環境變數**: 如果 Backend 啟動需要特定環境變數或配置，文件可能需要補充說明
3. **Working Directory 依賴**: 指令假設從 `handoff/20250928/40_App/api-backend` 目錄執行

---

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 僅修改技術文件（ENVIRONMENTS.md），無用戶可見 UI 變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] 純文件變更，無程式碼修改
- [x] CI 檢查通過（預期）

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 純文件 PR，不涉及程式碼邏輯

---

**風險等級**: 🟡 低-中等
- 純文件變更，不影響運行時功能
- 但文件準確性對開發者體驗至關重要
- 主要風險：命令未經實際測試

**相關 PR**: Follow-up to #1064  
**Link to Devin run**: https://app.devin.ai/sessions/6c521e7deed448e39a66c1b82f498e4b  
**Requested by**: Ryan Chen (@RC918, ryan2939z@gmail.com)