### PR TITLE
fix: Correct Tolgee CLI bootstrap syntax (--files-template instead of --path)

### DIFF
--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -39,7 +39,7 @@ jobs:
           TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
         run: |
           echo "🚀 Bootstrap: Pushing existing translations to Owner Console (Project #24693)..."
-          tolgee push --api-key "$TOLGEE_API_KEY" --path ./src/locales --force-mode OVERRIDE
+          tolgee push --api-key "$TOLGEE_API_KEY" --files-template "./src/locales/{languageTag}.json" --force-mode OVERRIDE
           echo "✅ Owner Console translations pushed successfully"
 
       - name: Bootstrap - Push translations to Frontend Dashboard (one-time)
@@ -49,7 +49,7 @@ jobs:
           TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
         run: |
           echo "🚀 Bootstrap: Pushing existing translations to Frontend Dashboard (Project #24702)..."
-          tolgee push --api-key "$TOLGEE_API_KEY" --path ./src/i18n/locales --force-mode OVERRIDE
+          tolgee push --api-key "$TOLGEE_API_KEY" --files-template "./src/i18n/locales/{languageTag}.json" --force-mode OVERRIDE
           echo "✅ Frontend Dashboard translations pushed successfully"
 
       - name: Preflight - Dry Pull and Validate Frontend Dashboard


### PR DESCRIPTION
## 描述 (Description)

修復 Tolgee bootstrap workflow 失敗問題。原始 workflow 使用了不存在的 `--path` 選項導致執行失敗（`error: unknown option '--path'`）。

**問題根源**：Tolgee CLI v2.14.0 的 `tolgee push` 命令不支持 `--path` 選項，正確的選項是 `--files-template`。

**修復內容**：
- Owner Console: `--path ./src/locales` → `--files-template "./src/locales/{languageTag}.json"`
- Frontend Dashboard: `--path ./src/i18n/locales` → `--files-template "./src/i18n/locales/{languageTag}.json"`

這是一次性 bootstrap 操作的修復，用於將現有翻譯推送到新的獨立 Tolgee projects (#24693 和 #24702)。

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 僅修復 CI/CD workflow，無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] 僅修改 GitHub Actions workflow 檔案
- [x] 語法符合 Tolgee CLI v2.14.0 規範
- [x] 保持原有的 `--force-mode OVERRIDE` 參數

## ⚠️ 重要審查項目

**需要人工驗證的風險點**：

1. **檔案模式匹配**：`{languageTag}` placeholder 是否正確匹配 `en-US.json` 和 `zh-TW.json`？
   - Owner Console 有：`en-US.json`, `en.json`, `zh-TW.json`
   - Frontend Dashboard 有：`en-US.json`, `zh-TW.json`
   - 需確認 Tolgee CLI 是否支持帶連字符的 language tags

2. **格式參數**：`.tolgeerc` 指定 `"format": "JSON_I18NEXT"`，但 push 命令未明確傳遞 `--format`
   - 需確認 CLI 是否會自動讀取 `.tolgeerc` 的 format 設定
   - 或是否需要明確添加 `--format JSON_I18NEXT` 參數

3. **未經測試**：此修復基於 CLI help 文檔，但未在實際環境中測試
   - 建議合併後立即運行 bootstrap workflow 驗證
   - 如失敗，可能需要調整 file pattern 或添加 format 參數

## 測試計劃

合併後執行以下步驟驗證：
1. 運行 bootstrap workflow（勾選 bootstrap 選項）
2. 檢查 workflow 日誌確認無錯誤
3. 驗證 Tolgee projects #24693 和 #24702 包含翻譯（詞條數 > 0）
4. 確認所有語言檔案都被正確推送

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 僅修改 CI/CD workflow
- [x] 所有環境變數已在先前 PR 中定義

---

**Link to Devin run**: https://app.devin.ai/sessions/1eb210bed90a4ecf955798198d50f9d4  
**Requested by**: Ryan Chen (@RC918)