### PR TITLE
docs: Mark /totp/verify-login endpoint as deprecated

### DIFF
--- a/docs/2FA_TOTP_DESIGN.md
+++ b/docs/2FA_TOTP_DESIGN.md
@@ -138,9 +138,22 @@ This document outlines the design for implementing Two-Factor Authentication (2F
 
 ### 3. Login with TOTP
 
-**Endpoint**: `POST /api/auth/v2/login`
+**⚠️ DEPRECATED ENDPOINT**: `POST /api/auth/v2/totp/verify-login`
 
-**Request** (when 2FA enabled):
+This endpoint is deprecated in favor of the new JWT-based pre-auth token flow using `/api/auth/v2/2fa/challenge`. The old endpoint required password re-transmission during 2FA verification, creating unnecessary security risk.
+
+**Migration Path**: Use the new 2FA flow documented in `docs/2fa-owner-launch/02-pre-auth-token-design.md`
+
+**New Flow (Recommended)**:
+1. `POST /api/auth/v2/login` with email + password
+2. If 2FA enabled, response includes `requires_2fa: true` and `tmp_login_token`
+3. `POST /api/auth/v2/2fa/challenge` with `Authorization: Bearer {tmp_login_token}` and `totp_code`
+4. Backend verifies TOTP and issues session tokens
+
+**Old Flow (Deprecated)**:
+**Endpoint**: `POST /api/auth/v2/totp/verify-login`
+
+**Request** (deprecated):
 ```json
 {
   "email": "user@example.com",
@@ -159,12 +172,12 @@ This document outlines the design for implementing Two-Factor Authentication (2F
 }
 ```
 
-**Flow**:
-1. User submits email + password
-2. If 2FA enabled, return `requires_2fa: true`
-3. Frontend prompts for TOTP code
-4. User submits TOTP code
-5. Backend verifies and issues session
+**Why Deprecated**:
+- Password transmitted twice (login + 2FA verification)
+- Increased attack surface for password interception
+- Violates principle of least privilege
+
+**Removal Timeline**: This endpoint will be removed in Q2 2026
 
 ---
 

--- a/docs/2fa-owner-launch/02-pre-auth-token-design.md
+++ b/docs/2fa-owner-launch/02-pre-auth-token-design.md
@@ -20,7 +20,10 @@ This document proposes a Pre-Auth Token (Challenge Token) mechanism to eliminate
 
 ## Problem Statement
 
-### Current Flow (Insecure)
+### Current Flow (Deprecated - Insecure)
+
+**⚠️ DEPRECATED**: The `/api/auth/v2/totp/verify-login` endpoint is deprecated as of November 2025.
+
 ```
 1. User → POST /api/auth/v2/login {email, password}
    ← Response: {requires_2fa: true, user: {...}}
@@ -34,6 +37,8 @@ This document proposes a Pre-Auth Token (Challenge Token) mechanism to eliminate
 - Increased attack surface for password interception
 - Password stored in browser memory longer
 - Violates principle of least privilege (password not needed after initial auth)
+
+**Status**: This endpoint is kept for backward compatibility but will be removed in Q2 2026. All new integrations should use the JWT-based pre-auth token flow (`/api/auth/v2/2fa/challenge`).
 
 ### Proposed Flow (Secure)
 ```

--- a/docs/2fa-owner-launch/README.md
+++ b/docs/2fa-owner-launch/README.md
@@ -32,11 +32,11 @@ This launch pack contains all documentation required for deploying 2FA enforceme
 
 ### 2. Pre-Auth Token Design Document
 **File**: [`02-pre-auth-token-design.md`](./02-pre-auth-token-design.md)  
-**Status**: 📋 Awaiting CTO Approval  
+**Status**: ✅ IMPLEMENTED (November 2025)  
 **Priority**: P0 (Security Enhancement)  
-**Target Delivery**: Week 1 (November 11, 2025)
+**Delivery**: Completed November 2025
 
-**Summary**: Proposes a Pre-Auth Token (Challenge Token) mechanism to eliminate password re-transmission during 2FA verification. Currently, the `/api/auth/v2/totp/verify-login` endpoint requires users to send their password again along with the TOTP code, creating unnecessary security risk.
+**Summary**: Implements JWT-based Pre-Auth Token mechanism to eliminate password re-transmission during 2FA verification. The old `/api/auth/v2/totp/verify-login` endpoint (now **DEPRECATED**) required users to send their password again along with the TOTP code, creating unnecessary security risk. The new `/api/auth/v2/2fa/challenge` endpoint uses JWT-based pre-auth tokens transmitted via Authorization header.
 
 **Key Features**:
 - Opaque random token (256-bit entropy)

--- a/docs/DEPRECATED_ENDPOINTS.md
+++ b/docs/DEPRECATED_ENDPOINTS.md
@@ -1,0 +1,150 @@
+# Deprecated API Endpoints
+
+This document tracks deprecated API endpoints, their replacement endpoints, and removal timelines.
+
+---
+
+## Active Deprecations
+
+### 1. `/api/auth/v2/totp/verify-login` (POST)
+
+**Status**: ⚠️ DEPRECATED (November 2025)  
+**Removal Date**: Q2 2026  
+**Replacement**: `/api/auth/v2/2fa/challenge` (POST)
+
+**Reason for Deprecation**:
+The old endpoint required password re-transmission during 2FA verification, creating unnecessary security risk:
+- Password transmitted twice over the network
+- Increased attack surface for password interception
+- Password stored in browser memory longer
+- Violates principle of least privilege
+
+**Migration Guide**:
+
+**Old Flow (Deprecated)**:
+```
+1. POST /api/auth/v2/login
+   Request: {email, password}
+   Response: {requires_2fa: true, user: {...}}
+
+2. POST /api/auth/v2/totp/verify-login
+   Request: {email, password, totp_code}
+   Response: {success: true, user: {...}} + Set-Cookie: access_token, refresh_token
+```
+
+**New Flow (Recommended)**:
+```
+1. POST /api/auth/v2/login
+   Request: {email, password}
+   Response: {requires_2fa: true, tmp_login_token: "jwt-token", user: {...}}
+
+2. POST /api/auth/v2/2fa/challenge
+   Headers: Authorization: Bearer {tmp_login_token}
+   Request: {totp_code: "123456"}
+   Response: {success: true, user: {...}} + Set-Cookie: access_token, refresh_token
+```
+
+**Key Differences**:
+- ✅ Password transmitted only once (during initial login)
+- ✅ JWT-based pre-auth token (short-lived, one-time-use)
+- ✅ Token transmitted via Authorization header (not in request body)
+- ✅ Atomic token consumption prevents replay attacks
+- ✅ Scope enforcement (enroll vs challenge)
+
+**Code Changes Required**:
+
+**Frontend (TypeScript/JavaScript)**:
+```typescript
+// OLD (Deprecated)
+const response = await fetch('/api/auth/v2/totp/verify-login', {
+  method: 'POST',
+  headers: {'Content-Type': 'application/json'},
+  body: JSON.stringify({
+    email: userEmail,
+    password: userPassword,  // ❌ Password sent again
+    totp_code: totpCode
+  })
+});
+
+// NEW (Recommended)
+// Step 1: Login
+const loginResponse = await fetch('/api/auth/v2/login', {
+  method: 'POST',
+  headers: {'Content-Type': 'application/json'},
+  body: JSON.stringify({email: userEmail, password: userPassword})
+});
+const {tmp_login_token} = await loginResponse.json();
+
+// Step 2: 2FA Challenge
+const response = await fetch('/api/auth/v2/2fa/challenge', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${tmp_login_token}`  // ✅ JWT token
+  },
+  body: JSON.stringify({totp_code: totpCode})
+});
+```
+
+**Backend (Python)**:
+```python
+# OLD (Deprecated)
+@totp_bp.route('/verify-login', methods=['POST'])
+def verify_totp_login():
+    data = request.get_json()
+    email = data.get('email')
+    password = data.get('password')  # ❌ Password received again
+    totp_code = data.get('totp_code')
+    # ... verify password and TOTP
+
+# NEW (Recommended)
+@auth_2fa_bp.route('/challenge', methods=['POST'])
+@pre_auth_required  # ✅ Validates JWT token from Authorization header
+@pre_auth_scope_required('challenge')  # ✅ Enforces scope
+def challenge_2fa():
+    data = request.get_json()
+    totp_code = data.get('totp_code')
+    # ... verify TOTP only (no password needed)
+```
+
+**Documentation**:
+- Design Document: `docs/2fa-owner-launch/02-pre-auth-token-design.md`
+- Implementation: `handoff/20250928/40_App/api-backend/src/routes/auth_2fa.py`
+- Tests: `handoff/20250928/40_App/api-backend/tests/test_preauth_*.py`
+
+**Support**:
+- The deprecated endpoint will continue to work until Q2 2026
+- Backward compatibility is maintained (fallback to password flow)
+- Deprecation warnings are logged when the old endpoint is used
+
+---
+
+## Removed Deprecations
+
+None yet.
+
+---
+
+## Deprecation Policy
+
+**Deprecation Timeline**:
+1. **Announcement**: Endpoint marked as deprecated in documentation and code
+2. **Warning Period**: 6 months minimum (deprecation warnings logged)
+3. **Removal Notice**: 3 months before removal, send email notifications
+4. **Removal**: Endpoint removed from codebase
+
+**Backward Compatibility**:
+- Deprecated endpoints continue to function during warning period
+- Breaking changes are avoided when possible
+- Migration guides provided for all deprecations
+
+**Communication Channels**:
+- API documentation (this file)
+- Release notes
+- Email notifications to API consumers
+- Deprecation warnings in API responses (via headers)
+
+---
+
+**Last Updated**: November 8, 2025  
+**Maintained By**: Engineering Team


### PR DESCRIPTION
## 描述 (Description)

This PR updates API documentation to mark the `/api/auth/v2/totp/verify-login` endpoint as **DEPRECATED** and provides a comprehensive migration guide to the new JWT-based pre-auth token flow.

**Background**: The endpoint code already contains deprecation warnings (totp.py:622-627, 649), but the API documentation was not updated. This PR completes the deprecation announcement by updating all relevant documentation files.

**Key Changes**:
- ⚠️ Mark `/api/auth/v2/totp/verify-login` as DEPRECATED (removal: Q2 2026)
- ✅ Document replacement endpoint: `/api/auth/v2/2fa/challenge`
- 📖 Create comprehensive migration guide with code examples
- 🔄 Update existing 2FA design documents to reflect deprecation

## Changes

### 1. Created `docs/DEPRECATED_ENDPOINTS.md` (NEW FILE)
- Comprehensive deprecation tracking document
- Side-by-side comparison of old vs new authentication flows
- Code examples for frontend (TypeScript/JavaScript) and backend (Python)
- Security improvements documentation
- Deprecation policy and timeline

### 2. Updated `docs/2FA_TOTP_DESIGN.md`
- Added deprecation warning to "Login with TOTP" section
- Documented migration path to new JWT-based flow
- Added removal timeline (Q2 2026)
- Explained why the endpoint is deprecated (password re-transmission risk)

### 3. Updated `docs/2fa-owner-launch/02-pre-auth-token-design.md`
- Marked "Current Flow" section as "Deprecated - Insecure"
- Added explicit deprecation notice at top of Problem Statement
- Updated status: endpoint kept for backward compatibility until Q2 2026

### 4. Updated `docs/2fa-owner-launch/README.md`
- Changed Pre-Auth Token status from "Awaiting CTO Approval" to "IMPLEMENTED"
- Updated delivery status to "Completed November 2025"
- Clarified that `/totp/verify-login` is now DEPRECATED

## Why This Endpoint Is Deprecated

**Security Issue**: The old endpoint requires password re-transmission during 2FA verification:
```
1. POST /api/auth/v2/login {email, password}
2. POST /api/auth/v2/totp/verify-login {email, password, totp_code}  ❌ Password sent twice
```

**New Secure Flow**: JWT-based pre-auth tokens eliminate password re-transmission:
```
1. POST /api/auth/v2/login {email, password}
   Response: {tmp_login_token: "jwt-token"}
