### PR TITLE
feat: add P2 improvements to heartbeat monitor

### DIFF
--- a/.github/workflows/worker-heartbeat-monitor.yml
+++ b/.github/workflows/worker-heartbeat-monitor.yml
@@ -42,10 +42,11 @@ jobs:
               { owner, repo, state: 'open', labels: 'monitor:heartbeat', per_page: 100 }
             )
 
-            const allowedCreators = (process.env.ALLOWED_HEARTBEAT_CREATORS ?? 'github-actions[bot]')
-              .split(',')
-              .map(s => s.trim())
-              .filter(Boolean)
+            // P2-1: Fix empty string environment variable handling
+            const raw = process.env.ALLOWED_HEARTBEAT_CREATORS
+            const allowedCreators = (raw && raw.trim()) 
+              ? raw.split(',').map(s => s.trim()).filter(Boolean)
+              : ['github-actions[bot]']
 
             const toClose = issues
               // do not touch PRs
@@ -62,17 +63,30 @@ jobs:
             }
 
             core.info(`Closing ${toClose.length} heartbeat issue(s): ` + toClose.map(i => `#${i.number}`).join(', '))
+            
+            // P2-4: Add statistics logging
+            let closedCount = 0, failedCount = 0
+            
             for (const issue of toClose) {
               try {
+                // P2-3: Improve close comment with direct link
                 await github.rest.issues.createComment({
                   owner, repo, issue_number: issue.number,
-                  body: `Resolved by successful run ${context.runId} at ${new Date().toISOString()}`
+                  body: `✅ Resolved by successful run: ${context.payload.repository.html_url}/actions/runs/${context.runId} at ${new Date().toISOString()}`
                 })
+                // P2-2: Add state_reason when closing issues
                 await github.rest.issues.update({
-                  owner, repo, issue_number: issue.number, state: 'closed'
+                  owner, repo, issue_number: issue.number, 
+                  state: 'closed',
+                  state_reason: 'completed'
                 })
                 core.info(`Successfully closed #${issue.number}`)
+                closedCount++
               } catch (e) {
+                failedCount++
                 core.warning(`Failed to close #${issue.number}: ${e.message}`)
               }
             }
+            
+            // P2-4: Summary statistics
+            core.info(`Summary: Closed ${closedCount}, Failed ${failedCount}`)


### PR DESCRIPTION
## 描述 (Description)

此 PR 實施 4 個 P2（優先級 2）改進，增強 Worker Heartbeat Monitor 的穩健性、用戶體驗和可觀測性。這些改進是基於 PR #1413 合併後的 CTO 驗收報告中識別的非阻塞建議。

### 變更內容

**P2-1: 修復空字串環境變數處理**
- 檢查 `ALLOWED_HEARTBEAT_CREATORS` 是否為空字串或僅包含空白
- 如果為空，回退到預設值 `['github-actions[bot]']`
- 防止空陣列導致所有 issues 都無法關閉

**P2-2: 添加 state_reason**
- 關閉 issue 時設置 `state_reason: 'completed'`
- 在 GitHub UI 中提供更清晰的關閉語義

**P2-3: 改進關閉註解**
- 添加直接連結到 workflow run
- 格式：`✅ Resolved by successful run: [link] at [timestamp]`
- 更容易導航到相關 workflow 進行除錯和審計

**P2-4: 添加統計日誌**
- 追蹤 `closedCount` 和 `failedCount`
- 在循環結束後記錄摘要：`Summary: Closed X, Failed Y`
- 提供更好的可觀測性

### 技術細節

**P2-1 修復前後對比**:
```javascript
// 修復前：空字串會產生空陣列
const allowedCreators = (process.env.ALLOWED_HEARTBEAT_CREATORS ?? 'github-actions[bot]')
  .split(',').map(s => s.trim()).filter(Boolean)
// 如果 ALLOWED_HEARTBEAT_CREATORS=""，結果是 []

// 修復後：空字串回退到預設值
const raw = process.env.ALLOWED_HEARTBEAT_CREATORS
const allowedCreators = (raw && raw.trim()) 
  ? raw.split(',').map(s => s.trim()).filter(Boolean)
  : ['github-actions[bot]']
// 如果 ALLOWED_HEARTBEAT_CREATORS=""，結果是 ['github-actions[bot]']
```

