### PR TITLE
Phase 1-2 Cleanup: Add USE_LLM_PLANNER and USE_CODEGEN_WORKFLOW_PERCENT flags

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -503,6 +503,15 @@ USE_LANGGRAPH=false
 # Required: False
 USE_LANGGRAPH_PERCENT=0
 
+# Enable LLM-powered planner in LangGraph orchestrator (Phase 1)
+# Controls whether the planner node uses LLM for dynamic planning:
+# - false (default): Static planning (hardcoded steps)
+# - true: LLM-powered dynamic planning (GPT-4 generates execution steps)
+# Requires OPENAI_API_KEY to be set for LLM operations.
+# Only effective when USE_LANGGRAPH=true or USE_LANGGRAPH_PERCENT>0.
+# Required: False
+USE_LLM_PLANNER=false
+
 # Enable AI-powered code generation workflow (Phase 2)
 # Controls whether the code generation workflow is enabled:
 # - false (default): Code generation workflow disabled
@@ -510,6 +519,13 @@ USE_LANGGRAPH_PERCENT=0
 # Requires OPENAI_API_KEY to be set for LLM operations.
 # Required: False
 USE_CODE_GENERATION=false
+
+# Percentage of tasks to use code generation workflow (0-100, for canary rollout)
+# Canary rollout mechanism for code generation workflow. Takes precedence over USE_CODE_GENERATION.
+# Example: 10 = 10% of tasks use code generation, 90% use standard workflow.
+# Uses same MD5 hash routing as USE_LANGGRAPH_PERCENT for deterministic task assignment.
+# Required: False
+USE_CODEGEN_WORKFLOW_PERCENT=0
 
 # Enable cookie-based authentication (vs header-only)
 # Required: False

--- a/config/env.schema.yaml
+++ b/config/env.schema.yaml
@@ -1,17 +1,17 @@
 version: '1.1'
 description: Morning AI Complete Environment Schema (Phase 11 + Missing Variables)
 metadata:
-  total_variables: 133
+  total_variables: 135
   required_variables: 20
-  optional_variables: 113
+  optional_variables: 115
   last_updated: '2025-11-18'
-  notes: 'Added 52 missing variables found in codebase:
+  notes: 'Added 54 missing variables found in codebase:
 
     - TOTP_ENCRYPTION_KEY (critical for 2FA)
 
     - ENABLE_MOCK_USERS (security flag)
 
-    - USE_LANGGRAPH, USE_LANGGRAPH_PERCENT, USE_CODE_GENERATION (orchestrator control)
+    - USE_LANGGRAPH, USE_LANGGRAPH_PERCENT, USE_LLM_PLANNER, USE_CODE_GENERATION, USE_CODEGEN_WORKFLOW_PERCENT (orchestrator control)
 
     - Rate limiting, monitoring, testing, and infrastructure variables
 
@@ -685,6 +685,24 @@ fields:
       Example: 5 = 5% of tasks use LangGraph, 95% use simple mode.
 
       '
+  USE_LLM_PLANNER:
+    type: boolean
+    required: false
+    default: false
+    description: Enable LLM-powered planner in LangGraph orchestrator (Phase 1)
+    category: Feature Flags
+    security_level: public
+    notes: 'Controls whether the planner node uses LLM for dynamic planning:
+
+      - false (default): Static planning (hardcoded steps)
+
+      - true: LLM-powered dynamic planning (GPT-4 generates execution steps)
+
+      Requires OPENAI_API_KEY to be set for LLM operations.
+
+      Only effective when USE_LANGGRAPH=true or USE_LANGGRAPH_PERCENT>0.
+
+      '
   USE_CODE_GENERATION:
     type: boolean
     required: false
@@ -699,6 +717,22 @@ fields:
       - true: Enable LLM-powered code generation with security validation
 
       Requires OPENAI_API_KEY to be set for LLM operations.
+
+      '
+  USE_CODEGEN_WORKFLOW_PERCENT:
+    type: integer
+    required: false
+    default: 0
+    min: 0
+    max: 100
+    description: Percentage of tasks to use code generation workflow (0-100, for canary rollout)
+    category: Feature Flags
+    security_level: public
+    notes: 'Canary rollout mechanism for code generation workflow. Takes precedence over USE_CODE_GENERATION.
+
+      Example: 10 = 10% of tasks use code generation, 90% use standard workflow.
+
+      Uses same MD5 hash routing as USE_LANGGRAPH_PERCENT for deterministic task assignment.
 
       '
   SUPABASE_DB_PASSWORD:

