### PR TITLE
fix: Add --no-strict-namespace flag to Tolgee bootstrap push

### DIFF
--- a/.github/workflows/tolgee-sync.yml
+++ b/.github/workflows/tolgee-sync.yml
@@ -39,7 +39,7 @@ jobs:
           TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
         run: |
           echo "🚀 Bootstrap: Pushing existing translations to Owner Console (Project #24693)..."
-          tolgee push --api-key "$TOLGEE_API_KEY" --files-template "./src/locales/{languageTag}.json" --force-mode OVERRIDE
+          tolgee push --api-key "$TOLGEE_API_KEY" --files-template "src/locales/{languageTag}.json" --no-strict-namespace --force-mode OVERRIDE
           echo "✅ Owner Console translations pushed successfully"
 
       - name: Bootstrap - Push translations to Frontend Dashboard (one-time)
@@ -49,7 +49,7 @@ jobs:
           TOLGEE_API_KEY: ${{ secrets.TOLGEE_API_KEY }}
         run: |
           echo "🚀 Bootstrap: Pushing existing translations to Frontend Dashboard (Project #24702)..."
-          tolgee push --api-key "$TOLGEE_API_KEY" --files-template "./src/i18n/locales/{languageTag}.json" --force-mode OVERRIDE
+          tolgee push --api-key "$TOLGEE_API_KEY" --files-template "src/i18n/locales/{languageTag}.json" --no-strict-namespace --force-mode OVERRIDE
           echo "✅ Frontend Dashboard translations pushed successfully"
 
       - name: Preflight - Dry Pull and Validate Frontend Dashboard


### PR DESCRIPTION
## 描述 (Description)

修復 Tolgee bootstrap workflow 的第二個語法錯誤。在 PR #1277 修復 `--path` 選項後，bootstrap 執行時遇到新錯誤：`🔴 Unexpected part "./src/locales/" in template`。

**根本原因**：Tolgee CLI 使用 `JSON_I18NEXT` 格式時，預設期望文件結構包含 namespace（命名空間），但我們的翻譯文件沒有使用 namespace 結構。

**解決方案**：
1. 添加 `--no-strict-namespace` 旗標告訴 CLI 我們不使用 namespace
2. 移除 `./` 前綴使路徑更簡潔（可選優化）

## 變更內容

### Owner Console Bootstrap
```diff
- tolgee push --api-key "$TOLGEE_API_KEY" --files-template "./src/locales/{languageTag}.json" --force-mode OVERRIDE
+ tolgee push --api-key "$TOLGEE_API_KEY" --files-template "src/locales/{languageTag}.json" --no-strict-namespace --force-mode OVERRIDE
```

### Frontend Dashboard Bootstrap
```diff
- tolgee push --api-key "$TOLGEE_API_KEY" --files-template "./src/i18n/locales/{languageTag}.json" --force-mode OVERRIDE
+ tolgee push --api-key "$TOLGEE_API_KEY" --files-template "src/i18n/locales/{languageTag}.json" --no-strict-namespace --force-mode OVERRIDE
```

## 重要審查點

⚠️ **關鍵風險**：此修復基於 Tolgee CLI 錯誤訊息和文檔分析，但**無法在本地環境測試實際 bootstrap 執行**。

**請審查者特別注意**：
1. ✅ `--no-strict-namespace` 是否為 Tolgee CLI v2.14.0 的正確旗標？
2. ✅ 移除 `./` 前綴是否會影響 `working-directory` 的路徑解析？
3. ✅ 是否有其他潛在的 Tolgee CLI 配置問題？

## 測試計劃

由於這是 GitHub Actions workflow 變更，測試方式為：
1. 合併此 PR 到 main
2. 手動觸發 Tolgee sync workflow 並勾選 bootstrap 選項
3. 驗證日誌顯示成功訊息
4. 確認 Tolgee projects (#24693, #24702) 包含翻譯

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅修改 CI workflow）

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（workflow YAML 語法正確）
- [x] 所有 CI 檢查通過
- [x] 變更遵循現有 workflow 模式

## 提醒
- [x] 此為 workflow 修復，不涉及 OpenAPI/資料欄位
- [x] 不涉及已廢棄目錄或模組

---

**相關 PR**：
- PR #1277: 第一次修復（`--path` → `--files-template`）
- PR #1259, #1260, #1265: Tolgee 分離和清理相關 PR


**Devin Session**: https://app.devin.ai/sessions/1eb210bed90a4ecf955798198d50f9d4  
**Requested by**: Ryan Chen (@RC918)