**P2-3 註解改進**:
```javascript
// 修復前
body: `Resolved by successful run ${context.runId} at ${new Date().toISOString()}`

// 修復後
body: `✅ Resolved by successful run: ${context.payload.repository.html_url}/actions/runs/${context.runId} at ${new Date().toISOString()}`
```

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - CI 驗證 YAML 語法
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [x] 手動測試 (Manual Testing) - 需要在 production 環境驗證
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

**自動測試（CI）**：
1. ✅ YAML 語法驗證
2. ✅ 所有 CI 檢查

**手動測試（建議合併後執行）**：

**測試 P2-1（空字串處理）**：
1. 暫時設置 `ALLOWED_HEARTBEAT_CREATORS: ""` 在 workflow 中
2. 觸發 workflow
3. 確認日誌顯示使用預設值 `['github-actions[bot]']`
4. 恢復原始設置

**測試 P2-2（state_reason）**：
1. 觸發 workflow（確保有 heartbeat issues 可關閉）
2. 檢查關閉的 issue
3. 確認 issue 顯示 "Completed" 狀態（而非僅 "Closed"）

**測試 P2-3（改進的註解）**：
1. 觸發 workflow
2. 檢查關閉的 issue 上的註解
3. 確認註解包含：
   - ✅ emoji
   - 可點擊的 workflow run 連結
   - 時間戳

**測試 P2-4（統計日誌）**：
1. 觸發 workflow（確保有多個 issues）
2. 檢查 workflow 日誌
3. 確認看到摘要行：`Summary: Closed X, Failed Y`

### 預期結果 (Expected Results)

1. 空字串環境變數不會導致所有 issues 無法關閉
2. 關閉的 issues 顯示 "Completed" 狀態
3. 關閉註解包含可點擊的連結和 emoji
4. Workflow 日誌包含統計摘要

### 實際結果 (Actual Results)

- ✅ CI 檢查全部通過
- ⏳ 等待合併後手動驗證

### 測試環境 (Test Environment)

- [x] CI/CD Pipeline - YAML 語法驗證
- [ ] Staging 環境 - N/A（workflow 只在 production repo 運行）
- [ ] 本地開發環境 - N/A（無法本地測試 GitHub Actions）

### 受影響的區域 (Affected Areas)

- Worker Heartbeat Monitor workflow（`.github/workflows/worker-heartbeat-monitor.yml`）
- 關閉 heartbeat alert issues 的行為（更穩健、更好的 UX）
- Workflow 日誌輸出（新增統計摘要）

### 新增的自動化測試 (New Automated Tests)

- N/A - GitHub Actions workflow 無法進行傳統單元測試
- CI 驗證 YAML 語法正確性

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅修改 GitHub Actions workflow）

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）
- [x] TypeScript 類型檢查通過
- [x] 所有測試通過
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [ ] **新增環境變數** - `ALLOWED_HEARTBEAT_CREATORS` 已在 PR #1413 中添加，此 PR 僅改進其處理邏輯
- [x] 不適用 - 此 PR 不需要額外文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
- [x] 避免使用已廢棄的目錄
- [x] 所有環境變數已適當處理

## 人工審查重點 (Human Review Checklist)

請特別注意以下項目：

1. **Context 物件可用性**：
   - 驗證 `context.payload.repository.html_url` 在所有執行上下文中都可用（scheduled runs 和 workflow_dispatch）
   - 如果不確定，可能需要添加 fallback 或 null check

2. **空字串處理邏輯**：
   - 確認新的 fallback 邏輯符合預期行為
   - 空字串現在會回退到預設值，而非產生空陣列

3. **註解格式變更**：
   - 確認新的註解格式（包含 emoji 和連結）符合團隊偏好
   - 連結格式是否在所有情況下都正確

4. **統計日誌價值**：
   - 評估統計摘要是否提供足夠價值
   - 是否會在日誌中產生過多噪音

5. **測試限制**：
   - 此變更無法在 CI 中完整測試（只能驗證 YAML 語法）
   - 建議合併後手動觸發 workflow 驗證實際行為

## 相關 Issues

- 基於 PR #1413 的 CTO 驗收報告中的 P2 改進建議
- 所有改進均為非阻塞性增強

---

**Link to Devin run**: https://app.devin.ai/sessions/5dbb33e7e52f416a9f5930e7ddd94107  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918