--- a/docs/ops/staging-backend-env-template.txt
+++ b/docs/ops/staging-backend-env-template.txt
@@ -55,6 +55,15 @@ TESTING=false
 # Feature Flags
 # HITL_APPROVAL_ENABLED=false
 
+# LangGraph Canary Rollout (Phase 1)
+USE_LANGGRAPH_PERCENT=5
+
+# LLM Planner (Phase 1 - requires USE_LANGGRAPH_PERCENT>0)
+USE_LLM_PLANNER=false
+
+# Code Generation Canary Rollout (Phase 2)
+USE_CODEGEN_WORKFLOW_PERCENT=0
+
 # ============================================
 # NOTES
 # ============================================

--- a/handoff/20250928/40_App/api-backend/.env.example
+++ b/handoff/20250928/40_App/api-backend/.env.example
@@ -503,6 +503,15 @@ USE_LANGGRAPH=false
 # Required: False
 USE_LANGGRAPH_PERCENT=0
 
+# Enable LLM-powered planner in LangGraph orchestrator (Phase 1)
+# Controls whether the planner node uses LLM for dynamic planning:
+# - false (default): Static planning (hardcoded steps)
+# - true: LLM-powered dynamic planning (GPT-4 generates execution steps)
+# Requires OPENAI_API_KEY to be set for LLM operations.
+# Only effective when USE_LANGGRAPH=true or USE_LANGGRAPH_PERCENT>0.
+# Required: False
+USE_LLM_PLANNER=false
+
 # Enable AI-powered code generation workflow (Phase 2)
 # Controls whether the code generation workflow is enabled:
 # - false (default): Code generation workflow disabled
@@ -510,6 +519,13 @@ USE_LANGGRAPH_PERCENT=0
 # Requires OPENAI_API_KEY to be set for LLM operations.
 # Required: False
 USE_CODE_GENERATION=false
+
+# Percentage of tasks to use code generation workflow (0-100, for canary rollout)
+# Canary rollout mechanism for code generation workflow. Takes precedence over USE_CODE_GENERATION.
+# Example: 10 = 10% of tasks use code generation, 90% use standard workflow.
+# Uses same MD5 hash routing as USE_LANGGRAPH_PERCENT for deterministic task assignment.
+# Required: False
+USE_CODEGEN_WORKFLOW_PERCENT=0
 
 # Enable cookie-based authentication (vs header-only)
 # Required: False

--- a/handoff/20250928/40_App/frontend-dashboard/.env.example
+++ b/handoff/20250928/40_App/frontend-dashboard/.env.example
@@ -201,6 +201,15 @@ USE_LANGGRAPH=false
 # Required: False
 USE_LANGGRAPH_PERCENT=0
 
+# Enable LLM-powered planner in LangGraph orchestrator (Phase 1)
+# Controls whether the planner node uses LLM for dynamic planning:
+# - false (default): Static planning (hardcoded steps)
+# - true: LLM-powered dynamic planning (GPT-4 generates execution steps)
+# Requires OPENAI_API_KEY to be set for LLM operations.
+# Only effective when USE_LANGGRAPH=true or USE_LANGGRAPH_PERCENT>0.
+# Required: False
+USE_LLM_PLANNER=false
+
 # Enable AI-powered code generation workflow (Phase 2)
 # Controls whether the code generation workflow is enabled:
 # - false (default): Code generation workflow disabled
@@ -208,6 +217,13 @@ USE_LANGGRAPH_PERCENT=0
 # Requires OPENAI_API_KEY to be set for LLM operations.
 # Required: False
 USE_CODE_GENERATION=false
+
+# Percentage of tasks to use code generation workflow (0-100, for canary rollout)
+# Canary rollout mechanism for code generation workflow. Takes precedence over USE_CODE_GENERATION.
+# Example: 10 = 10% of tasks use code generation, 90% use standard workflow.
+# Uses same MD5 hash routing as USE_LANGGRAPH_PERCENT for deterministic task assignment.
+# Required: False
+USE_CODEGEN_WORKFLOW_PERCENT=0
 
 # Enable cookie-based authentication (vs header-only)
 # Required: False

--- a/handoff/20250928/40_App/owner-console/.env.example
+++ b/handoff/20250928/40_App/owner-console/.env.example
@@ -201,6 +201,15 @@ USE_LANGGRAPH=false
 # Required: False
 USE_LANGGRAPH_PERCENT=0
 
