### PR TITLE
fix(security): Parameterize COOKIE_SECURE and change COOKIE_SAMESITE default to Lax (P0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,22 @@ ENCRYPTION_MASTER_KEY=your-secret-here
 # Required: False
 MASTER_KEY=your-secret-here
 
+# Enable Secure flag on authentication cookies (HTTPS-only)
+# When true, cookies are only sent over HTTPS connections.
+# Defaults to true in production, false in development.
+# Required to be true when COOKIE_SAMESITE=None (browser requirement).
+# Required: False
+COOKIE_SECURE=True
+
+# SameSite attribute for authentication cookies
+# Controls when cookies are sent on cross-site requests.
+# - Strict: Cookies only sent on same-site requests (most secure)
+# - Lax: Cookies sent on top-level navigation (default, balanced)
+# - None: Cookies sent on all requests (requires COOKIE_SECURE=true)
+# For cross-domain deployments (e.g., Staging), use None with COOKIE_SECURE=true.
+# Required: False
+COOKIE_SAMESITE=Lax
+
 # Database
 
 # PostgreSQL database connection URL
@@ -234,10 +250,17 @@ SANDBOX_ENABLED=false
 FEATURE_2FA_ENABLED=True
 
 # Enable Pre-Auth Token for 2FA (Week 1 - reduces password transmission)
+# When enabled, password is only transmitted once during login.
+# 2FA verification uses a short-lived pre-auth token instead of password.
+# Reduces password exposure risk by 50%.
 # Required: False
 FEATURE_2FA_PREAUTH=false
 
 # Pre-Auth Token TTL in seconds (5 minutes default)
+# Time-to-live for pre-auth tokens in seconds.
+# Tokens automatically expire after this duration.
+# Recommended: 300 seconds (5 minutes).
+# Protected by @rate_limit decorator on verify endpoint.
 # Required: False
 PREAUTH_TOKEN_TTL=300
 

--- a/config/env.schema.yaml
+++ b/config/env.schema.yaml
@@ -413,6 +413,33 @@ fields:
     category: Feature Flags
     security_level: public
     
+  COOKIE_SECURE:
+    type: boolean
+    required: false
+    default: true
+    description: Enable Secure flag on authentication cookies (HTTPS-only)
+    category: Security
+    security_level: public
+    notes: |
+      When true, cookies are only sent over HTTPS connections.
+      Defaults to true in production, false in development.
+      Required to be true when COOKIE_SAMESITE=None (browser requirement).
+  
+  COOKIE_SAMESITE:
+    type: string
+    required: false
+    default: Lax
+    description: SameSite attribute for authentication cookies
+    category: Security
+    security_level: public
+    choices: [Strict, Lax, None]
+    notes: |
+      Controls when cookies are sent on cross-site requests.
+      - Strict: Cookies only sent on same-site requests (most secure)
+      - Lax: Cookies sent on top-level navigation (default, balanced)
+      - None: Cookies sent on all requests (requires COOKIE_SECURE=true)
+      For cross-domain deployments (e.g., Staging), use None with COOKIE_SECURE=true.
+  
   FEATURE_2FA_ENABLED:
     type: boolean
     required: false

--- a/handoff/20250928/40_App/api-backend/.env.example
+++ b/handoff/20250928/40_App/api-backend/.env.example
@@ -39,6 +39,22 @@ ENCRYPTION_MASTER_KEY=your-secret-here
 # Required: False
 MASTER_KEY=your-secret-here
 
+# Enable Secure flag on authentication cookies (HTTPS-only)
+# When true, cookies are only sent over HTTPS connections.
+# Defaults to true in production, false in development.
+# Required to be true when COOKIE_SAMESITE=None (browser requirement).
+# Required: False
+COOKIE_SECURE=True
+
+# SameSite attribute for authentication cookies
+# Controls when cookies are sent on cross-site requests.
+# - Strict: Cookies only sent on same-site requests (most secure)
+# - Lax: Cookies sent on top-level navigation (default, balanced)
+# - None: Cookies sent on all requests (requires COOKIE_SECURE=true)
+# For cross-domain deployments (e.g., Staging), use None with COOKIE_SECURE=true.
+# Required: False
+COOKIE_SAMESITE=Lax
+
 # Database
 
 # PostgreSQL database connection URL
@@ -232,6 +248,21 @@ SANDBOX_ENABLED=false
 # Enable Two-Factor Authentication (2FA/TOTP) feature
 # Required: False
 FEATURE_2FA_ENABLED=True
+
+# Enable Pre-Auth Token for 2FA (Week 1 - reduces password transmission)
+# When enabled, password is only transmitted once during login.
+# 2FA verification uses a short-lived pre-auth token instead of password.
+# Reduces password exposure risk by 50%.
+# Required: False
+FEATURE_2FA_PREAUTH=false
+
+# Pre-Auth Token TTL in seconds (5 minutes default)
+# Time-to-live for pre-auth tokens in seconds.
+# Tokens automatically expire after this duration.
+# Recommended: 300 seconds (5 minutes).
+# Protected by @rate_limit decorator on verify endpoint.
+# Required: False
+PREAUTH_TOKEN_TTL=300
 
 # Testing
 

--- a/handoff/20250928/40_App/api-backend/src/services/auth_service.py
+++ b/handoff/20250928/40_App/api-backend/src/services/auth_service.py
@@ -30,8 +30,8 @@ JWT_SECRET_KEY = os.environ.get('JWT_SECRET_KEY')  # No default - must be set
 JWT_ALGORITHM = 'HS256'
 
 # Cookie Configuration
-COOKIE_SECURE = IS_PRODUCTION  # Always secure in production
-COOKIE_SAMESITE = os.environ.get('COOKIE_SAMESITE', 'Strict')  # Configurable: 'Strict', 'Lax', or 'None'
+COOKIE_SECURE = os.environ.get('COOKIE_SECURE', 'true' if IS_PRODUCTION else 'false').lower() == 'true'
+COOKIE_SAMESITE = os.environ.get('COOKIE_SAMESITE', 'Lax')  # Configurable: 'Strict', 'Lax', or 'None'
 COOKIE_HTTPONLY = True
 COOKIE_DOMAIN = os.environ.get('COOKIE_DOMAIN', None)  # Optional: restrict to specific domain
 COOKIE_PATH = os.environ.get('COOKIE_PATH', '/')  # Optional: restrict to specific path

--- a/handoff/20250928/40_App/frontend-dashboard/.env.example
+++ b/handoff/20250928/40_App/frontend-dashboard/.env.example
@@ -79,3 +79,18 @@ SANDBOX_ENABLED=false
 # Enable Two-Factor Authentication (2FA/TOTP) feature
 # Required: False
 FEATURE_2FA_ENABLED=True
+
+# Enable Pre-Auth Token for 2FA (Week 1 - reduces password transmission)
+# When enabled, password is only transmitted once during login.
+# 2FA verification uses a short-lived pre-auth token instead of password.
+# Reduces password exposure risk by 50%.
+# Required: False
+FEATURE_2FA_PREAUTH=false
+
+# Pre-Auth Token TTL in seconds (5 minutes default)
+# Time-to-live for pre-auth tokens in seconds.
+# Tokens automatically expire after this duration.
+# Recommended: 300 seconds (5 minutes).
+# Protected by @rate_limit decorator on verify endpoint.
+# Required: False
+PREAUTH_TOKEN_TTL=300

--- a/handoff/20250928/40_App/owner-console/.env.example
+++ b/handoff/20250928/40_App/owner-console/.env.example
@@ -79,3 +79,18 @@ SANDBOX_ENABLED=false
 # Enable Two-Factor Authentication (2FA/TOTP) feature
 # Required: False
 FEATURE_2FA_ENABLED=True
+
+# Enable Pre-Auth Token for 2FA (Week 1 - reduces password transmission)
+# When enabled, password is only transmitted once during login.
+# 2FA verification uses a short-lived pre-auth token instead of password.
+# Reduces password exposure risk by 50%.
+# Required: False
+FEATURE_2FA_PREAUTH=false
+
+# Pre-Auth Token TTL in seconds (5 minutes default)
+# Time-to-live for pre-auth tokens in seconds.
+# Tokens automatically expire after this duration.
+# Recommended: 300 seconds (5 minutes).
+# Protected by @rate_limit decorator on verify endpoint.
+# Required: False
+PREAUTH_TOKEN_TTL=300

--- a/orchestrator/.env.example
+++ b/orchestrator/.env.example
@@ -122,3 +122,18 @@ SANDBOX_ENABLED=false
 # Enable Two-Factor Authentication (2FA/TOTP) feature
 # Required: False
 FEATURE_2FA_ENABLED=True
+
+# Enable Pre-Auth Token for 2FA (Week 1 - reduces password transmission)
+# When enabled, password is only transmitted once during login.
+# 2FA verification uses a short-lived pre-auth token instead of password.
+# Reduces password exposure risk by 50%.
+# Required: False
+FEATURE_2FA_PREAUTH=false
+
+# Pre-Auth Token TTL in seconds (5 minutes default)
+# Time-to-live for pre-auth tokens in seconds.
+# Tokens automatically expire after this duration.
+# Recommended: 300 seconds (5 minutes).
+# Protected by @rate_limit decorator on verify endpoint.
+# Required: False
+PREAUTH_TOKEN_TTL=300


### PR DESCRIPTION
## 描述 (Description)

**P0 Critical Fix**: Parameterize `COOKIE_SECURE` and change `COOKIE_SAMESITE` default to enable cross-domain CSRF testing in Staging.

### Problem
- `COOKIE_SECURE` was hardcoded to `IS_PRODUCTION`, preventing Staging from setting `COOKIE_SECURE=true`
- Browsers require `SameSite=None` cookies to have `Secure=true`, blocking cross-domain testing
- Staging deployment is cross-domain (backend: onrender.com, frontend: vercel.app)

### Solution
1. **Parameterize COOKIE_SECURE**: Make it configurable via environment variable, defaulting to `true` in production and `false` in development
2. **Change COOKIE_SAMESITE default**: From `'Strict'` to `'Lax'` to match previous `pre_auth_token` cookie behavior
3. **Add configuration schema**: Document new variables in `env.schema.yaml` with browser requirement notes
4. **Regenerate .env.example**: Include new variables across all applications

### Key Changes
```python
# Before
COOKIE_SECURE = IS_PRODUCTION
COOKIE_SAMESITE = os.environ.get('COOKIE_SAMESITE', 'Strict')

# After  
COOKIE_SECURE = os.environ.get('COOKIE_SECURE', 'true' if IS_PRODUCTION else 'false').lower() == 'true'
COOKIE_SAMESITE = os.environ.get('COOKIE_SAMESITE', 'Lax')
```

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅後端 cookie 配置）

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）: N/A (Python backend)
- [x] TypeScript 類型檢查通過: N/A (Python backend)
- [x] 無 `any` 類型: N/A (Python backend)
- [x] 所有測試通過：14 個 TOTP API 測試全部通過
- [x] 程式碼遵循現有模式和慣例

## 人工審查重點 (Human Review Checklist)

### ⚠️ 關鍵審查項目（P0）

1. **Boolean Parsing Robustness** (Critical)
   - [ ] 確認 `os.environ.get('COOKIE_SECURE', ...).lower() == 'true'` 正確處理預期的輸入格式
   - [ ] 驗證只接受 'true'/'false' (不分大小寫)，對於 '1'/'yes' 等格式會正確拒絕
   - [ ] **潛在風險**: 如果 production 環境誤設 `COOKIE_SECURE=1`，將被解析為 False

2. **Default Value Change Impact** (Critical)
   - [ ] 確認 COOKIE_SAMESITE 從 'Strict' 改為 'Lax' 的安全影響
   - [ ] 驗證 **所有** 使用 `create_cookie_config()` 的 cookie 都能接受 'Lax'（不只是 pre_auth_token）
   - [ ] **背景**: pre_auth_token 之前硬編碼為 'Lax'，但 access_token/refresh_token 可能依賴 'Strict'

3. **Production Environment Safety** (Critical)
   - [ ] 確認所有 production 環境的 `IS_PRODUCTION` 變數已正確設定
   - [ ] 如果 IS_PRODUCTION=false 且未設定 COOKIE_SECURE，cookies 將不會有 Secure flag
   - [ ] **建議**: Production 應明確設定 `COOKIE_SECURE=true` 而非依賴預設值

4. **Validation Logic Consistency** (Important)
   - [ ] 檢查 auth_service.py:77-78 的驗證邏輯與新的 COOKIE_SECURE 參數化相容
   - [ ] 確認啟動時驗證會攔截 `COOKIE_SAMESITE=None` 但 `COOKIE_SECURE=false` 的錯誤配置

5. **Configuration Schema Accuracy** (Important)
   - [ ] 檢查 env.schema.yaml 中的文檔是否清楚說明瀏覽器要求
   - [ ] 確認 choices: [Strict, Lax, None] 的大小寫與程式碼一致

### 📋 測試限制

- ⚠️ **Browser Testing Pending**: Cookie SameSite 行為只能透過真實瀏覽器測試，Playwright 測試將在此 PR 合併後進行
- ⚠️ **Python requests 不可靠**: Python requests 不會強制執行瀏覽器 cookie 政策（例如 SameSite=None 需要 Secure）

### 🔄 Migration Notes

**環境變數遷移**:
- **Staging**: 需要明確設定 `COOKIE_SECURE=true` 和 `COOKIE_SAMESITE=None`
- **Production**: 建議明確設定 `COOKIE_SECURE=true` 和 `COOKIE_SAMESITE=Lax`（或 Strict）
- **Development**: 預設行為不變（COOKIE_SECURE=false）

**預設值變更影響**:
```
環境          | 舊預設 (Strict)      | 新預設 (Lax)        | 影響
-------------|---------------------|---------------------|------------------
Production   | Strict (via code)   | Lax (可覆蓋)         | 略微放寬但符合原 pre_auth_token 行為
Staging      | Strict              | Lax (改為 None 測試) | 啟用跨域 cookie
Development  | Strict              | Lax                  | 略微放寬
```

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR（Security configuration）
- [x] 未使用已廢棄的目錄

---

**Link to Devin run**: https://app.devin.ai/sessions/04055f322bc042dea40afa8acc2f69ff  
**Requested by**: Ryan Chen (@RC918)

**後續步驟**:
1. 合併此 PR 到 `devin/week0-2fa-integration`
2. 在 Staging Render 設定 `COOKIE_SECURE=true` 和 `COOKIE_SAMESITE=None`
3. 重新部署 Staging
4. 執行 Playwright 瀏覽器測試驗證 CSRF 保護（下一個 PR）