### PR TITLE
fix: Correct environment variable count from 53 to 56

### DIFF
--- a/config/env.schema.yaml
+++ b/config/env.schema.yaml
@@ -1,10 +1,10 @@
 version: '1.0'
 description: 'Morning AI Phase 11 Complete Environment Schema'
 metadata:
-  total_variables: 53
+  total_variables: 56
   required_variables: 19
-  optional_variables: 34
-  last_updated: '2025-10-13'
+  optional_variables: 37
+  last_updated: '2025-11-03'
 
 fields:
   

--- a/docs/PROJECT_STRUCTURE_REPORT.md
+++ b/docs/PROJECT_STRUCTURE_REPORT.md
@@ -513,7 +513,7 @@ MorningAI has two separate frontend applications with distinct purposes and boun
 **Purpose**: Canonical definition of all environment variables across the entire application
 
 **Key Features**:
-- 53 total variables (19 required, 34 optional)
+- 56 total variables (19 required, 37 optional)
 - Categorized by purpose (Authentication, Security, Database, Cloud Services, etc.)
 - Type validation (secret, url, string, boolean, integer)
 - Security level classification (critical, secret, public)

--- a/docs/config/env_schema.md
+++ b/docs/config/env_schema.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Morning AI uses a comprehensive environment configuration system with **53 variables** across 11 categories. This document provides the complete reference for all environment variables, their security levels, and usage guidelines.
+Morning AI uses a comprehensive environment configuration system with **56 variables** across 11 categories. This document provides the complete reference for all environment variables, their security levels, and usage guidelines.
 
 **Schema Location**: `/config/env.schema.yaml`  
 **Example File**: `/.env.example`  
@@ -295,6 +295,6 @@ else:
 
 ---
 
-**Last Updated**: Phase 11 Task 4 (2025-10-13)  
-**Total Variables**: 53 (19 required, 34 optional)  
+**Last Updated**: Phase 11 Task 4 (2025-11-03)  
+**Total Variables**: 56 (19 required, 37 optional)  
 **Maintainer**: Morning AI Engineering Team

--- a/scripts/generate-env-examples.py
+++ b/scripts/generate-env-examples.py
@@ -98,8 +98,13 @@ def main():
     print(f"📖 Loading schema from: {schema_path}")
     schema = load_schema(schema_path)
     
+    fields = schema.get('fields', {})
+    total_count = len(fields)
+    required_count = sum(1 for v in fields.values() if v.get('required', False))
+    optional_count = total_count - required_count
+    
     print(f"📊 Schema version: {schema.get('version')}")
-    print(f"📊 Total variables: {schema.get('metadata', {}).get('total_variables')}")
+    print(f"📊 Total variables: {total_count} ({required_count} required, {optional_count} optional)")
     print("")
     
     backend_categories = [


### PR DESCRIPTION
## 描述 (Description)

修復環境變數計數不一致問題：metadata 顯示 53 個變數，但實際 `fields` 區段有 56 個變數。

**問題根源**:
- `config/env.schema.yaml` metadata 過期（顯示 53 total, 34 optional）
- 實際欄位數量：56 total, 37 optional
- `scripts/generate-env-examples.py` 讀取 metadata 而非計算實際數量

**變更內容**:
1. 更新 `config/env.schema.yaml` metadata: 53 → 56 total, 34 → 37 optional
2. 改進 `scripts/generate-env-examples.py`: 動態計算實際欄位數量，不再依賴 metadata
3. 更新文檔引用: `docs/config/env_schema.md` 和 `docs/PROJECT_STRUCTURE_REPORT.md`

**驗證結果**:
```bash
$ python3 scripts/generate-env-examples.py
📊 Total variables: 56 (19 required, 37 optional) ✅
```

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅元數據和文檔更新）

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] 僅文檔和腳本輸出變更，無邏輯錯誤風險
- [x] 腳本已測試，輸出正確
- [x] 動態計算邏輯正確（計算 required vs optional）

## 人工審查重點 (Human Review Checklist)

**關鍵審查項目** ⚠️:

1. **驗證實際欄位數量**:
   ```bash
   # 確認 config/env.schema.yaml 的 fields 區段確實有 56 個欄位
   python3 -c "import yaml; print(len(yaml.safe_load(open('config/env.schema.yaml'))['fields']))"
   # 應該輸出: 56
   ```

2. **檢查遺漏的引用**:
   ```bash
   # 搜尋是否還有其他地方引用 "53 variables"
   grep -r "53.*variables\|variables.*53" . --exclude-dir=.git
   ```

3. **驗證計算邏輯**:
   - 檢查 `scripts/generate-env-examples.py` 的動態計算是否正確
   - 確認 required (19) + optional (37) = total (56)

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 此為文檔/元數據 PR（P2 優先級）
- [x] 無功能變更，僅修正計數準確性

---

**影響範圍**: P2 - 純粹修正顯示數字，無功能影響  
**Link to Devin run**: https://app.devin.ai/sessions/eedc97f82ced480c88c2eecb5d729878  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918

**相關 PR**: 
- PR #1065: 引入環境配置統一系統（已合併）
- PR #1080, #1083: 腳本命名統一（已合併）