### PR TITLE
test: Supplement Phase 0-Lite with persistence and LangGraph tests

### DIFF
--- a/handoff/20250928/40_App/orchestrator/persistence/db_writer.py
+++ b/handoff/20250928/40_App/orchestrator/persistence/db_writer.py
@@ -9,25 +9,16 @@ import logging
 from datetime import datetime, timezone
 from typing import Optional
 from .db_client import get_client
+import sys
+import os
 
-# Dual-import pattern to support both package and script execution modes
-# - When orchestrator is installed as a package (tests, pip install -e .)
-# - When running as a script from orchestrator directory (CI, production worker)
-try:
-    from orchestrator.exceptions import (
-        DatabaseConnectionError,
-        DatabaseWriteError,
-        DatabaseReadError,
-        TenantResolutionError
-    )
-except ModuleNotFoundError:
-    # Fallback for when running from orchestrator directory
-    from exceptions import (  # noqa: F401
-        DatabaseConnectionError,
-        DatabaseWriteError,
-        DatabaseReadError,
-        TenantResolutionError
-    )
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from exceptions import (
+    DatabaseConnectionError,
+    DatabaseWriteError,
+    DatabaseReadError,
+    TenantResolutionError
+)
 
 logger = logging.getLogger(__name__)
 

--- a/handoff/20250928/40_App/orchestrator/tests/test_persistence_db_writer.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_persistence_db_writer.py
@@ -5,15 +5,20 @@ Phase 0-Lite Supplement: Targeted tests for agent_tasks persistence
 """
 import pytest
 from unittest.mock import Mock, patch
+import sys
+import os
 
-from orchestrator.persistence.db_writer import (
+# Add orchestrator to path (standard pattern for all orchestrator tests)
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from persistence.db_writer import (
     fetch_user_tenant_id,
     upsert_task_queued,
     upsert_task_running,
     upsert_task_done,
     upsert_task_error
 )
-from orchestrator.exceptions import (
+from exceptions import (
     DatabaseReadError,
     TenantResolutionError
 )
@@ -40,7 +45,7 @@ def mock_supabase_client():
 class TestFetchUserTenantId:
     """Test fetch_user_tenant_id function"""
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_fetch_user_tenant_id_success(self, mock_get_client, mock_supabase_client):
         """Test successful tenant_id fetch"""
         mock_get_client.return_value = mock_supabase_client
@@ -50,7 +55,7 @@ class TestFetchUserTenantId:
         assert tenant_id == "test-tenant-123"
         mock_supabase_client.table.assert_called_once_with("user_profiles")
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_fetch_user_tenant_id_no_client(self, mock_get_client):
         """Test fetch_user_tenant_id handles missing client"""
         mock_get_client.return_value = None
@@ -59,7 +64,7 @@ class TestFetchUserTenantId:
         with pytest.raises(DatabaseReadError):
             fetch_user_tenant_id("user-123")
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_fetch_user_tenant_id_no_profile(self, mock_get_client, mock_supabase_client):
         """Test fetch_user_tenant_id handles missing user profile"""
         mock_get_client.return_value = mock_supabase_client
@@ -78,7 +83,7 @@ class TestFetchUserTenantId:
 
         assert "No user_profile found" in str(exc_info.value)
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_fetch_user_tenant_id_database_error(self, mock_get_client, mock_supabase_client):
         """Test fetch_user_tenant_id handles database errors"""
         mock_get_client.return_value = mock_supabase_client
@@ -99,7 +104,7 @@ class TestFetchUserTenantId:
 class TestUpsertTaskQueued:
     """Test upsert_task_queued function"""
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_queued_success(self, mock_get_client, mock_supabase_client):
         """Test successful task queued upsert"""
         mock_get_client.return_value = mock_supabase_client
@@ -128,7 +133,7 @@ class TestUpsertTaskQueued:
         assert upsert_data["job_id"] == "job-123"
         assert upsert_data["tenant_id"] == "tenant-123"
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_queued_default_tenant(self, mock_get_client, mock_supabase_client):
         """Test task queued upsert uses default tenant when not provided"""
         mock_get_client.return_value = mock_supabase_client
@@ -146,7 +151,7 @@ class TestUpsertTaskQueued:
         upsert_data = table_mock.upsert.call_args[0][0]
         assert upsert_data["tenant_id"] == "00000000-0000-0000-0000-000000000001"
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_queued_handles_exception(self, mock_get_client, mock_supabase_client):
         """Test task queued upsert handles exceptions gracefully"""
         mock_get_client.return_value = mock_supabase_client
@@ -167,7 +172,7 @@ class TestUpsertTaskQueued:
 class TestUpsertTaskRunning:
     """Test upsert_task_running function"""
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_running_success(self, mock_get_client, mock_supabase_client):
         """Test successful task running upsert"""
         mock_get_client.return_value = mock_supabase_client
@@ -188,7 +193,7 @@ class TestUpsertTaskRunning:
         assert "started_at" in upsert_data
         assert upsert_data["tenant_id"] == "tenant-123"
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_running_default_tenant(self, mock_get_client, mock_supabase_client):
         """Test task running upsert uses default tenant"""
         mock_get_client.return_value = mock_supabase_client
@@ -204,7 +209,7 @@ class TestUpsertTaskRunning:
         upsert_data = table_mock.upsert.call_args[0][0]
         assert upsert_data["tenant_id"] == "00000000-0000-0000-0000-000000000001"
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_running_handles_exception(self, mock_get_client, mock_supabase_client):
         """Test task running upsert handles exceptions"""
         mock_get_client.return_value = mock_supabase_client
@@ -223,7 +228,7 @@ class TestUpsertTaskRunning:
 class TestUpsertTaskDone:
     """Test upsert_task_done function"""
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_done_success(self, mock_get_client, mock_supabase_client):
         """Test successful task done upsert"""
         mock_get_client.return_value = mock_supabase_client
@@ -246,7 +251,7 @@ class TestUpsertTaskDone:
         assert "finished_at" in upsert_data
         assert upsert_data["tenant_id"] == "tenant-123"
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_done_handles_exception(self, mock_get_client, mock_supabase_client):
         """Test task done upsert handles exceptions"""
         mock_get_client.return_value = mock_supabase_client
@@ -266,7 +271,7 @@ class TestUpsertTaskDone:
 class TestUpsertTaskError:
     """Test upsert_task_error function"""
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_error_success(self, mock_get_client, mock_supabase_client):
         """Test successful task error upsert"""
         mock_get_client.return_value = mock_supabase_client
@@ -289,7 +294,7 @@ class TestUpsertTaskError:
         assert "finished_at" in upsert_data
         assert upsert_data["tenant_id"] == "tenant-123"
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_error_truncates_long_message(self, mock_get_client, mock_supabase_client):
         """Test task error upsert truncates long error messages"""
         mock_get_client.return_value = mock_supabase_client
@@ -309,7 +314,7 @@ class TestUpsertTaskError:
         upsert_data = table_mock.upsert.call_args[0][0]
         assert len(upsert_data["error_msg"]) == 500
 
-    @patch('orchestrator.persistence.db_writer.get_client')
+    @patch('persistence.db_writer.get_client')
     def test_upsert_task_error_handles_exception(self, mock_get_client, mock_supabase_client):
         """Test task error upsert handles exceptions"""
         mock_get_client.return_value = mock_supabase_client


### PR DESCRIPTION
## 描述 (Description)

補充 Phase 0-Lite 測試覆蓋，為 Phase 1 金絲雀發布做準備。新增 25 個測試（全部通過）涵蓋兩個關鍵模組：

1. **persistence/db_writer.py** (15 tests) - agent_tasks 資料庫持久化
2. **langgraph_orchestrator.py** (10 tests) - LangGraph 工作流程編排

**重要提醒**：此 PR 僅完成測試補充（Option C），Phase 1 準備工作（Option A：Staging E2E 測試、環境驗證、觀測性確認）尚未完成。

### 最新更新 (Updates Since Last Revision)

**2025-11-23 - 修正模組導入模式**：
- 恢復 `db_writer.py` 使用標準 `sys.path.insert()` 模式（移除錯誤的雙導入模式）
- 更新 `test_persistence_db_writer.py` 遵循既有測試慣例（與 287 個既有測試保持一致）
- 修正所有 15 個 `@patch` 裝飾器路徑從 `'orchestrator.persistence.db_writer.get_client'` 改為 `'persistence.db_writer.get_client'`
- 刪除 `test_codegen_workflow_smoke.py`（13 個永久跳過的測試無價值）
- **結果**：✅ 25/25 測試通過，CI 37/37 檢查通過

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest handoff/20250928/40_App/orchestrator/tests/test_*.py`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [ ] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)


1. 運行所有新增測試：
   ```bash
   cd ~/repos/morningai
   source .venv/bin/activate
   pytest handoff/20250928/40_App/orchestrator/tests/test_persistence_db_writer.py -v
   pytest handoff/20250928/40_App/orchestrator/tests/test_langgraph_smoke.py -v
   ```

2. 運行 lint 檢查：
   ```bash
   .venv/bin/flake8 handoff/20250928/40_App/orchestrator/tests/test_*.py
   ```

3. 驗證 script 模式執行：
   ```bash
   cd handoff/20250928/40_App/orchestrator
   python graph.py --goal "demo task"
   ```

### 預期結果 (Expected Results)

- **persistence/db_writer**: 15/15 tests passing ✓
- **langgraph_smoke**: 10/10 tests passing ✓
- Lint: 0 errors ✓
- Script mode: No ModuleNotFoundError ✓

### 實際結果 (Actual Results)

```
Total: 25 tests
- 25 passing ✓ (100%)
- 0 failing
- 0 skipped

Test execution time: 0.63s
CI checks: 37/37 passing ✓
```

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline (37/37 checks passing)
- [ ] Staging 環境 (pending Option A)
- [ ] 不同瀏覽器測試（如適用）

### 受影響的區域 (Affected Areas)

- `handoff/20250928/40_App/orchestrator/persistence/db_writer.py` - 模組導入模式修正
- `handoff/20250928/40_App/orchestrator/tests/test_persistence_db_writer.py` - 新增測試覆蓋（15 tests）
- `handoff/20250928/40_App/orchestrator/tests/test_langgraph_smoke.py` - 新增測試覆蓋（10 tests）

### 新增的自動化測試 (New Automated Tests)

**test_persistence_db_writer.py** (335 lines, 15 tests):
- `TestFetchUserTenantId` (4 tests) - tenant_id 查詢與異常處理
- `TestUpsertTaskQueued` (3 tests) - 任務排隊狀態寫入
- `TestUpsertTaskRunning` (3 tests) - 任務運行狀態寫入
- `TestUpsertTaskDone` (2 tests) - 任務完成狀態寫入
- `TestUpsertTaskError` (3 tests) - 任務錯誤狀態寫入與截斷

**test_langgraph_smoke.py** (274 lines, 10 tests):
- `TestAgentState` (1 test) - AgentState TypedDict 結構驗證
- `TestPlannerNode` (2 tests) - 靜態與 LLM 規劃模式
- `TestFinalizerNode` (2 tests) - 成功與錯誤結果處理
- `TestConditionalEdges` (4 tests) - 工作流程條件邊緣邏輯
- `TestCreateOrchestratorGraph` (1 test) - 圖形創建驗證

## i18n 檢查清單（強制）

- [ ] 所有用戶可見字串使用 `t()` 或 `<Trans>`（無硬編碼字串）
- [ ] 新 translation keys 已加入 `en-US.json` 和 `zh-TW.json`
- [ ] Translation keys 使用適當的命名空間
- [ ] 無障礙屬性已翻譯
- [ ] ESLint i18n 規則通過
- [ ] 已測試語言切換
- [x] **不適用 - 此 PR 無用戶可見變更**（僅測試代碼）

## 設計系統檢查 (Design System Checklist)

- [ ] 我已檢查 `@morningai/shared-ui` 是否有可用的元件
- [ ] 新元件已加入 Storybook story
- [ ] 我沒有重複實作已存在的元件
- [ ] 如使用設計 tokens，已從 `@morningai/shared-ui` 匯入
- [x] **不適用 - 此 PR 不包含 UI 元件變更**（僅測試代碼）

### Shared-UI Import 合規性（強制）

- [ ] 我已使用 `@morningai/shared-ui` 元件
- [ ] 我沒有直接 import UI 元件庫
- [ ] ESLint `no-restricted-imports` 規則通過
- [ ] CI 的 "Audit UI Library Imports" 檢查通過
- [x] **不適用 - 此 PR 不包含 UI import 變更**（僅測試代碼）

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`.venv/bin/flake8` (Python)
- [x] TypeScript 類型檢查通過：N/A (Python 代碼)
- [x] 無 `any` 類型：N/A (Python 代碼)
- [x] 所有測試通過：25/25 passing ✓
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [ ] 新增基礎設施/工具 → 更新 `ONBOARDING_GUIDE.md`
- [ ] 新增/修改環境變數 → 更新 `config/env.schema.yaml`
- [ ] 新增功能/API 端點 → 更新相關文檔
- [ ] 修改部署流程 → 更新 `docs/deployment/`
- [ ] 架構變更 → 更新 `PROJECT_STRUCTURE_REPORT.md`
- [ ] 新增/修改 GitHub Actions workflow → 更新 `docs/ci_matrix.md`
- [x] **不適用 - 此 PR 僅新增測試，無需文檔更新**

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
- [x] 避免使用已廢棄的目錄
- [x] 不在 src/** 中導入已廢棄的模組
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義

---

## 🔍 人工審查重點 (Human Review Checklist)

**✅ 已解決的問題**：
- ✅ 所有 25 個測試通過（15 db_writer + 10 langgraph）
- ✅ CI 37/37 檢查通過
- ✅ 模組導入模式與 287 個既有測試保持一致
- ✅ Mock 路徑正確（`persistence.db_writer.get_client`）

**⚠️ 需要審查的關鍵點**：

1. **sys.path.insert() 模式正確性**
   - 此 PR 使用 `sys.path.insert()` + `from exceptions import` 模式
   - 此模式與整個 orchestrator 代碼庫的 287 個既有測試一致
   - 需要確認此模式在 package 模式和 script 模式下都能正常工作

2. **Mock 路徑準確性**
   - 所有 15 個 `@patch` 裝飾器使用 `'persistence.db_writer.get_client'`
   - 這與 sys.path.insert() 模式匹配（模組作為頂層導入）
   - 需要驗證 mock 是否正確攔截實際調用

3. **Phase 1 準備工作未完成**
   - 用戶請求 "Option A + C"，但只完成了 Option C（測試補充）
   - **Option A 尚未執行**：Staging E2E 測試、環境驗證、觀測性確認
   - 此 PR 合併後，仍需完成 Option A 才能啟用 Phase 1 金絲雀

4. **測試覆蓋範圍**
   - 這些是"煙霧測試"（smoke tests），提供基本覆蓋但不全面
   - 是否足以支持 Phase 1 金絲雀發布（5% 流量）？
   - 建議：合併後立即執行 Option A 的 Staging E2E 測試

5. **生產代碼變更**
   - `db_writer.py` 的導入模式已修正（恢復原始 sys.path.insert() 模式）
   - 此變更影響生產代碼，需要特別注意

---

**Devin Session**: https://app.devin.ai/sessions/e9670283a56d4ac795311be1578bdc69  
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918  
**Related PR**: #1504 (Phase 0-Lite core tests - merged)