+# Enable LLM-powered planner in LangGraph orchestrator (Phase 1)
+# Controls whether the planner node uses LLM for dynamic planning:
+# - false (default): Static planning (hardcoded steps)
+# - true: LLM-powered dynamic planning (GPT-4 generates execution steps)
+# Requires OPENAI_API_KEY to be set for LLM operations.
+# Only effective when USE_LANGGRAPH=true or USE_LANGGRAPH_PERCENT>0.
+# Required: False
+USE_LLM_PLANNER=false
+
 # Enable AI-powered code generation workflow (Phase 2)
 # Controls whether the code generation workflow is enabled:
 # - false (default): Code generation workflow disabled
@@ -208,6 +217,13 @@ USE_LANGGRAPH_PERCENT=0
 # Requires OPENAI_API_KEY to be set for LLM operations.
 # Required: False
 USE_CODE_GENERATION=false
+
+# Percentage of tasks to use code generation workflow (0-100, for canary rollout)
+# Canary rollout mechanism for code generation workflow. Takes precedence over USE_CODE_GENERATION.
+# Example: 10 = 10% of tasks use code generation, 90% use standard workflow.
+# Uses same MD5 hash routing as USE_LANGGRAPH_PERCENT for deterministic task assignment.
+# Required: False
+USE_CODEGEN_WORKFLOW_PERCENT=0
 
 # Enable cookie-based authentication (vs header-only)
 # Required: False

--- a/orchestrator/.env.example
+++ b/orchestrator/.env.example
@@ -260,6 +260,15 @@ USE_LANGGRAPH=false
 # Required: False
 USE_LANGGRAPH_PERCENT=0
 
+# Enable LLM-powered planner in LangGraph orchestrator (Phase 1)
+# Controls whether the planner node uses LLM for dynamic planning:
+# - false (default): Static planning (hardcoded steps)
+# - true: LLM-powered dynamic planning (GPT-4 generates execution steps)
+# Requires OPENAI_API_KEY to be set for LLM operations.
+# Only effective when USE_LANGGRAPH=true or USE_LANGGRAPH_PERCENT>0.
+# Required: False
+USE_LLM_PLANNER=false
+
 # Enable AI-powered code generation workflow (Phase 2)
 # Controls whether the code generation workflow is enabled:
 # - false (default): Code generation workflow disabled
@@ -267,6 +276,13 @@ USE_LANGGRAPH_PERCENT=0
 # Requires OPENAI_API_KEY to be set for LLM operations.
 # Required: False
 USE_CODE_GENERATION=false
+
+# Percentage of tasks to use code generation workflow (0-100, for canary rollout)
+# Canary rollout mechanism for code generation workflow. Takes precedence over USE_CODE_GENERATION.
+# Example: 10 = 10% of tasks use code generation, 90% use standard workflow.
+# Uses same MD5 hash routing as USE_LANGGRAPH_PERCENT for deterministic task assignment.
+# Required: False
+USE_CODEGEN_WORKFLOW_PERCENT=0
 
 # Enable cookie-based authentication (vs header-only)
 # Required: False


### PR DESCRIPTION
## 描述 (Description)

此 PR 完成 Phase 1-2 補完任務，新增兩個 feature flags 以支援未來的 LLM planner 和 code generation 功能：

1. **USE_LLM_PLANNER** (boolean) - 控制 LangGraph orchestrator 中的 planner node 是否使用 LLM 動態規劃
2. **USE_CODEGEN_WORKFLOW_PERCENT** (integer, 0-100) - Code generation workflow 的金絲雀部署百分比

此外，更新 staging 環境配置模板，設定 `USE_LANGGRAPH_PERCENT=5` 以啟用 Phase 1 金絲雀部署。

**重要**: 此 PR 僅新增配置基礎設施，不包含實際的 LLM planner 或 code generation 實作。這些功能將在後續 PR 中實作。

**相關路線圖**: ROADMAP_INTEGRATION_ANALYSIS.md Phase 1-2 補完任務

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 手動測試 (Manual Testing) - 驗證配置文件正確性
- [ ] 單元測試 (Unit Tests) - 無需測試（僅配置變更）
- [ ] 整合測試 (Integration Tests) - 無需測試（無實作）
- [ ] E2E 測試 (End-to-End Tests) - 無需測試（無實作）

### 測試步驟 (Test Steps)

