### PR TITLE
fix(ops-agent): Add missing pydantic-settings dependency

### DIFF
--- a/agents/ops_agent/requirements.txt
+++ b/agents/ops_agent/requirements.txt
@@ -5,5 +5,6 @@ pytest-asyncio==1.2.0
 redis==5.0.1
 requests==2.31.0
 pydantic>=2.10.0
+pydantic-settings>=2.0.0
 PyYAML>=6.0
 supabase==2.6.0


### PR DESCRIPTION
## 描述 (Description)

修復生產環境 ops_agent worker 啟動失敗問題。ops_agent 從 `utils.redis_config` 導入時，該模組依賴 `common.config.settings`，而 settings 模組需要 `pydantic-settings` 套件，但此套件未包含在 `agents/ops_agent/requirements.txt` 中。

**錯誤訊息**：
```
ModuleNotFoundError: No module named 'pydantic_settings'
```

**根本原因**：
最近的 PR (#1216, #1212) 將環境變數存取遷移到集中式 settings 模組並進行 SecretStr 強化，使得 `utils/redis_config.py` 現在依賴 `pydantic-settings`。ops_agent 服務在 Render 上沒有安裝此依賴項。

**變更內容**：
- 在 `agents/ops_agent/requirements.txt` 中新增 `pydantic-settings>=2.0.0`，與 api-backend 的依賴需求保持一致

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] 僅修改 requirements.txt（依賴項變更）
- [x] 無程式碼變更，無需 ESLint/TypeScript 檢查
- [x] 無測試變更
- [x] 遵循現有依賴項管理模式

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 此為緊急修復 PR，僅包含依賴項變更
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義（無新增環境變數）

## 人工審查重點 (Human Review Checklist)

請特別注意以下項目：

1. **版本相容性**：確認 `pydantic-settings>=2.0.0` 與現有的 `pydantic>=2.10.0` 相容
2. **其他服務**：檢查是否有其他 agent 服務（faq_agent, dev_agent）也可能缺少類似依賴
3. **生產驗證**：部署後檢查 Render 日誌，確認 ops_agent worker 成功啟動
4. **架構考量**：此問題揭示了跨服務依賴管理的潛在問題，未來可能需要更好的依賴管理策略

## 測試計劃

由於這是生產環境緊急修復：
- ✅ 已驗證導入鏈：`worker.py` → `redis_config.py` → `settings.py` → `pydantic_settings`
- ✅ 已確認 api-backend 使用相同版本約束
- ⏳ 部署後需驗證：ops_agent worker 在 Render 上成功啟動（檢查日誌無 ModuleNotFoundError）

---

**Link to Devin run**: https://app.devin.ai/sessions/313f4c0f7f59412ea76124cfb9e979fc  
**Requested by**: Ryan Chen (@RC918)