### PR TITLE
fix(storybook): Disable PWA plugin for Storybook builds

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/.storybook/main.ts
+++ b/handoff/20250928/40_App/frontend-dashboard/.storybook/main.ts
@@ -24,10 +24,14 @@ const config: StorybookConfig = {
     buildStoriesJson: true,
   },
   async viteFinal(config) {
+
+    // Filter out any remaining PWA plugin variants as a safety measure
+    // The main PWA disabling is done via STORYBOOK env var in vite.config.js
+    config.plugins = config.plugins?.filter(
+      (plugin: any) => plugin && !plugin.name?.includes('vite-plugin-pwa')
+    );
+
     return mergeConfig(config, {
-      plugins: config.plugins?.filter(
-        (plugin: any) => plugin && plugin.name !== 'vite-plugin-pwa'
-      ),
       optimizeDeps: {
         include: [
           'react',
@@ -35,16 +39,9 @@ const config: StorybookConfig = {
           '@storybook/react',
         ],
       },
-      build: {
-        rollupOptions: {
-          output: {
-            manualChunks: {
-              'react-vendor': ['react', 'react-dom'],
-              'storybook-vendor': ['@storybook/react'],
-            },
-          },
-        },
-      },
+      // NOTE: Do NOT use manualChunks for Storybook builds!
+      // Storybook relies on __STORYBOOK_MODULE_PREVIEW_API__ being defined as a global
+      // before other modules access it. Custom chunking breaks this module resolution.
     });
   },
 };

--- a/handoff/20250928/40_App/frontend-dashboard/package.json
+++ b/handoff/20250928/40_App/frontend-dashboard/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit",
     "typecheck:strict": "tsc -p tsconfig.strict.json --noEmit",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build",
+    "build-storybook": "STORYBOOK=1 storybook build",
     "prepare": "husky"
   },
   "dependencies": {

--- a/handoff/20250928/40_App/frontend-dashboard/vite.config.js
+++ b/handoff/20250928/40_App/frontend-dashboard/vite.config.js
@@ -7,6 +7,9 @@ import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
+  // Disable PWA for Storybook builds to prevent interference with iframe communication
+  const isStorybook = Boolean(process.env.STORYBOOK)
+  
   const enableSentry = Boolean(
     process.env.SENTRY_ORG && 
     process.env.SENTRY_PROJECT && 
@@ -32,12 +35,8 @@ export default defineConfig(({ mode }) => {
       )
     : null
 
-  return {
-    plugins: [
-      react(),
-      tailwindcss(),
-      ...(sentryPlugin ? [sentryPlugin] : []),
-      VitePWA({
+  // PWA plugin configuration - disabled for Storybook builds
+  const pwaPlugin = !isStorybook ? VitePWA({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.ico', 'apple-touch-icon.png', 'icon-192.png', 'icon-512.png'],
       manifest: {
@@ -115,7 +114,14 @@ export default defineConfig(({ mode }) => {
       devOptions: {
         enabled: false
       }
-    })
+    }) : null
+
+  return {
+    plugins: [
+      react(),
+      tailwindcss(),
+      ...(sentryPlugin ? [sentryPlugin] : []),
+      ...(pwaPlugin ? [pwaPlugin] : []),
     ],
     resolve: {
       alias: {


### PR DESCRIPTION
## 描述 (Description)

修復 Storybook 部署時的 `__STORYBOOK_MODULE_PREVIEW_API__` 錯誤。

**根本原因分析：**
1. **PWA 插件干擾**：PWA 插件在 `viteFinal` hook 執行後才被加入，導致 iframe 通訊被干擾
2. **manualChunks 破壞模組解析**：自定義的 chunk 分割破壞了 Storybook 的全域模組解析機制

**修復方案：**
- 在 `vite.config.js` 中使用 `STORYBOOK` 環境變數條件性地禁用 PWA 插件
- 更新 `build-storybook` 腳本設定 `STORYBOOK=1`
- 移除 Storybook 配置中的 `manualChunks`（會破壞 `__STORYBOOK_MODULE_PREVIEW_API__` 全域變數）
- 改進 PWA 插件過濾器使用 `includes()` 以捕獲所有 PWA 插件變體

Closes #1628

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. 執行 `STORYBOOK=1 pnpm --filter frontend-dashboard build-storybook`
2. 檢查 `storybook-static/iframe.html` 確認沒有 PWA 相關腳本（`registerSW.js`、`manifest.webmanifest`）
3. 執行 `pnpm --filter frontend-dashboard build` 確認生產環境 PWA 仍正常運作

### 預期結果 (Expected Results)

- Storybook 建置成功，無 `__STORYBOOK_MODULE_PREVIEW_API__` 錯誤
- `iframe.html` 中無 PWA 相關引用
- 生產環境建置仍包含 PWA 功能

### 實際結果 (Actual Results)

- Storybook 建置成功
- `iframe.html` 中無 PWA 引用（已驗證）
- 注意：存在獨立的 "unable to determine source of event" 問題，這是 Storybook 8.x 的已知問題，與此 PR 無關

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [ ] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- Storybook 建置流程
- PWA 插件配置（僅影響 Storybook 建置，不影響生產環境）

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`pnpm lint`
- [x] TypeScript 類型檢查通過：`pnpm typecheck`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒
- [x] 不修改 OpenAPI/資料欄位
- [x] 避免使用已廢棄的目錄

## Human Review Checklist

請特別注意以下項目：

- [ ] 確認生產環境建置（無 `STORYBOOK` 環境變數）仍包含 PWA 功能
- [ ] 確認 CI 中 Storybook 建置成功
- [ ] 注意：存在獨立的 "unable to determine source of event" 問題需要後續調查

---

**Link to Devin run**: https://app.devin.ai/sessions/7272a0e7fc244e51979340f52dcf42b4
**Requested by**: Ryan Chen (@RC918)