### PR TITLE
P0: Fix jwt_required to support cookie-based authentication

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/middleware/auth_middleware.py
+++ b/handoff/20250928/40_App/api-backend/src/middleware/auth_middleware.py
@@ -67,12 +67,44 @@ def _parse_bearer_token(auth_header):
             'message': 'Authorization header must be in format: Bearer <token>'
         }), 401)
 
+def _extract_jwt_from_request():
+    """
+    Extract JWT token from request (Authorization header or access_token cookie).
+    
+    Priority:
+    1. Authorization header (for API clients and backward compatibility)
+    2. access_token cookie (for browser-based authentication)
+    
+    Returns:
+        tuple: (token, error_response) where error_response is None if successful
+    """
+    auth_header = request.headers.get('Authorization')
+    if auth_header:
+        token, error = _parse_bearer_token(auth_header)
+        if not error:
+            return token, None
+        # This prevents confusion when both are present
+        return None, error
+    
+    cookie_token = request.cookies.get('access_token')
+    if cookie_token:
+        return cookie_token, None
+    
+    return None, (jsonify({
+        'error': 'Authentication required',
+        'message': 'Please provide a valid JWT token via Authorization header or access_token cookie.'
+    }), 401)
+
 def jwt_required(f):
-    """JWT authentication decorator for protecting endpoints (supports both Supabase and custom JWT)"""
+    """
+    JWT authentication decorator for protecting endpoints.
+    
+    Supports both Authorization header and access_token cookie for authentication.
+    Priority: Authorization header > access_token cookie
+    """
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        auth_header = request.headers.get('Authorization')
-        token, error = _parse_bearer_token(auth_header)
+        token, error = _extract_jwt_from_request()
         if error:
             return error
         
@@ -118,11 +150,14 @@ def jwt_required(f):
     return decorated_function
 
 def admin_required(f):
-    """Decorator for endpoints requiring admin role"""
+    """
+    Decorator for endpoints requiring admin role.
+    
+    Supports both Authorization header and access_token cookie for authentication.
+    """
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        auth_header = request.headers.get('Authorization')
-        token, error = _parse_bearer_token(auth_header)
+        token, error = _extract_jwt_from_request()
         if error:
             return error
         
@@ -167,11 +202,14 @@ def admin_required(f):
     return decorated_function
 
 def analyst_required(f):
-    """Decorator for endpoints requiring analyst role or higher"""
+    """
+    Decorator for endpoints requiring analyst role or higher.
+    
+    Supports both Authorization header and access_token cookie for authentication.
+    """
     @wraps(f)
     def decorated_function(*args, **kwargs):
-        auth_header = request.headers.get('Authorization')
-        token, error = _parse_bearer_token(auth_header)
+        token, error = _extract_jwt_from_request()
         if error:
             return error
         
@@ -297,12 +335,15 @@ def create_user_token():
     return generate_jwt_token(user_data)
 
 def roles_required(*allowed_roles):
-    """Decorator for endpoints requiring specific roles"""
+    """
+    Decorator for endpoints requiring specific roles.
+    
+    Supports both Authorization header and access_token cookie for authentication.
+    """
     def decorator(f):
         @wraps(f)
         def decorated_function(*args, **kwargs):
-            auth_header = request.headers.get('Authorization')
-            token, error = _parse_bearer_token(auth_header)
+            token, error = _extract_jwt_from_request()
             if error:
                 return error
             


### PR DESCRIPTION
## 描述 (Description)

**Problem**: Owner Console users could log in successfully but received HTTP 401 "Authorization header missing" errors when accessing 2FA settings (`/api/auth/v2/totp/status`).

**Root Cause**: The `@jwt_required` decorator only checked for `Authorization: Bearer <token>` headers, but Owner Console uses cookie-based authentication (HttpOnly `access_token` cookie set during login).

**Solution**: Modified authentication decorators to support both Authorization header and cookie-based authentication with proper priority handling.

**Testing**: Reproduced the issue in browser, implemented fix, verified all TOTP tests pass (14/14).

---

## 變更內容 (Changes)

### 新增 Helper Function
- Added `_extract_jwt_from_request()` to extract JWT from either:
  1. **Authorization header** (priority - for API clients and backward compatibility)
  2. **access_token cookie** (fallback - for browser-based authentication)

### 修改 4 個 Decorators
- `jwt_required`: Now accepts both header and cookie
- `admin_required`: Now accepts both header and cookie  
- `analyst_required`: Now accepts both header and cookie
- `roles_required`: Now accepts both header and cookie

### 錯誤訊息更新
- Changed error message from "Authorization header missing" to "Authentication required" (more generic since we now support multiple auth methods)

---

## 安全考量 (Security Considerations)

✅ **Safe Implementation**:
- Authorization header checked first (prevents cookie from overriding explicit header)
- Invalid Authorization header does NOT fall back to cookie (prevents confusion if both present)
- HttpOnly cookies already in use (XSS protection)
- CSRF protection already exists on state-changing TOTP endpoints

⚠️ **CORS Dependency**: 
- This fix requires proper CORS configuration:
  - `Access-Control-Allow-Credentials: true`
  - `Access-Control-Allow-Origin: <exact-vercel-origin>` (not `*`)
- **Reviewer**: Please verify CORS is configured correctly in `main.py`

---

## 測試結果 (Test Results)

```
tests/test_totp_api.py::TestTOTPSetup::test_setup_totp_success PASSED
tests/test_totp_api.py::TestTOTPStatus::test_get_status_enabled PASSED
... (14/14 TOTP tests passed)
```

---

## 部署計劃 (Deployment Plan)