2. POST /api/auth/v2/2fa/challenge
   Headers: Authorization: Bearer {tmp_login_token}
   Body: {totp_code: "123456"}  ✅ No password needed
```

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅文檔更新）

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] 僅文檔變更，無需 lint/typecheck
- [x] TOTP tests 通過（驗證無意外破壞）

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 不涉及已廢棄的目錄或模組
- [x] 不涉及環境變數變更

---

## 🔍 Human Review Checklist

**Critical Items to Verify**:
1. **Migration guide accuracy**: Verify the code examples in `DEPRECATED_ENDPOINTS.md` match the actual API implementation
   - Old endpoint: `/api/auth/v2/totp/verify-login`
   - New endpoint: `/api/auth/v2/2fa/challenge`
   - JWT token flow (Authorization header pattern)
2. **Removal timeline**: Confirm Q2 2026 is an acceptable removal date (6+ months warning period)
3. **Consistency**: Check all 4 documentation files have consistent deprecation messaging
4. **Backward compatibility**: Verify documentation clearly states the old endpoint will continue to work until Q2 2026

**Low Priority**:
- Check links to related documentation are correct
- Verify formatting and markdown rendering

---

**Link to Devin run**: https://app.devin.ai/sessions/3fa773a244c44a02b03cd0e336cd3353  
**Requested by**: Ryan Chen (@RC918)