### PR TITLE
test(phase2): PR-A LangGraph E2E integration tests for fixer_node

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_langgraph_fixer_e2e.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_langgraph_fixer_e2e.py
@@ -255,8 +255,9 @@ class TestAutoFixerCanaryRollout:
         assert all(r == results[0] for r in results), \
             "Canary routing should be deterministic"
 
-    def test_autofixer_uses_pr_number_for_canary(self):
-        """Test that canary uses pr_number when available"""
+    @patch("project_engineer.fixer_integration.hashlib.md5")
+    def test_autofixer_uses_pr_number_for_canary(self, mock_md5):
+        """Test that canary uses pr_number when available, falling back to trace_id"""
         from project_engineer.fixer_integration import AutoFixer
 
         settings = MockSettings(
@@ -265,22 +266,31 @@ class TestAutoFixerCanaryRollout:
         )
         fixer = AutoFixer(settings=settings)
 
-        state_with_pr = create_test_state(pr_number=456)
-        state_same_trace_diff_pr = create_test_state(pr_number=789)
+        # Setup mock to return a valid hash object
+        mock_hash_obj = MagicMock()
+        mock_hash_obj.hexdigest.return_value = '0' * 32
+        mock_md5.return_value = mock_hash_obj
 
-        # Call should_run_for_task - results may differ because different PR numbers
-        # hash to different buckets. This test just verifies the function runs without error
+        # Test with pr_number - should use pr_number as key
+        state_with_pr = create_test_state(pr_number=456, trace_id="should-be-ignored")
         fixer.should_run_for_task(state_with_pr)
-        fixer.should_run_for_task(state_same_trace_diff_pr)
+        mock_md5.assert_called_once_with(b'456')
+        mock_md5.reset_mock()
+
+        # Test without pr_number - should fall back to trace_id
+        state_without_pr = create_test_state(trace_id="should-be-used")
+        state_without_pr["pr_number"] = None
+        fixer.should_run_for_task(state_without_pr)
+        mock_md5.assert_called_once_with(b'should-be-used')
 
 
 class TestMaxRetriesEnforcement:
     """Tests for MAX_FIXER_RETRIES enforcement"""
 
-    def test_max_retries_constant_is_defined(self):
-        """Test that MAX_FIXER_RETRIES constant is defined"""
+    def test_max_retries_constant_is_valid(self):
+        """Test that MAX_FIXER_RETRIES constant is a positive integer"""
+        assert isinstance(MAX_FIXER_RETRIES, int)
         assert MAX_FIXER_RETRIES > 0
-        assert MAX_FIXER_RETRIES == 3  # Expected value
 
     def test_fixer_node_uses_max_retries_constant(self):
         """Test that fixer_node uses MAX_FIXER_RETRIES constant"""


### PR DESCRIPTION
## 描述 (Description)

PR-A: 為 Phase 2 Step C Fixer Node 新增 LangGraph E2E 整合測試。

此 PR 在進行 PR-B（安全規則強化）和 PR-C（Async Wrapper 優化）之前，建立 fixer_node 在 orchestrator 流程中的基線測試覆蓋。

**測試覆蓋（31 個測試）：**
- `TestFixerNodeRouting` (6 tests): Orchestrator graph 中的路由邏輯
- `TestFixerNodeBehavior` (6 tests): fixer_node 與 AutoFixer 的行為
- `TestAutoFixerCanaryRollout` (5 tests): Canary rollout 邏輯
- `TestMaxRetriesEnforcement` (3 tests): MAX_FIXER_RETRIES 限制
- `TestStateTransitions` (3 tests): 通過 fixer_node 的狀態轉換
- `TestOrchestratorWorkflowPaths` (4 tests): 完整工作流程路徑
- `TestErrorRecovery` (2 tests): 錯誤恢復路徑
- `TestLoggingAndObservability` (2 tests): 日誌和可觀測性

### Updates since last revision

Addressed gemini-code-assist code review comments:

1. **`test_autofixer_uses_pr_number_for_canary`** - Added `@patch("project_engineer.fixer_integration.hashlib.md5")` decorator and assertions to verify:
   - When `pr_number` is present, it's used as the canary hash key
   - When `pr_number` is None, falls back to `trace_id`

2. **`test_max_retries_constant_is_defined`** → **`test_max_retries_constant_is_valid`** - Removed brittle hardcoded assertion (`assert MAX_FIXER_RETRIES == 3`), now only validates the constant is a positive integer.

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest`
- [x] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests) - Playwright
- [ ] 視覺回歸測試 (Visual Regression Tests) - VRT
- [ ] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 運行測試：
   ```bash
   cd ~/repos/morningai && source .venv/bin/activate
   export PYTHONPATH="$PWD/handoff/20250928/40_App/orchestrator:$PWD/handoff/20250928/40_App/api-backend/src:$PYTHONPATH"
   pytest handoff/20250928/40_App/orchestrator/tests/test_langgraph_fixer_e2e.py -v
   ```

### 預期結果 (Expected Results)

- 31 個測試全部通過
- 無 lint 錯誤

### 實際結果 (Actual Results)

- 31 passed in 0.47s
- flake8: 0 errors

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline
- [ ] Staging 環境
- [ ] 不同瀏覽器測試（如適用）

### 受影響的區域 (Affected Areas)

- LangGraph orchestrator 測試覆蓋
- 無生產代碼變更

### 新增的自動化測試 (New Automated Tests)

- `handoff/20250928/40_App/orchestrator/tests/test_langgraph_fixer_e2e.py` (31 tests)

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)


- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`flake8`
- [x] 所有測試通過：`pytest`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 避免使用已廢棄的目錄

## Human Review Checklist

請特別注意以下項目：

1. **Mock 設置模式** - 所有調用 `fixer_node` 的測試都需要設置 `MockAutoFixer.MAX_FIX_RETRIES = MAX_FIXER_RETRIES`，否則會因為 MagicMock 比較而產生 TypeError
2. **hashlib.md5 patch 路徑** - `test_autofixer_uses_pr_number_for_canary` 使用 `@patch("project_engineer.fixer_integration.hashlib.md5")` 來驗證 canary key 選擇邏輯，確認 patch 位置正確
3. **Canary key 優先順序** - 驗證測試正確反映 `pr_number` 優先於 `trace_id` 的邏輯（參考 `fixer_integration.py` line 109: `key = str(state.get("pr_number") or state.get("trace_id") or "unknown")`）
4. **MAX_FIXER_RETRIES 測試** - 已移除硬編碼值斷言，現在只驗證類型和正值

---

**Link to Devin run**: https://app.devin.ai/sessions/d677fe3dbfc945be974a95a828947be1
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918