1. ✅ Merge this PR to `devin/week0-2fa-integration`
2. 🔄 Deploy to staging backend (`morningai-backend-v2-stg.onrender.com`)
3. 🧪 Test 2FA flow in Owner Console preview: `owner-console-git-devin-1762318914-add-2fa-na-084313-morning-ai.vercel.app`
4. ✅ Verify no more 401 errors on `/api/auth/v2/totp/status`
5. 🚀 Proceed with merging PR #1128 (Owner Console 2FA navigation)

---

## Human Review Checklist

**Critical Items** ⚠️:
- [ ] **CORS configuration**: Verify `main.py` has correct `Access-Control-Allow-Credentials` and `Access-Control-Allow-Origin` for Vercel preview domains
- [ ] **Security review**: Confirm priority logic (header > cookie) is correct and no security bypasses exist
- [ ] **Staging test**: After deployment, manually test 2FA flow in Owner Console to verify 401 errors are resolved

**Code Quality**:
- [ ] `_extract_jwt_from_request()` logic is correct (header first, then cookie, clear error messages)
- [ ] All 4 decorators consistently use the new helper function
- [ ] Backward compatibility maintained for existing API clients using Authorization headers

**Testing**:
- [ ] TOTP API tests passed (14/14) ✅
- [ ] Consider adding explicit tests for cookie-based authentication vs header-based authentication

---

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 為 backend 變更，無用戶可見字串

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] 所有測試通過：`pytest tests/test_totp_api.py` (14/14 passed)
- [x] 程式碼遵循現有模式和慣例
- [ ] Backend lint check (需在 CI 中驗證)

---

## 相關資源

- **Devin Session**: https://app.devin.ai/sessions/6c521e7deed448e39a66c1b82f498e4b
- **Requested by**: Ryan Chen (@RC918, ryan2939z@gmail.com)
- **Related PR**: #1128 (Owner Console 2FA navigation - blocked by this issue)
- **Test credentials**: ryan2939x@gmail.com / CPas32Aw95JPP6ikXkmQXmaxfvg9YcYJ

---

## 截圖 (Screenshots)

**Before (401 Error)**:
![2FA 401 Error](https://devin-public-attachments.s3.dualstack.us-west-2.amazonaws.com/attachments_private/org-586ab28be1e7412aa1c72d6ab213d157/f0b8f245-051d-41e7-be0a-3ea41dd9c95a?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAT64VHFT724X4WNQK%2F20251105%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20251105T095501Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEML%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIQCb4AKB%2FgpXjBIoOkjkXM4ot0aV896TSgNTHWKu9aKHJQIgCNtBXQRCmfGdSyOlA5rl%2By64RXC3TEiPxitd4Z3lsa4qwgUIi%2F%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARABGgwyNzI1MDY0OTgzMDMiDAPm7dfCVzrllhQrESqWBQGNFVL6Rb9L7d%2B96TYN7tUR6AfzEGa4SDMOO8ngz5fTCjYurWGnVwhHigkSlgU63bxXFx%2B7zNjxmQD6Eu0mdUZLk7VFPEcHpBDz1PU%2FeLIREJ6n8FU5snf9ucjG6AFNxctK1kSnaic9bmuuO44IXYfk8rFNSREQdLhXgc4%2BDKvt9%2FYKlK47pALOH2BIQjN0LntK7qlm22Sld3VRSSztS1qdmYLI4rYQ6rdahEAqj1O8shbGxMrnb6rgbPURhXPDEf5HOdpMgVDxcNSG4xbONo7bH%2BltMNWYtXVsdz7MAkDa0SIhtYK3eITxL5jzMLXMCJXQN%2FzxzRX3prmxWprEc7lEHAQOtfL0LCP0rJAcDncC14KIfqa8mfHwCKGvAc%2Fqt6KRigNDw63f6PqTo6kfZ6J%2BXed7cdBmWqP0SPRQW9GY%2Fci59URkhGk1zWrF%2BUFR7dWGaRNPysfFqgA6BQ3e0Z2txOF2CKn9%2B03rkdKYgJpDlJOGVup9Fzi5XQq6hWK7GzwOPZqj%2FsbPF38EuMDcrJo1ah1oCWqliM%2FjoVFjHApzBZgI7whsNIUQALLtbfWftYHHFtcv6EkZ4kes7GWIA851wDLw2I5XRx7sxa0tZ5QGIGyLab5WdUIAezvl21nLEVU1cDiUFfXn%2FBHzZUGBQRMzmK2IF2NEOxpie%2Fa8byIOjUkcbXLmlLnERxbtJtcKWxPpXzHOmkyrjcgR8r1wc2s7a8GhQzEJb9Ta7pljUd35ugPrpGpU%2BjMFzBc5I1dw4%2FqRs8X7gVZc5aBYvV2KJmVgZwYJxLZPBlJp6j3M51oCOrzhTkm1dMwdgiXykRbZzgY4oplMkwCEN54%2FfCXz65UJJWr7aXyEX8DK81pgdPBOF0JwTohAMOG1rMgGOpYB8jqKV4aES7RAiv2jiLzbnXS5vxHBW6BEmiZh%2BFLfzIMeQVJCQzGpmFpCpdyw%2FkTKlC4hzQZWNCcYHFmsvzvr9iQT4R7Fjt8R1N0zvoeLh2VToCFYzkZJhjPWWlYEcFaLD3MdudJmGdJWwov%2FMRAsWh%2FaFORQUgx9JDAhJB%2FIE1ILwSMZQx%2FqrVMTP9pb7h1%2FokYCsAmY&X-Amz-Signature=8d468120b594b0e776546d2909f43751f1ea34d46d24b11d5a9d496c954169ba)

**After Fix**: 
- 2FA settings page should load successfully
- No more "Authorization header missing" errors
- Both header-based and cookie-based auth work correctly