1. 驗證 `config/env.schema.yaml` 包含新的 feature flags
2. 確認所有 `.env.example` 文件已正確生成（使用 `scripts/generate-env-examples.py`）
3. 檢查 `docs/ops/staging-backend-env-template.txt` 包含 Phase 1 配置
4. 確認 metadata 中的 `total_variables` 從 133 更新為 135

### 預期結果 (Expected Results)

- `USE_LLM_PLANNER` 和 `USE_CODEGEN_WORKFLOW_PERCENT` 出現在所有 `.env.example` 文件中
- Staging 配置模板包含 `USE_LANGGRAPH_PERCENT=5`
- 所有配置文件格式正確，無語法錯誤

### 實際結果 (Actual Results)

✅ 所有 `.env.example` 文件已正確生成
✅ Staging 配置模板已更新
✅ env.schema.yaml metadata 已更新（133 → 135 variables）

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline - 等待 CI 檢查

### 受影響的區域 (Affected Areas)

- 環境變數配置系統
- Staging 環境部署文檔
- 未來的 Phase 1-2 實作將依賴這些 flags

### 新增的自動化測試 (New Automated Tests)

無 - 此 PR 僅新增配置，無需新增測試

## i18n 檢查清單（強制）


- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）- 僅配置文件變更
- [x] TypeScript 類型檢查通過 - 無 TypeScript 變更
- [x] 無 `any` 類型 - 無程式碼變更
- [x] 所有測試通過 - 無測試變更需要
- [x] 程式碼遵循現有模式和慣例 - 遵循 USE_LANGGRAPH_PERCENT 模式

## 文檔更新檢查清單 (Documentation Updates)

- [x] **新增/修改環境變數** → 已更新 `config/env.schema.yaml` 和 `docs/ops/staging-backend-env-template.txt`
- [x] 不適用 - 其他類型的文檔更新

**重要**: 
- ✅ `config/env.schema.yaml` 已更新為 SSOT
- ✅ Staging 環境模板已反映新的環境變數
- ⚠️ 實際 staging 環境需要手動在 Render dashboard 更新這些變數

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義
- [x] 使用官方腳本生成 `.env.example` 文件

## 變更摘要 (Changes Summary)

### 新增的環境變數 (New Environment Variables)

1. **USE_LLM_PLANNER** (boolean, default: false)
   - 用途: 啟用 LangGraph orchestrator 中的 LLM-powered planner
   - 依賴: 需要 `USE_LANGGRAPH=true` 或 `USE_LANGGRAPH_PERCENT>0`
   - 需要: `OPENAI_API_KEY`

2. **USE_CODEGEN_WORKFLOW_PERCENT** (integer, 0-100, default: 0)
   - 用途: Code generation workflow 的金絲雀部署百分比
   - 機制: 使用與 `USE_LANGGRAPH_PERCENT` 相同的 MD5 hash 路由
   - 優先級: 高於 `USE_CODE_GENERATION` boolean flag

### Staging 配置更新 (Staging Config Updates)

在 `docs/ops/staging-backend-env-template.txt` 中新增：
- `USE_LANGGRAPH_PERCENT=5` - Phase 1 金絲雀部署（5% 流量）
- `USE_LLM_PLANNER=false` - 預設關閉，待實作完成後啟用
- `USE_CODEGEN_WORKFLOW_PERCENT=0` - Phase 2 預留，預設關閉

## 審查重點 (Review Checklist)

請特別注意以下項目：

1. **Flag 命名**: 確認 `USE_LLM_PLANNER` 和 `USE_CODEGEN_WORKFLOW_PERCENT` 符合路線圖要求
2. **Canary 機制**: 確認 `USE_CODEGEN_WORKFLOW_PERCENT` 的描述正確說明使用 MD5 hash 路由
3. **Staging 配置**: 確認 `USE_LANGGRAPH_PERCENT=5` 是合理的 Phase 1 金絲雀百分比
4. **Metadata 正確性**: 確認 `total_variables: 135` 正確（133 + 2 新增）
5. **無實作代碼**: 確認此 PR 僅包含配置變更，無意外包含實作代碼

## 後續步驟 (Next Steps)

此 PR 合併後，Phase 1-2 實作可以開始：
1. Phase 1: 實作 LLM planner adapter 整合到 `planner_node`
2. Phase 2: 實作 code generation workflow 整合到 `executor_node`
3. 在 staging 環境手動設定 `USE_LANGGRAPH_PERCENT=5` 進行金絲雀測試

---

**Link to Devin run**: https://app.devin.ai/sessions/46a89ed46ea745d5bd53bf07d7b74d44  
**Requested by**: Ryan Chen (@RC918)