### PR TITLE
feat: Add production environment guard for REPO_ROOT_PATH (#1224)

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/utils/repo_root.py
+++ b/handoff/20250928/40_App/api-backend/src/utils/repo_root.py
@@ -60,14 +60,22 @@ def get_repo_root(start_path: Optional[Path] = None) -> Path:
     """
     env_root = os.environ.get('REPO_ROOT_PATH')
     if env_root:
-        env_path = Path(env_root).resolve()
-        if env_path.exists() and env_path.is_dir():
-            return env_path
-        else:
-            logger.debug(
-                "REPO_ROOT_PATH=%r is not a valid directory; ignoring and falling back to git/sentinels",
-                env_root
+        is_production = os.environ.get('ENVIRONMENT') == 'production'
+        if is_production:
+            logger.warning(
+                "REPO_ROOT_PATH is set in production environment. "
+                "This should only be used in testing/CI. "
+                "Ignoring REPO_ROOT_PATH and using auto-detection."
             )
+        else:
+            env_path = Path(env_root).resolve()
+            if env_path.exists() and env_path.is_dir():
+                return env_path
+            else:
+                logger.debug(
+                    "REPO_ROOT_PATH=%r is not a valid directory; ignoring and falling back to git/sentinels",
+                    env_root
+                )
     
     try:
         result = subprocess.run(

--- a/handoff/20250928/40_App/api-backend/tests/unit/test_repo_root_discovery.py
+++ b/handoff/20250928/40_App/api-backend/tests/unit/test_repo_root_discovery.py
@@ -372,3 +372,59 @@ class TestCacheBehavior:
         result2 = repo_root_module.get_repo_root()
         assert call_count == 2
         assert result1 == result2
+
+
+class TestProductionGuards:
+    """Test production environment guards for REPO_ROOT_PATH."""
+
+    def test_repo_root_path_ignored_in_production(self, tmp_path, repo_root_module, monkeypatch, caplog):
+        """REPO_ROOT_PATH should be ignored when ENVIRONMENT=production."""
+        fake_repo = tmp_path / "fake_repo"
+        fake_repo.mkdir()
+        
+        monkeypatch.setenv("REPO_ROOT_PATH", str(fake_repo))
+        monkeypatch.setenv("ENVIRONMENT", "production")
+        
+        actual_repo = Path(__file__).resolve().parent.parent.parent.parent.parent.parent
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = str(actual_repo) + "\n"
+        monkeypatch.setattr(subprocess, "run", lambda *args, **kwargs: mock_result)
+        
+        if hasattr(repo_root_module.get_repo_root, 'cache_clear'):
+            repo_root_module.get_repo_root.cache_clear()
+        
+        result = repo_root_module.get_repo_root()
+        
+        assert result == actual_repo
+        assert result != fake_repo
+        assert "REPO_ROOT_PATH is set in production environment" in caplog.text
+        assert "Ignoring REPO_ROOT_PATH and using auto-detection" in caplog.text
+
+    def test_repo_root_path_allowed_in_non_production(self, tmp_path, repo_root_module, monkeypatch):
+        """REPO_ROOT_PATH should work in non-production environments."""
+        fake_repo = tmp_path / "fake_repo"
+        fake_repo.mkdir()
+        
+        monkeypatch.setenv("REPO_ROOT_PATH", str(fake_repo))
+        monkeypatch.setenv("ENVIRONMENT", "development")
+        
+        if hasattr(repo_root_module.get_repo_root, 'cache_clear'):
+            repo_root_module.get_repo_root.cache_clear()
+        
+        result = repo_root_module.get_repo_root()
+        assert result == fake_repo
+
+    def test_repo_root_path_allowed_when_environment_not_set(self, tmp_path, repo_root_module, monkeypatch):
+        """REPO_ROOT_PATH should work when ENVIRONMENT is not set."""
+        fake_repo = tmp_path / "fake_repo"
+        fake_repo.mkdir()
+        
+        monkeypatch.setenv("REPO_ROOT_PATH", str(fake_repo))
+        monkeypatch.delenv("ENVIRONMENT", raising=False)
+        
+        if hasattr(repo_root_module.get_repo_root, 'cache_clear'):
+            repo_root_module.get_repo_root.cache_clear()
+        
+        result = repo_root_module.get_repo_root()
+        assert result == fake_repo

--- a/scripts/repo_root_utils.py
+++ b/scripts/repo_root_utils.py
@@ -60,14 +60,22 @@ def get_repo_root(start_path: Optional[Path] = None) -> Path:
     """
     env_root = os.environ.get('REPO_ROOT_PATH')
     if env_root:
-        env_path = Path(env_root).resolve()
-        if env_path.exists() and env_path.is_dir():
-            return env_path
-        else:
-            logger.debug(
-                "REPO_ROOT_PATH=%r is not a valid directory; ignoring and falling back to git/sentinels",
-                env_root
+        is_production = os.environ.get('ENVIRONMENT') == 'production'
+        if is_production:
+            logger.warning(
+                "REPO_ROOT_PATH is set in production environment. "
+                "This should only be used in testing/CI. "
+                "Ignoring REPO_ROOT_PATH and using auto-detection."
             )
+        else:
+            env_path = Path(env_root).resolve()
+            if env_path.exists() and env_path.is_dir():
+                return env_path
+            else:
+                logger.debug(
+                    "REPO_ROOT_PATH=%r is not a valid directory; ignoring and falling back to git/sentinels",
+                    env_root
+                )
     
     try:
         result = subprocess.run(


### PR DESCRIPTION
## 描述 (Description)

新增 `REPO_ROOT_PATH` 環境變數的生產環境守衛機制，防止在正式環境中誤用測試/CI 專用的路徑覆蓋功能。

**背景**: PR #1211 引入了 `REPO_ROOT_PATH` 環境變數用於測試和 CI 環境，但缺乏防止生產環境誤用的主動保護機制。本 PR 實作運行時檢查，當偵測到生產環境時自動忽略 `REPO_ROOT_PATH` 設定。

**變更內容**:
- 在使用 `REPO_ROOT_PATH` 前檢查 `ENVIRONMENT` 環境變數
- 若 `ENVIRONMENT == 'production'`，記錄警告並忽略 `REPO_ROOT_PATH`
- 非生產環境或未設定 `ENVIRONMENT` 時維持原有行為
- 新增 3 個測試案例（共 6 個測試，因為參數化 2 個模組）

**受影響檔案**:
- `handoff/20250928/40_App/api-backend/src/utils/repo_root.py`
- `scripts/repo_root_utils.py`
- `handoff/20250928/40_App/api-backend/tests/unit/test_repo_root_discovery.py`

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 為後端基礎設施變更，無用戶可見內容

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（Python 專案，使用 flake8）
- [x] TypeScript 類型檢查通過（不適用於此 PR）
- [x] 所有測試通過：30 個測試全部通過（24 個既有 + 6 個新增）
- [x] 程式碼遵循現有模式和慣例

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 所有環境變數 `ENVIRONMENT` 已在 `config/env.schema.yaml` 中定義

## 🔍 關鍵審查重點

### 1. 生產環境偵測邏輯 (High Priority)
```python
is_production = os.environ.get('ENVIRONMENT') == 'production'
```
**潛在問題**:
- ⚠️ 僅檢查 `ENVIRONMENT == 'production'`（大小寫敏感、精確匹配）
- 如果實際部署使用 `ENVIRONMENT=prod` 或 `NODE_ENV=production`，守衛將**不會**啟動
- Issue #1224 原始討論提到多種環境變數（NODE_ENV, DEPLOYMENT_ENV），但最終只實作 ENVIRONMENT 檢查

**建議審查**:
- [ ] 確認所有生產部署都設定 `ENVIRONMENT=production`（不是 prod、PRODUCTION 或其他值）
- [ ] 考慮是否需要更寬鬆的檢查（例如：`in ('production', 'prod', 'prd')`）
- [ ] 確認是否需要同時檢查 NODE_ENV（對於 Node.js 服務）

### 2. 程式碼重複 (Medium Priority)
相同的守衛邏輯分別實作在兩個檔案中：
- `api-backend/src/utils/repo_root.py`
- `scripts/repo_root_utils.py`

**脈絡**: PR #1225（Follow-up 1）將這兩個檔案整合到 `common/utils/repo_root.py`。如果 #1225 先合併，此 PR 需要更新。

### 3. 測試覆蓋範圍 (Medium Priority)
新增測試驗證：
- ✅ `ENVIRONMENT=production` → REPO_ROOT_PATH 被忽略
- ✅ `ENVIRONMENT=development` → REPO_ROOT_PATH 正常運作
- ✅ `ENVIRONMENT` 未設定 → REPO_ROOT_PATH 正常運作

**未涵蓋場景**:
- ❌ 大小寫變化（PRODUCTION, Prod, prod）
- ❌ 其他生產環境值（staging, preprod）
- ❌ 真實生產環境整合測試

### 4. 行為影響分析
| 場景 | REPO_ROOT_PATH 設定 | ENVIRONMENT 值 | 結果 |
|------|-------------------|----------------|------|
| 本地開發 | ❌ 未設定 | 未設定 | 使用 git/sentinel 自動偵測 ✅ |
| 單元測試 | ✅ 設定 | 未設定 | 使用 REPO_ROOT_PATH 覆蓋 ✅ |
| CI/CD | ✅ 設定 | development/testing | 使用 REPO_ROOT_PATH 覆蓋 ✅ |
| 生產環境（正確配置） | ✅ 誤設定 | production | **忽略 REPO_ROOT_PATH**，記錄警告 ✅ |
| 生產環境（錯誤配置） | ✅ 誤設定 | prod/未設定 | **使用錯誤的 REPO_ROOT_PATH** ⚠️ |

## 🔗 相關連結
- Issue: #1224
- Devin Session: https://app.devin.ai/sessions/3fa773a244c44a02b03cd0e336cd3353
- 相關 PR: #1225 (Follow-up 1: 整合重複實作), #1226 (Follow-up 2), #1227 (Follow-up 3)
- Requested by: Ryan Chen (@RC918)

## 📋 測試結果
```
============================== 30 passed in 0.15s ==============================
```
- 24 個既有測試保持通過
- 6 個新增測試通過（3 個測試 × 2 個參數化模組）