### PR TITLE
Good Case #4 – Fix Contrast Violations – Dashboard Text Readability

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/Dashboard.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/Dashboard.tsx
@@ -351,7 +351,7 @@ const Dashboard = (): React.ReactElement => {
         <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
           {showReportCenter ? t('reportCenter.title') : t('dashboard.title')}
         </h1>
-        <p className="text-gray-600 dark:text-gray-600 mt-2">
+        <p className="text-gray-700 dark:text-gray-300 mt-2">
           {showReportCenter ? t('reportCenter.description') : t('dashboard.description')}
         </p>
         {isEditMode && (
@@ -578,8 +578,8 @@ const Dashboard = (): React.ReactElement => {
                       </div>
                       <div>
                         <h4 className="font-medium dark:text-white">{decision.strategy}</h4>
-                        <p className="text-sm text-gray-600 dark:text-gray-600">{decision.impact}</p>
-                        <p className="text-xs text-gray-600 dark:text-gray-600">
+                        <p className="text-sm text-gray-700 dark:text-gray-300">{decision.impact}</p>
+                        <p className="text-xs text-gray-600 dark:text-gray-400">
                           {new Date(decision.timestamp).toLocaleString()}
                         </p>
                       </div>
@@ -589,7 +589,7 @@ const Dashboard = (): React.ReactElement => {
                         {decision.status === 'executed' ? t('decisions.status.executed') : 
                          decision.status === 'pending' ? t('decisions.status.pending') : t('decisions.status.failed')}
                       </Badge>
-                      <p className="text-sm text-gray-600 dark:text-gray-600 mt-1">
+                      <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">
                         {t('decisions.confidence')}: {(decision.confidence * 100).toFixed(0)}%
                       </p>
                     </div>
@@ -604,9 +604,9 @@ const Dashboard = (): React.ReactElement => {
         {isEditMode && (
           <Card className="border-dashed border-2">
             <CardContent className="p-6 text-center">
-              <Edit3 className="w-12 h-12 mx-auto mb-4 text-gray-600" />
+              <Edit3 className="w-12 h-12 mx-auto mb-4 text-gray-700" />
               <h3 className="text-lg font-medium mb-2 dark:text-white">{t('dashboard.customize')}</h3>
-              <p className="text-gray-600 dark:text-gray-600 mb-4">
+              <p className="text-gray-700 dark:text-gray-300 mb-4">
                 {t('dashboard.editInstructions')}
               </p>
               <div className="flex justify-center space-x-2">

--- a/scripts/ux/capture.mjs
+++ b/scripts/ux/capture.mjs
@@ -38,38 +38,69 @@ async function setupAuth(page) {
 
   console.log('🔐 Setting up authentication...');
   
-  try {
-    // Navigate to login page
-    await page.goto(`${BASE_URL}/login`, { waitUntil: 'networkidle' });
-    
-    // Wait for form to be visible
-    await page.waitForSelector('input[name="username"]', { state: 'visible', timeout: 10000 });
-    
-    // Fill in credentials using attribute-based selectors
-    await page.fill('input[name="username"]', QA_TEST_EMAIL);
-    await page.fill('input[name="password"]', QA_TEST_PASSWORD);
-    
-    // Submit form by pressing Enter on password field (more reliable than clicking button)
-    await page.press('input[name="password"]', 'Enter');
-    
-    // Wait for navigation to dashboard after successful login
-    await page.waitForURL(/\/dashboard(\/|$)/, { timeout: 15000 });
-    
-    // Verify authentication by checking for authenticated-only elements
-    // The sidebar is only visible when authenticated
-    const isAuthenticated = await page.locator('nav[role="navigation"]').isVisible().catch(() => false);
-    
-    if (isAuthenticated) {
-      console.log('✅ Authentication successful\n');
-      return true;
-    } else {
-      console.log('❌ Authentication failed - no authenticated elements found\n');
-      return false;
+  // Try primary credentials first, then fallback to mock credentials
+  const credentialSets = [
+    { username: QA_TEST_EMAIL, password: QA_TEST_PASSWORD, label: 'Primary credentials' },
+    { username: 'admin', password: 'admin123', label: 'Mock credentials (admin/admin123)' }
+  ];
+  
+  for (const creds of credentialSets) {
+    try {
+      console.log(`   Attempting login with ${creds.label}...`);
+      
+      // Navigate to login page
+      await page.goto(`${BASE_URL}/login`, { waitUntil: 'networkidle' });
+      
+      // Wait for form to be visible
+      await page.waitForSelector('input[name="username"]', { state: 'visible', timeout: 10000 });
+      
+      // Fill in credentials using attribute-based selectors
+      await page.fill('input[name="username"]', creds.username);
+      await page.fill('input[name="password"]', creds.password);
+      
+      // Submit form by pressing Enter on password field (more reliable than clicking button)
+      await page.press('input[name="password"]', 'Enter');
+      
+      console.log('   Waiting for authenticated shell (Sidebar) to appear...');
+      
+      // Wait for the Sidebar to appear (proves authentication succeeded and React state updated)
+      // The sidebar is ONLY rendered when isAuthenticated === true
+      // Check for either role="navigation" OR aria-label containing "navigation"
+      const sidebarLocator = page.locator('nav[role="navigation"], nav[aria-label*="navigation"]').first();
+      
+      try {
+        await sidebarLocator.waitFor({ state: 'visible', timeout: 12000 });
+        console.log('   ✓ Sidebar appeared - authentication successful!');
+      } catch (timeoutError) {
+        console.log(`   Authentication check failed with ${creds.label} - sidebar did not appear`);
+        continue; // Try next credential set
+      }
+      
+      // Now navigate to dashboard using SPA client-side routing (preserves React state)
+      // Click the dashboard link in the sidebar instead of using page.goto()
+      console.log('   Navigating to /dashboard via SPA link...');
+      const dashboardLink = page.locator('a[href="/dashboard"]').first();
+      await dashboardLink.click();
+      
+      // Wait for dashboard route to load
+      await page.waitForURL(/\/dashboard(\/|$)/, { timeout: 5000 });
+      
+      // Verify we're still authenticated (sidebar should still be visible)
+      const stillAuthenticated = await sidebarLocator.isVisible().catch(() => false);
+      
+      if (stillAuthenticated) {
+        console.log(`✅ Authentication successful with ${creds.label}\n`);
+        return true;
+      } else {
+        console.log(`   Authentication lost after navigation with ${creds.label}`);
+      }
+    } catch (error) {
+      console.log(`   Authentication attempt failed with ${creds.label}: ${error.message}`);
     }
-  } catch (error) {
-    console.error(`❌ Authentication error: ${error.message}\n`);
-    return false;
   }
+  
+  console.error('❌ All authentication attempts failed\n');
+  return false;
 }
 
 async function captureScreenshots() {
@@ -110,37 +141,13 @@ async function captureScreenshots() {
   const pages = config.PAGES[APP_NAME] || [];
   const capturedPages = [];
   
-  // Determine if we need authentication
-  const requiresAuth = pages.some(p => p.requiresAuth);
-  let isAuthenticated = false;
+  // Split pages into public and authenticated
+  const publicPages = pages.filter(p => !p.requiresAuth);
+  const authenticatedPages = pages.filter(p => p.requiresAuth);
   
-  if (requiresAuth) {
-    // Attempt authentication
-    isAuthenticated = await setupAuth(page);
-    
-    // Save auth state for future runs
-    if (isAuthenticated) {
-      try {
-        await context.storageState({ path: AUTH_STORAGE_PATH });
-        console.log(`💾 Saved authentication state to ${AUTH_STORAGE_PATH}\n`);
-      } catch (error) {
-        console.log(`⚠️  Could not save auth state: ${error.message}\n`);
-      }
-    }
-  }
-
-  for (const pageConfig of pages.slice(0, config.BUDGET.maxPagesPerApp)) {
-    // Skip authenticated pages if not authenticated
-    if (pageConfig.requiresAuth && !isAuthenticated) {
-      console.log(`⏭️  Skipping: ${pageConfig.name} (requires authentication)`);
-      capturedPages.push({
-        name: pageConfig.name,
-        path: pageConfig.path,
-        error: 'Requires authentication (credentials not provided)',
-        skipped: true,
-      });
-      continue;
-    }
+  // PHASE 1: Capture public pages using page.goto()
+  console.log('📸 Phase 1: Capturing public pages...\n');
+  for (const pageConfig of publicPages.slice(0, config.BUDGET.maxPagesPerApp)) {
     console.log(`Capturing: ${pageConfig.name} (${pageConfig.path})`);
 
     try {
@@ -196,6 +203,119 @@ async function captureScreenshots() {
         path: pageConfig.path,
         error: error.message,
       });
+    }
+  }
+  
+  // PHASE 2: Setup authentication if needed
+  let isAuthenticated = false;
+  if (authenticatedPages.length > 0) {
+    console.log('\n🔐 Phase 2: Setting up authentication...\n');
+    isAuthenticated = await setupAuth(page);
+    
+    // Save auth state for future runs
+    if (isAuthenticated) {
+      try {
+        await context.storageState({ path: AUTH_STORAGE_PATH });
+        console.log(`💾 Saved authentication state to ${AUTH_STORAGE_PATH}\n`);
+      } catch (error) {
+        console.log(`⚠️  Could not save auth state: ${error.message}\n`);
+      }
+    }
+  }
+  
+  // PHASE 3: Capture authenticated pages using SPA navigation (NO page.goto!)
+  if (authenticatedPages.length > 0) {
+    console.log('📸 Phase 3: Capturing authenticated pages...\n');
+    
+    if (!isAuthenticated) {
+      console.log('⏭️  Skipping authenticated pages (authentication failed)\n');
+      for (const pageConfig of authenticatedPages) {
+        capturedPages.push({
+          name: pageConfig.name,
+          path: pageConfig.path,
+          error: 'Requires authentication (credentials not provided)',
+          skipped: true,
+        });
+      }
+    } else {
+      // We're already on /dashboard after setupAuth(), capture it first
+      const sidebarLocator = page.locator('nav[role="navigation"], nav[aria-label*="navigation"]').first();
+      
+      for (const pageConfig of authenticatedPages.slice(0, config.BUDGET.maxPagesPerApp - publicPages.length)) {
+        console.log(`Capturing: ${pageConfig.name} (${pageConfig.path})`);
+
+        try {
+          const url = `${BASE_URL}${pageConfig.path}`;
+          
+          // If not already on this page, navigate via SPA (click sidebar link)
+          const currentUrl = page.url();
+          if (!currentUrl.includes(pageConfig.path)) {
+            console.log(`   Navigating to ${pageConfig.path} via SPA link...`);
+            const navLink = page.locator(`a[href="${pageConfig.path}"]`).first();
+            await navLink.click();
+            await page.waitForURL(new RegExp(pageConfig.path.replace('/', '\\/')), { timeout: 5000 });
+          }
+          
+          // Verify we're still authenticated
+          const stillAuthenticated = await sidebarLocator.isVisible().catch(() => false);
+          if (!stillAuthenticated) {
+            throw new Error('Authentication lost during navigation');
+          }
+          
+          // Scroll to top to ensure above-the-fold content is captured
+          await page.evaluate(() => window.scrollTo(0, 0));
+          
+          // Wait for page to stabilize
+          await page.waitForTimeout(500);
+          
+          // Record actual URL after navigation (to detect redirects)
+          const actualUrl = page.url();
+
+          // Hide dynamic elements that could cause variance
+          await page.addStyleTag({
+            content: `
+              [data-testid="timestamp"],
+              .timestamp,
+              .live-indicator,
+              .pulse-animation {
+                visibility: hidden !important;
+              }
+            `,
+          });
+
+          // Take screenshot
+          const screenshotPath = path.join(
+            SCREENSHOTS_DIR,
+            `${pageConfig.name.toLowerCase().replace(/\s+/g, '-')}.jpg`
+          );
+
+          await page.screenshot({
+            path: screenshotPath,
+            type: 'jpeg',
+            quality: Math.round(config.BUDGET.imageQuality * 100),
+            fullPage: false, // Only capture viewport
+          });
+
+          console.log(`  ✅ Saved: ${path.basename(screenshotPath)}`);
+
+          capturedPages.push({
+            name: pageConfig.name,
+            path: pageConfig.path,
+            description: pageConfig.description,
+            screenshotPath,
+            url,
+            actualUrl, // Record actual URL to detect redirects
+            requiresAuth: pageConfig.requiresAuth || false,
+          });
+        } catch (error) {
+          console.error(`  ❌ Error capturing ${pageConfig.name}: ${error.message}`);
+          capturedPages.push({
+            name: pageConfig.name,
+            path: pageConfig.path,
+            error: error.message,
+          });
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## 描述 (Description)

**Week 2 AI QA Calibration - Good Case #4: Dashboard Text Contrast Improvements**

This PR improves text contrast ratios in the Dashboard component to meet WCAG AA accessibility standards. This is part of the Week 2 AI QA calibration effort to test whether contrast improvements raise AI-detected Harmony scores.

**Testing Hypothesis:**
- Contrast sub-score: 70 → 80+ (+10 improvement)
- Overall Harmony: 72.5 → 75+ (+2.5 improvement)

**⚠️ Important**: This PR should **remain open** for calibration data collection, not be merged to main.

### Changes Made

**Dashboard.tsx - Text Contrast Improvements:**
- Dashboard description: `text-gray-600` → `text-gray-700` (light), `dark:text-gray-600` → `dark:text-gray-300` (dark)
- Recent Decisions impact text: `text-gray-600` → `text-gray-700` (light), `dark:text-gray-600` → `dark:text-gray-300` (dark)
- Recent Decisions confidence: `text-gray-600` → `text-gray-700` (light), `dark:text-gray-600` → `dark:text-gray-300` (dark)
- Edit Mode icon & instructions: `text-gray-600` → `text-gray-700` (light), `dark:text-gray-600` → `dark:text-gray-300` (dark)
- Recent Decisions timestamp: kept at `text-gray-600`/`dark:text-gray-400` for visual hierarchy

**capture.mjs - Authentication Fix (v4):**
Refactored screenshot capture into 3 phases to preserve React authentication state:
1. **Phase 1**: Capture public pages using `page.goto()`
2. **Phase 2**: Setup authentication via login + SPA navigation  
3. **Phase 3**: Capture authenticated pages using SPA navigation only (NO `page.goto()`)

This fix resolves the issue where `page.goto()` was resetting React state and causing Dashboard screenshots to show the Landing Page instead.

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅修改 CSS 類名，所有文字內容使用現有 translation keys）

## 設計系統檢查 (Design System Checklist)

- [x] 我已檢查 `@morningai/shared-ui` 是否有可用的元件
- [x] 如使用設計 tokens，我已從 `@morningai/shared-ui` 匯入而非硬編碼
- [x] 使用 Tailwind 設計 tokens (gray-600 → gray-700, gray-300) 而非自定義顏色

## 程式碼品質檢查

- [ ] ESLint 通過（0 warnings）：`pnpm lint` - **待 CI 驗證**
- [ ] TypeScript 類型檢查通過：`pnpm typecheck` - **待 CI 驗證**
- [x] 無 `any` 類型（使用適當的類型定義）
- [ ] 所有測試通過：`pnpm test` - **待 CI 驗證**
- [x] 程式碼遵循現有模式和慣例

## WCAG AA Accessibility Standards

**Target Contrast Ratios:**
- Normal text (16px): 4.5:1 minimum ✅
- Large text (18px+): 3:1 minimum ✅

**Color Changes:**
- `text-gray-600` (#52525b) → `text-gray-700` (#374151): Increases contrast from ~7:1 to ~10:1 on white background
- `dark:text-gray-600` → `dark:text-gray-300`: Increases contrast on dark backgrounds

## 人工審查重點 (Critical Review Points)

### 🔴 High Priority - Capture Script Changes
- **capture.mjs authentication flow**: This is critical infrastructure for AI QA testing
- Verify the 3-phase approach (public → auth → SPA navigation) works correctly in CI
- Check that authenticated pages (Dashboard, Settings) are captured correctly
- ⚠️ Note: Includes hardcoded fallback credentials `admin/admin123` for testing

### 🟡 Medium Priority - Visual Verification
- **Dark mode contrast**: Manually verify `dark:text-gray-300` looks good on dark backgrounds
- **Visual hierarchy**: Ensure timestamp (`text-gray-600`) remains visually distinct from primary text (`text-gray-700`)
- **Above-the-fold focus**: All changes are in the viewport's first screen (as required for AI QA)

### 🟢 Low Priority
- No breaking changes to component APIs
- No new dependencies added
- No database/API changes

## 測試說明 (Testing Instructions)

1. **Visual Testing:**
   ```bash
   pnpm --filter frontend-dashboard dev
   # Navigate to /dashboard
   # Toggle between light/dark mode
   # Verify text contrast improvements are visible
   ```

2. **AI QA Testing:**
   - Wait for CI workflow "AI Perceptual QA (frontend-dashboard)" to complete
   - Download artifacts: `gh run download <run-id> -n ux-qa-results-frontend-dashboard`
   - Check if Contrast score improved: 70 → 80+
   - Check if Harmony score improved: 72.5 → 75+

## 相關 PRs (Related PRs)

- PR #1162: Good Case #1 - A11y (baseline: Harmony=75, Delight=88)
- PR #1163: Good Case #2 - Color Tokens (Harmony=75, Delight=88)
- PR #1165: Good Case #3 - Spacing (Harmony=72.5, Spacing=75)
- **PR #1166**: Good Case #4 - Contrast (this PR)
- PR #TBD: Good Case #5 - Alignment (pending)

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式
- [x] 避免使用已廢棄的目錄

---

**Link to Devin run**: https://app.devin.ai/sessions/78281bb24ded402ea1acdc6c4fc8c40c  
**Requested by**: Ryan Chen (ryan2939z@gmail.com / @RC918)  
**Purpose**: Week 2 AI QA Calibration - Testing contrast improvement sensitivity