### PR TITLE
test: Extend deprecated import check to detect aliased imports (Task 7)

### DIFF
--- a/handoff/20250928/40_App/api-backend/tests/lint/test_no_deprecated_imports.py
+++ b/handoff/20250928/40_App/api-backend/tests/lint/test_no_deprecated_imports.py
@@ -66,6 +66,9 @@ def check_file_for_deprecated_imports(file_path: Path) -> List[Tuple[int, str, s
                             ))
             
             elif isinstance(node, ast.ImportFrom):
+                if node.level > 0:
+                    continue
+                
                 if node.module:
                     for deprecated in DEPRECATED_MODULES:
                         if node.module == deprecated or node.module.endswith(f".{deprecated}"):
@@ -81,9 +84,10 @@ def check_file_for_deprecated_imports(file_path: Path) -> List[Tuple[int, str, s
                                 import_stmt,
                                 deprecated
                             ))
-                        elif deprecated.endswith(f".{node.module}"):
+                        else:
                             for alias in node.names:
-                                if alias.name == deprecated.split('.')[-1]:
+                                fqn = f"{node.module}.{alias.name}"
+                                if fqn == deprecated:
                                     import_stmt = f"from {node.module} import {alias.name}"
                                     if alias.asname:
                                         import_stmt += f" as {alias.asname}"
@@ -166,16 +170,21 @@ def test_aliased_import_detection():
     import tempfile
     
     test_cases = [
-        # (code, should_detect, description)
         ("import utils.preauth_token", True, "Direct module import"),
         ("import utils.preauth_token as preauth", True, "Module import with alias"),
         ("from utils.preauth_token import generate_preauth_token", True, "Direct function import"),
         ("from utils.preauth_token import generate_preauth_token as gen_token", True, "Function import with alias"),
         ("from utils.preauth_token import generate_preauth_token as gen, validate_and_consume_preauth_token as validate", True, "Multiple imports with aliases"),
         ("from utils.preauth_token import generate_preauth_token, validate_and_consume_preauth_token as validate", True, "Mixed imports (some aliased)"),
+        ("from utils import preauth_token", True, "Import submodule from parent"),
+        ("from utils import preauth_token as pt", True, "Import submodule from parent with alias"),
+        ("from utils.preauth_token import *", True, "Star import"),
+        ("from utils.preauth_token import (\n    generate_preauth_token as gen\n)", True, "Multi-line import with parentheses"),
         ("from utils.pre_auth_token import PreAuthTokenManager", False, "Valid import (not deprecated)"),
         ("import utils.pre_auth_token", False, "Valid module import (not deprecated)"),
         ("from utils.pre_auth_token import PreAuthTokenManager as Manager", False, "Valid aliased import (not deprecated)"),
+        ("import utils.preauth_token_tools", False, "Similar name should not trigger"),
+        ("from utils import preauth_token_tools", False, "Similar submodule name should not trigger"),
     ]
     
     for code, should_detect, description in test_cases:


### PR DESCRIPTION
## 描述 (Description)

擴展 deprecated import 檢查以偵測 **aliased imports** 並修復關鍵 bug。

### 🐛 Critical Bug Fix

**問題**：`from utils import preauth_token` 和 `from utils import preauth_token as pt` 完全未被偵測

**根本原因**：
```python
# ❌ 錯誤邏輯（line 84）
elif deprecated.endswith(f".{node.module}"):
```
檢查 `"utils.preauth_token".endswith(".utils")` → 永遠為 `False`

**修復**：
```python
# ✅ 正確邏輯
fqn = f"{node.module}.{alias.name}"  # 構建完整限定名稱
if fqn == deprecated:  # 直接比對
```

### 🎯 新增功能

現在可偵測所有 aliased import 模式：
- ✅ `import utils.preauth_token as preauth` - 模組別名
- ✅ `from utils.preauth_token import func as f` - 函數別名  
- ✅ `from utils import preauth_token as pt` - 子模組別名（**之前未偵測**）
- ✅ `from utils.preauth_token import *` - 星號導入
- ✅ Multi-line imports with parentheses

### 📊 測試覆蓋

- **測試案例數**：15（原本 9）
- **新增關鍵測試**：
  - `from utils import preauth_token` ← **修復前未偵測**
  - `from utils import preauth_token as pt` ← **修復前未偵測**
  - Star imports, multi-line imports
  - Negative tests for similar names (`preauth_token_tools`)

### 🔒 相對導入政策

明確跳過相對導入（`if node.level > 0: continue`），理由：
- 生產代碼應使用絕對導入
- 相對導入路徑解析複雜且易錯
- 可透過其他 lint 規則強制絕對導入

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅測試/lint 工具）

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）
- [x] TypeScript 類型檢查通過（N/A - Python 檔案）
- [x] 所有測試通過：`pytest tests/lint/test_no_deprecated_imports.py -v` (2/2 passed)
- [x] 程式碼遵循現有模式和慣例

## 提醒
- [x] 不在 src/** 中導入已廢棄的模組 - **這正是此 PR 要防止的**
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義（N/A）

---

## 🔍 審查重點 (Review Checklist)

### Critical - 必須審查
1. **FQN 構建邏輯** (line 89-90)
   ```python
   fqn = f"{node.module}.{alias.name}"
   if fqn == deprecated:
   ```
   驗證此邏輯正確構建完整模組路徑

2. **相對導入政策** (line 69-70)
   ```python
   if node.level > 0:
       continue  # Skip relative imports
   ```
   確認團隊同意跳過相對導入的決策

3. **False Positive 測試**
   - Line 186: `import utils.preauth_token_tools` 不應觸發
   - Line 187: `from utils import preauth_token_tools` 不應觸發
   - 驗證類似名稱不會誤報

### Important - 建議審查
4. **Star import 處理** (line 181) - 確認 `from utils.preauth_token import *` 被正確偵測
5. **Multi-line import** (line 182) - 確認 AST 正確解析括號內的多行導入
6. **Error message 格式** - 確認顯示完整 import 語句（包含別名）

### Low Priority
7. 測試覆蓋是否有遺漏的 edge case

---

**Link to Devin run**: https://app.devin.ai/sessions/3fa773a244c44a02b03cd0e336cd3353  
**Requested by**: Ryan Chen (@RC918)

**本地驗證**：
```bash
$ pytest tests/lint/test_no_deprecated_imports.py -v
# ✅ 2 passed in 0.20s

# Bug 驗證
$ python /tmp/test_bug_verification.py  
# ✅ Found 2 violations (both patterns now detected)
```