### PR TITLE
fix(2fa): Parameterize pre_auth_token cookie SameSite attribute for cross-domain CSRF testing

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/routes/auth_enhanced.py
+++ b/handoff/20250928/40_App/api-backend/src/routes/auth_enhanced.py
@@ -157,7 +157,7 @@ def login():
                         max_age=PREAUTH_TOKEN_TTL,
                         httponly=True,
                         secure=COOKIE_SECURE,
-                        samesite='Lax',
+                        samesite=COOKIE_SAMESITE,
                         path='/api/auth/v2/totp'
                     )
                     

--- a/handoff/20250928/40_App/api-backend/src/routes/totp.py
+++ b/handoff/20250928/40_App/api-backend/src/routes/totp.py
@@ -27,7 +27,8 @@ from ..services.auth_service import (
     get_user_by_id,
     authenticate_user,
     FEATURE_2FA_PREAUTH,
-    COOKIE_SECURE
+    COOKIE_SECURE,
+    COOKIE_SAMESITE
 )
 from ..utils.totp_utils import TOTPManager, BackupCodeManager, generate_device_fingerprint, calculate_device_expiry
 from ..utils.preauth_token import validate_and_consume_preauth_token
@@ -721,7 +722,7 @@ def verify_totp_login():
             max_age=0,
             httponly=True,
             secure=COOKIE_SECURE,
-            samesite='Lax',
+            samesite=COOKIE_SAMESITE,
             path='/api/auth/v2/totp'
         )
         


### PR DESCRIPTION
## 描述 (Description)

修復 `pre_auth_token` cookie 的 SameSite 屬性被硬編碼為 'Lax' 的問題，改為從 `COOKIE_SAMESITE` 環境變數讀取。這使得 Staging 環境可以設定 `COOKIE_SAMESITE=None` 來支援跨域部署（backend 在 onrender.com，frontend 在 vercel.app）並測試 CSRF 保護。

**變更內容**:
- `auth_enhanced.py:160` - 設定 pre_auth_token cookie 時使用 `COOKIE_SAMESITE`
- `totp.py:725` - 清除 pre_auth_token cookie 時使用 `COOKIE_SAMESITE`
- `totp.py:31` - 從 auth_service 匯入 `COOKIE_SAMESITE`

**Cookie 路徑對稱性**: 確保 set_cookie 和 clear_cookie 使用相同的參數（path、samesite、secure、httponly），否則 cookie 無法正確清除。

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅後端 cookie 配置）

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）
- [x] TypeScript 類型檢查通過：N/A (Python backend)
- [x] 無 `any` 類型：N/A (Python backend)
- [x] 所有測試通過：`python -m pytest tests/test_totp_api.py` (14 passed)
- [x] 程式碼遵循現有模式和慣例

## 人工審查重點 (Human Review Checklist)

### ⚠️ 關鍵審查項目

1. **Cookie 參數對稱性** (Critical)
   - [ ] 確認 `auth_enhanced.py:160` (set) 和 `totp.py:725` (clear) 使用相同的 `samesite` 參數
   - [ ] 兩處都使用相同的 `path='/api/auth/v2/totp'`
   - [ ] 兩處都使用相同的 `secure=COOKIE_SECURE`

2. **環境變數預設值** (Important)
   - [ ] 檢查 `auth_service.py:33` 中 `COOKIE_SAMESITE` 的預設值（應為 'Strict'）
   - [ ] 確認從 'Lax'（硬編碼）改為 'Strict'（預設）不會破壞現有部署

3. **已知限制** (Blocking)
   - [ ] 了解 `COOKIE_SECURE` 仍硬編碼為 `IS_PRODUCTION`（auth_service.py:32）
   - [ ] 在 Staging 設定 `COOKIE_SAMESITE=None` 時需要 `COOKIE_SECURE=True`，但因硬編碼問題目前會失敗
   - [ ] 此 PR **僅**修復 SameSite 參數化，不修復 COOKIE_SECURE 問題

### 📝 測試驗證

- [x] 單元測試通過（14 個 TOTP API 測試）
- [ ] **待驗證**: 在 Staging 設定 `COOKIE_SAMESITE=None` 後測試跨域 cookie 行為
- [ ] **待驗證**: CSRF 保護在跨域請求中正常運作

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR（API/邏輯變更）
- [x] 未使用已廢棄的目錄

---

**Link to Devin run**: https://app.devin.ai/sessions/04055f322bc042dea40afa8acc2f69ff  
**Requested by**: Ryan Chen (@RC918)

**相關 PR**: 
- #1116 (Password verification fix - 已合併)

**後續步驟**:
1. 合併此 PR 到 `devin/week0-2fa-integration`
2. 在 Staging 設定 `COOKIE_SAMESITE=None` 和 `COOKIE_SECURE=true`（需要另外修復 COOKIE_SECURE 硬編碼問題）
3. 測試跨域 CSRF 保護
4. 驗證 pre_auth_token cookie 在跨域請求中正確發送和清除