### PR TITLE
fix(2fa): Fix password verification for Supabase users in TOTP endpoints

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/routes/totp.py
+++ b/handoff/20250928/40_App/api-backend/src/routes/totp.py
@@ -25,6 +25,7 @@ from supabase import create_client
 
 from ..services.auth_service import (
     get_user_by_id,
+    authenticate_user,
     FEATURE_2FA_PREAUTH,
     COOKIE_SECURE
 )
@@ -118,7 +119,8 @@ def setup_totp():
         if not user:
             return jsonify({'error': 'User not found'}), 404
         
-        if not check_password_hash(user.get('hashed_password', ''), password):
+        # Supabase users don't have hashed_password in the user object, so we use authenticate_user
+        if not authenticate_user(user.get('email'), password):
             return jsonify({'error': 'Invalid password'}), 401
         
         supabase_url = os.environ.get('SUPABASE_URL')
@@ -279,7 +281,8 @@ def disable_totp():
         if not user:
             return jsonify({'error': 'User not found'}), 404
         
-        if not check_password_hash(user.get('hashed_password', ''), password):
+        # Supabase users don't have hashed_password in the user object, so we use authenticate_user
+        if not authenticate_user(user.get('email'), password):
             return jsonify({'error': 'Invalid password'}), 401
         
         supabase_url = os.environ.get('SUPABASE_URL')
@@ -349,7 +352,8 @@ def regenerate_backup_codes():
         if not user:
             return jsonify({'error': 'User not found'}), 404
         
-        if not check_password_hash(user.get('hashed_password', ''), password):
+        # Supabase users don't have hashed_password in the user object, so we use authenticate_user
+        if not authenticate_user(user.get('email'), password):
             return jsonify({'error': 'Invalid password'}), 401
         
         supabase_url = os.environ.get('SUPABASE_URL')

--- a/handoff/20250928/40_App/api-backend/tests/test_totp_api.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_totp_api.py
@@ -79,8 +79,8 @@ class TestTOTPSetup:
     @patch('src.routes.totp.get_totp_manager')
     @patch('src.routes.totp.get_backup_manager')
     @patch('src.routes.totp.get_user_by_id')
-    @patch('src.routes.totp.check_password_hash')
-    def test_setup_totp_success(self, mock_check_password, mock_get_user, mock_backup_manager, mock_totp_manager, client, mock_supabase, mock_user_id):
+    @patch('src.routes.totp.authenticate_user')
+    def test_setup_totp_success(self, mock_authenticate, mock_get_user, mock_backup_manager, mock_totp_manager, client, mock_supabase, mock_user_id):
         """Test successful TOTP setup."""
         mock_totp = MagicMock()
         mock_totp.generate_secret.return_value = 'TEST_SECRET_BASE32'
@@ -95,10 +95,9 @@ class TestTOTPSetup:
         
         mock_get_user.return_value = {
             'id': mock_user_id,
-            'email': 'test@example.com',
-            'hashed_password': 'hashed_password'
+            'email': 'test@example.com'
         }
-        mock_check_password.return_value = True
+        mock_authenticate.return_value = {'id': mock_user_id, 'email': 'test@example.com'}
         
         mock_supabase.table.return_value.select.return_value.eq.return_value.execute.return_value.data = []
         
@@ -131,15 +130,14 @@ class TestTOTPSetup:
         assert 'Password confirmation required' in data['error']
     
     @patch('src.routes.totp.get_user_by_id')
-    @patch('src.routes.totp.check_password_hash')
-    def test_setup_totp_invalid_password(self, mock_check_password, mock_get_user, client, mock_user_id, auth_headers):
+    @patch('src.routes.totp.authenticate_user')
+    def test_setup_totp_invalid_password(self, mock_authenticate, mock_get_user, client, mock_user_id, auth_headers):
         """Test TOTP setup with invalid password."""
         mock_get_user.return_value = {
             'id': mock_user_id,
-            'email': 'test@example.com',
-            'hashed_password': 'hashed_password'
+            'email': 'test@example.com'
         }
