### PR TITLE
P1: Fix Lint Violations in check_heartbeat.py

### DIFF
--- a/.github/scripts/check_heartbeat.py
+++ b/.github/scripts/check_heartbeat.py
@@ -1,29 +1,58 @@
-import os,sys,time,json,redis,datetime as dt
-r=redis.from_url(os.environ['REDIS_URL']); now=time.time()
-active={ w.decode().split(':')[-1] for w in r.smembers('rq:workers') }  # 目前存活 worker_id 集合
-stale=[]; purged=[]; corrupted_cleanup=[]
+import os
+import sys
+import time
+import json
+import redis
+import datetime as dt
+
+r = redis.from_url(os.environ['REDIS_URL'])
+now = time.time()
+# 目前存活 worker_id 集合
+active = {w.decode().split(':')[-1] for w in r.smembers('rq:workers')}
+stale = []
+purged = []
+corrupted_cleanup = []
+
 for k in r.scan_iter('worker:heartbeat:*'):
-    key=k.decode(); val=(r.get(k) or b'{}').decode()
+    key = k.decode()
+    val = (r.get(k) or b'{}').decode()
     try:
-        m=json.loads(val); ts=m.get('last_heartbeat') or m.get('lastHeartbeat')
-        t=dt.datetime.fromisoformat(str(ts).replace('Z','+00:00')).timestamp()
-    except Exception: t=0
-    age=int(now-t) if t else 999999
-    wid=key.split(':')[-1]
-    
-    # Force-cleanup corrupted workers (age=999999 = unparseable heartbeat)
+        m = json.loads(val)
+        ts = m.get('last_heartbeat') or m.get('lastHeartbeat')
+        t = dt.datetime.fromisoformat(
+            str(ts).replace('Z', '+00:00')
+        ).timestamp()
+    except Exception:
+        t = 0
+    age = int(now - t) if t else 999999
+    wid = key.split(':')[-1]
+
+    # Force-cleanup corrupted workers
+    # (age=999999 = unparseable heartbeat)
     if age >= 999999:
         r.delete(k)
-        r.srem('rq:workers', wid)  # Also remove from active workers set (important-comment)
+        r.srem('rq:workers', wid)
         corrupted_cleanup.append((key, wid))
         continue
-    
+
     if wid not in active:
-        if age>600: r.delete(k); purged.append(key)   # 清理孤兒鍵（>10m）
-        continue                                      # 不納入判斷
-    if age>120: stale.append((key,age))
+        # 清理孤兒鍵（>10m）
+        if age > 600:
+            r.delete(k)
+            purged.append(key)
+        continue
+    if age > 120:
+        stale.append((key, age))
+
 if stale:
-    print("Stale active heartbeats:", stale); sys.exit(1)
-print(f"OK: active heartbeats fresh; purged_orphans={len(purged)}; corrupted_cleanup={len(corrupted_cleanup)}")
+    print("Stale active heartbeats:", stale)
+    sys.exit(1)
+
+print(
+    f"OK: active heartbeats fresh; "
+    f"purged_orphans={len(purged)}; "
+    f"corrupted_cleanup={len(corrupted_cleanup)}"
+)
+
 if corrupted_cleanup:
     print(f"Cleaned up corrupted workers: {corrupted_cleanup}")


### PR DESCRIPTION
## 描述 (Description)

修復 `.github/scripts/check_heartbeat.py` 中的 40+ flake8 lint 違規。此腳本用於監控 Redis worker heartbeat 健康狀態，之前使用壓縮/minified 風格撰寫導致大量 lint 錯誤。

**變更內容**:
- ✅ 分離單行多個 import（E401）
- ✅ 在運算符周圍添加空白（E225, E231）
- ✅ 拆分過長的行（>79 字元，E501）
- ✅ 移除單行多個語句（E702, E701）
- ✅ 修復空白行的空白字元（W293）
- ✅ 改善整體程式碼可讀性

**重要**: 這是純格式化變更，沒有修改任何功能邏輯。所有 Redis 操作、條件判斷、錯誤處理保持完全相同。

**相關 Issue**: #1063

---

## i18n 檢查清單（強制）

- [x] **不適用** - 此 PR 為純程式碼格式化變更，無用戶可見字串

## 設計系統檢查 (Design System Checklist)

- [x] **不適用** - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] Flake8 通過：40+ 違規已全部修復
- [x] 功能邏輯完全保留（純格式化變更）
- [x] 程式碼遵循 PEP 8 風格指南

---

## 人工審查檢查項目

請特別注意以下高風險區域：

1. **Datetime 解析邏輯** (lines 21-23)：
   ```python
   t = dt.datetime.fromisoformat(
       str(ts).replace('Z', '+00:00')
   ).timestamp()
   ```
   - 確認多行拆分沒有破壞邏輯
   - 驗證括號配對正確

2. **Stale worker 檢測** (lines 44-45, 47-48)：
   ```python
   if age > 120:
       stale.append((key, age))
   ```
   - 確認條件判斷（`age > 120`, `age > 600`）保持不變
   - 驗證 tuple 格式 `(key, age)` 正確

3. **Redis 操作**：
   - `r.delete(k)` - 刪除 key
   - `r.srem('rq:workers', wid)` - 從集合移除
   - 確認所有操作順序和條件保持一致

4. **輸出訊息**：
   - 分行的 f-string (lines 51-54) 輸出應與原始相同
   - 驗證沒有意外的換行或空白

---

**測試限制**: 此腳本需要 Redis 連線和特定環境設置，無法在開發環境輕易測試。建議在 CI/CD 中觀察首次運行。

**Link to Devin run**: https://app.devin.ai/sessions/6c521e7deed448e39a66c1b82f498e4b  
**Requested by**: Ryan Chen (@RC918)