### PR TITLE
feat: improve verification script robustness and portability (Problem 3)

### DIFF
--- a/scripts/verify_system_state.sh
+++ b/scripts/verify_system_state.sh
@@ -45,8 +45,8 @@ echo "========================================="
 echo ""
 
 echo "1. Verifying React versions..."
-FRONTEND_REACT=$(grep -A 1 '"react":' handoff/20250928/40_App/frontend-dashboard/package.json | grep -oP '\d+\.\d+\.\d+' | head -1)
-OWNER_REACT=$(grep -A 1 '"react":' handoff/20250928/40_App/owner-console/package.json | grep -oP '\d+\.\d+\.\d+' | head -1)
+FRONTEND_REACT=$(grep '"react":' handoff/20250928/40_App/frontend-dashboard/package.json | sed -E 's/[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | head -1)
+OWNER_REACT=$(grep '"react":' handoff/20250928/40_App/owner-console/package.json | sed -E 's/[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/' | head -1)
 
 if [[ "$FRONTEND_REACT" == "19.1.0" ]]; then
     check_pass "frontend-dashboard React version: $FRONTEND_REACT"
@@ -87,13 +87,29 @@ else
     check_fail "Vector API NOT found at src/routes/vectors.py"
 fi
 
+if grep -R -qE 'vector\s*\(\s*[0-9]+\s*\)' migrations/ agents/*/migrations/ 2>/dev/null; then
+    check_pass "pgvector columns actively used in migrations (e.g., vector(1536))"
+    log_verbose "$(grep -R -E 'vector\s*\(\s*[0-9]+\s*\)' migrations/ agents/*/migrations/ 2>/dev/null | wc -l) vector column definitions found"
+else
+    check_warn "No vector column definitions found (extension created but not yet used)"
+fi
+
 echo ""
 echo "3. Verifying dual orchestrator architecture..."
 
-if awk '/- key: USE_LANGGRAPH/{getline; if ($0 ~ /value: false/) ok=1} END{exit(ok?0:1)}' render.yaml 2>/dev/null; then
-    check_pass "USE_LANGGRAPH=false in render.yaml"
+if command -v yq >/dev/null 2>&1; then
+    USE_LANGGRAPH_VALUE=$(yq eval '.services[] | select(.envVars[] | select(.key == "USE_LANGGRAPH")) | .envVars[] | select(.key == "USE_LANGGRAPH") | .value' render.yaml 2>/dev/null | head -1)
+    if [[ "$USE_LANGGRAPH_VALUE" == "false" ]]; then
+        check_pass "USE_LANGGRAPH=false in render.yaml (verified with yq)"
+    else
+        check_fail "USE_LANGGRAPH flag not set to false in render.yaml (got: $USE_LANGGRAPH_VALUE)"
+    fi
 else
-    check_fail "USE_LANGGRAPH flag not set to false in render.yaml"
+    if awk '/- key: USE_LANGGRAPH/{getline; if ($0 ~ /value: false/) ok=1} END{exit(ok?0:1)}' render.yaml 2>/dev/null; then
+        check_pass "USE_LANGGRAPH=false in render.yaml (verified with awk)"
+    else
+        check_fail "USE_LANGGRAPH flag not set to false in render.yaml"
+    fi
 fi
 
 if grep -q "handoff/.*/orchestrator" render.yaml; then
@@ -162,8 +178,9 @@ for file in "${PHASE_FILES[@]}"; do
     fi
 done
 
-if grep -q "^from phase[4-7]" handoff/20250928/40_App/api-backend/src/main.py 2>/dev/null; then
+if grep -qE '^(from|import)[[:space:]]+phase[4-7]' handoff/20250928/40_App/api-backend/src/main.py 2>/dev/null; then
     check_fail "main.py directly imports Phase API modules (should be lazy loaded)"
+    log_verbose "Found: $(grep -E '^(from|import)[[:space:]]+phase[4-7]' handoff/20250928/40_App/api-backend/src/main.py 2>/dev/null)"
 else
     check_pass "main.py does NOT directly import Phase API modules"
 fi


### PR DESCRIPTION
## 描述 (Description)

This PR implements **Problem 3 improvements** from the CTO assessment follow-up, enhancing the verification script's robustness and cross-platform compatibility.

### Changes

**High Priority (macOS Compatibility):**
1. **Replace `grep -oP` with POSIX-compatible `sed -E`** for React version extraction
   - Eliminates dependency on Perl regex (not available on macOS)
   - Pattern: `sed -E 's/[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/'`

2. **Add `yq` support with `awk` fallback** for YAML parsing
   - Uses `yq` for robust YAML parsing when available
   - Falls back to existing `awk` solution if `yq` not installed
   - More resilient to YAML format changes

**Medium Priority (Verification Accuracy):**
3. **Add pgvector usage verification** beyond just extension creation
   - New check: searches for `vector(1536)` column definitions in migrations
   - Validates actual usage, not just `CREATE EXTENSION`
   - Adds verbose logging showing count of vector columns found

4. **Expand Phase API import detection** to catch more patterns
   - Old: Only checked `^from phase[4-7]`
   - New: Checks `^(from|import)[[:space:]]+phase[4-7]`
   - Catches both import styles with verbose logging

### Results
- ✅ Total checks: **30** (was 29 - added pgvector usage check)
- ✅ macOS compatible (no `grep -P` dependency)
- ✅ More robust YAML parsing (`yq` preferred, `awk` fallback)
- ✅ Better pgvector verification (extension + actual usage)
- ✅ Stricter Phase API import detection

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（bash script only）

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] 所有測試通過：Script verified locally with `--verbose` flag
- [x] 程式碼遵循現有模式和慣例
- [x] 無 TypeScript/ESLint issues (not applicable - bash script)

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
- [x] 避免使用已廢棄的目錄

## 🔍 Human Review Checklist

**Critical Items:**

1. **⚠️ macOS Compatibility (UNTESTED)**: The `sed -E` pattern was only tested on Linux. Please verify on macOS:
   ```bash
   # Test the sed pattern on macOS
   grep '"react":' handoff/20250928/40_App/frontend-dashboard/package.json | sed -E 's/[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*/\1/'
   # Should output: 19.1.0
   ```

2. **yq Installation Check**: Verify the `command -v yq` detection works correctly. Test both scenarios:
   - With `yq` installed: Should show "verified with yq"
   - Without `yq`: Should show "verified with awk"

3. **Regex Pattern Risk**: The new sed pattern `[^0-9]*([0-9]+\.[0-9]+\.[0-9]+).*` is more permissive than `grep -oP '\d+\.\d+\.\d+'`. Could it match version numbers in unexpected places (e.g., comments)?

4. **Check Count Increase**: Total checks increased from 29 → 30. This is intentional (new pgvector usage check) but verify the baseline expectations are updated.

5. **Phase API Import Pattern**: Verify the expanded regex `^(from|import)[[:space:]]+phase[4-7]` doesn't have false positives:
   ```bash
   # Should NOT match:
   # - "# from phase4_meta_agent_api import something" (commented)
   # - "  from phase4..." (indented - not at line start)
   ```

**Medium Priority:**

- Verify pgvector usage check finds the right patterns in migrations
- Test script behavior when package.json or render.yaml format changes
- Ensure verbose mode shows useful debugging info for all new checks

**Low Priority:**

- Check that error messages are clear and actionable
- Verify the script still passes in CI/CD environments

---

**Link to Devin run**: https://app.devin.ai/sessions/ffb0dd0eb22743b5aaffea4348e083ac  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918  
**Related**: Problem 3 from CTO assessment follow-up