-        mock_check_password.return_value = False
+        mock_authenticate.return_value = None
         
         response = client.post(
             '/api/auth/v2/totp/setup',


### PR DESCRIPTION
## 描述 (Description)

**Critical Bug Fix**: 修復 Supabase 用戶無法設定/管理 2FA 的問題

### 🐛 問題
當 Supabase 用戶嘗試設定 2FA 時，`setup_totp`、`disable_totp` 和 `regenerate_backup_codes` 端點會返回 `401 Invalid password` 錯誤，即使密碼正確。

**根本原因**: 這些端點使用 `check_password_hash(user.get('hashed_password', ''), password)` 來驗證密碼，但 Supabase Admin API 返回的用戶對象不包含 `hashed_password` 欄位，導致驗證永遠失敗。

### ✅ 解決方案
將密碼驗證改為使用 `authenticate_user(email, password)`，該函數：
- ✅ 對 Supabase 用戶使用 Supabase Auth API 驗證
- ✅ 對 mock 用戶使用 `check_password_hash` 驗證（開發環境）
- ✅ 統一驗證邏輯，避免重複代碼

### 📝 變更內容
- **修改的端點** (3 個):
  - `setup_totp` (line 122)
  - `disable_totp` (line 284)
  - `regenerate_backup_codes` (line 355)
- **測試更新**: 2 個測試改為 mock `authenticate_user` 而非 `check_password_hash`
- **新增 import**: `authenticate_user` 加入 `totp.py`

---

## ⚠️ 重要審查事項 (Critical Review Items)

### 🔴 **必須在 Staging 測試 (MUST TEST ON STAGING)**
此修復僅通過單元測試，**必須**在 Staging 環境使用真實 Supabase 用戶測試：
1. 用 `ryan2939x@gmail.com` 測試 2FA setup
2. 驗證密碼驗證正常工作
3. 確認 Pre-Auth Token 流程完整可用

**在 Production 部署前必須完成此測試！**

### 🔒 **安全性考量**
- ✅ `authenticate_user` 使用 Supabase Auth API，與 login 流程一致
- ⚠️ 請審查 `src/services/auth_service.py::authenticate_user` 確保實作安全
- ⚠️ 現在這些操作依賴 Supabase API 可用性

### ⚡ **性能影響**
- 從內存操作 (`check_password_hash`) 改為 HTTP 請求 (`authenticate_user`)
- 增加網絡延遲，但對於不頻繁的 2FA 管理操作可接受
- Supabase Auth API 有 rate limiting 保護

---

## i18n 檢查清單（強制）
- [x] 不適用 - 此 PR 僅修改後端邏輯，無用戶可見變更

## 設計系統檢查 (Design System Checklist)
- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查
- [x] 單元測試通過：`pytest tests/test_totp_api.py::TestTOTPSetup` (3/3 passed)
- [x] 程式碼遵循現有模式（使用已存在的 `authenticate_user` 函數）
- [x] 無硬編碼或 placeholder 邏輯
- [ ] ⚠️ **待完成**: Staging 環境端到端測試

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 僅含 API/邏輯變更（後端 PR）

---

## 📋 人工審查清單 (Human Review Checklist)

請審查者檢查：

1. **安全性**: 
   - [ ] 檢查 `authenticate_user` 實作是否安全
   - [ ] 確認錯誤訊息不洩漏敏感資訊
   
2. **正確性**:
   - [ ] 驗證對 Supabase 用戶和 mock 用戶都能正常工作
   - [ ] 確認測試 mocks 正確模擬了 `authenticate_user` 行為

3. **部署計劃**:
   - [ ] 確認此 PR 會先部署到 Staging
   - [ ] 確認已安排 Staging 測試（與 ryan2939x@gmail.com 一起測試）
   - [ ] **只有在 Staging 測試通過後才能部署到 Production**

---

**Link to Devin run**: https://app.devin.ai/sessions/04055f322bc042dea40afa8acc2f69ff  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918