### PR TITLE
hotfix: Fix Python syntax error in monitor_orchestrator.py f-string

### DIFF
--- a/scripts/monitor_orchestrator.py
+++ b/scripts/monitor_orchestrator.py
@@ -53,7 +53,8 @@ class OrchestratorMonitor:
     def send_slack_alert(self, message: str, severity: str = "warning") -> bool:
         """Send alert to Slack (gracefully skips if webhook not configured)"""
         if not self.slack_webhook_url:
-            print(f"[{severity.upper()}] {message.replace('*', '').replace('\\n', ' ')}")
+            sanitized_message = message.replace('*', '').replace('\n', ' ')
+            print(f"[{severity.upper()}] {sanitized_message}")
             return True
         
         emoji_map = {


### PR DESCRIPTION
## 描述 (Description)

**🚨 CRITICAL HOTFIX**: Fixes Python SyntaxError causing Monitor Orchestrator workflow to fail every 5 minutes.

**Root Cause**: PR #1258 (commit cc8d7970) introduced a syntax error in `scripts/monitor_orchestrator.py` line 56:
```python
# ❌ BROKEN - f-string expressions cannot contain backslashes
print(f"[{severity.upper()}] {message.replace('*', '').replace('\\n', ' ')}")
```

**Error**:
```
SyntaxError: f-string expression part cannot include a backslash
```

**Fix**: Pre-sanitize the message string outside the f-string expression:
```python
# ✅ FIXED
sanitized_message = message.replace('*', '').replace('\n', ' ')
print(f"[{severity.upper()}] {sanitized_message}")
```

## 🔍 Review Checklist

**Critical Items**:
- [ ] Verify the syntax fix is correct (pre-sanitizing string outside f-string)
- [ ] Confirm this resolves the workflow failure (check next scheduled run after merge)
- [ ] No functional changes - only syntax fix

**Low Priority**:
- [ ] Consider adding `python -m py_compile scripts/*.py` to CI in follow-up PR

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅修復 Python 語法錯誤）

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] 語法檢查通過：`python -m py_compile scripts/monitor_orchestrator.py` ✅
- [x] 程式碼遵循現有模式和慣例
- [x] 無功能變更 - 僅修復語法錯誤

## 提醒

- [x] 這是緊急 hotfix - workflow 每 5 分鐘失敗一次
- [x] 變更最小化 - 僅 2 行改動
- [x] 已在本地驗證語法正確

---

**Link to Devin run**: https://app.devin.ai/sessions/48110040209243b7ad1e6d4837958ca2  
**Requested by**: Ryan Chen (@RC918)

**Impact**: Fixes workflow failures introduced in PR #1258  
**Urgency**: HIGH - Workflow failing every 5 minutes on main branch  
**Risk**: MINIMAL - Simple syntax fix with no functional changes