### PR TITLE
test(phase2): Phase 2 Step C follow-up improvements - Enhanced tests and documentation

### DIFF
--- a/docs/ONBOARDING_GUIDE.md
+++ b/docs/ONBOARDING_GUIDE.md
@@ -560,6 +560,8 @@ pytest handoff/20250928/40_App/orchestrator/tests/test_langgraph_fixer_e2e.py::T
 - **TestAutoFixerCanaryRollout**: Tests canary deployment with deterministic bucket assignment
 - **TestMaxRetriesEnforcement**: Ensures MAX_FIXER_RETRIES constant is used consistently
 - **TestStateTransitions**: Verifies state preservation and message handling
+- **TestOrchestratorWorkflowPaths**: Tests workflow paths (success, failure, fixer, max retries)
+- **TestErrorRecovery**: Tests error recovery from AutoFixer errors and missing settings
 - **TestLoggingAndObservability**: Tests structured logging with autofixer_disabled_reason
 - **TestSafetyRulesEnforcement**: Verifies whitelist enforcement and codegen flag respect
 - **TestAsyncWrapperOptimization**: Tests async-to-sync bridging with thread-safe executor

--- a/handoff/20250928/40_App/orchestrator/project_engineer/fixer_integration.py
+++ b/handoff/20250928/40_App/orchestrator/project_engineer/fixer_integration.py
@@ -59,9 +59,10 @@ def _shutdown_autofixer_executor() -> None:
     are released when the application exits.
     """
     global _autofixer_executor
-    if _autofixer_executor is not None:
-        _autofixer_executor.shutdown(wait=True)
-        _autofixer_executor = None
+    with _autofixer_executor_lock:
+        if _autofixer_executor is not None:
+            _autofixer_executor.shutdown(wait=True)
+            _autofixer_executor = None
 
 
 # Register shutdown handler to clean up executor on exit

--- a/handoff/20250928/40_App/orchestrator/tests/test_langgraph_fixer_e2e.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_langgraph_fixer_e2e.py
@@ -837,19 +837,6 @@ class TestRealIntegrationScenarios:
             assert result.get("success") is False
             assert "GitHub API rate limit exceeded" in result.get("error", "")
 
-    def test_autofixer_handles_ci_failure_scenario(self):
-        """Test that AutoFixer handles CI failure scenario correctly"""
-        # Create state with CI failure error
-        state = create_test_state(
-            error="CI check failed: lint errors in src/main.py",
-            retry_count=1
-        )
-
-        # Verify fixer recognizes CI failure state
-        assert state.get("error") is not None
-        assert "CI check failed" in state.get("error", "")
-        assert state.get("retry_count") == 1
-
     def test_autofixer_handles_pr_creation_failure(self):
         """Test that AutoFixer handles PR creation failure gracefully"""
         import asyncio
@@ -1044,17 +1031,8 @@ class TestSmokeTestGraphExecution:
         graph = app.get_graph()
         nodes = graph.nodes
 
-        # Verify fixer_node exists
-        assert "fix" in nodes or any("fix" in str(node) for node in nodes)
-
-    def test_graph_initial_state_structure(self):
-        """Test that initial state has required structure for graph execution"""
-        initial_state = create_test_state()
-
-        # Verify required fields for graph execution
-        assert "trace_id" in initial_state
-        assert "messages" in initial_state
-        assert "retry_count" in initial_state
+        # Verify fixer_node exists (node is named "fixer" in the graph)
+        assert "fixer" in nodes
 
     def test_fixer_node_can_be_invoked_directly(self):
         """Test that fixer_node can be invoked directly with valid state"""


### PR DESCRIPTION
## 描述 (Description)

實現 Phase 2 Step C Fixer Node 的 5 個後續改進項目：

1. **日誌斷言增強** - 驗證 `autofixer_disabled_reason` 具體內容 (flag_disabled, percent_zero, canary_bucket_excluded)
2. **真實整合測試** - GitHub API 錯誤、CI 失敗、PR 創建失敗場景
3. **開發手冊** - 新增「如何運行 LangGraph E2E 測試」章節到 ONBOARDING_GUIDE.md
4. **常數同步** - 確保 MAX_FIXER_RETRIES 在所有邏輯路徑中一致使用
5. **Smoke test** - 驗證完整 graph 編譯和路由函數

測試數量從 41 個增加到 56 個。

### Updates since last revision

Addressed gemini-code-assist review comments:
- Added `TestOrchestratorWorkflowPaths` and `TestErrorRecovery` to test coverage summary in ONBOARDING_GUIDE.md
- Added lock acquisition in `_shutdown_autofixer_executor` for improved thread safety
- Removed `test_autofixer_handles_ci_failure_scenario` (only tested helper function, not application logic)
- Fixed `test_graph_has_fixer_node` assertion to use `"fixer"` instead of `"fix"` (correct node name)
- Removed `test_graph_initial_state_structure` (only tested helper function)

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest`
- [x] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests) - Playwright
- [ ] 視覺回歸測試 (Visual Regression Tests) - VRT
- [ ] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 運行所有 E2E 測試：
```bash
cd ~/repos/morningai
source .venv/bin/activate
export PYTHONPATH="$PWD/handoff/20250928/40_App/orchestrator:$PWD/handoff/20250928/40_App/api-backend/src:$PYTHONPATH"
pytest handoff/20250928/40_App/orchestrator/tests/test_langgraph_fixer_e2e.py -v
```

### 預期結果 (Expected Results)

- 56 個測試全部通過
- Lint 檢查通過

### 實際結果 (Actual Results)

- 56 passed in 2.02s
- flake8: 0 errors

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline
- [ ] Staging 環境
- [ ] 不同瀏覽器測試（如適用）

### 受影響的區域 (Affected Areas)

- `handoff/20250928/40_App/orchestrator/tests/test_langgraph_fixer_e2e.py`
- `docs/ONBOARDING_GUIDE.md`
- `handoff/20250928/40_App/orchestrator/project_engineer/fixer_integration.py` (async wrapper from PR-C)

### 新增的自動化測試 (New Automated Tests)

- `TestLoggingAndObservability::test_autofixer_logs_disabled_reason_percent_zero`
- `TestLoggingAndObservability::test_autofixer_logs_disabled_reason_canary_excluded`
- `TestAsyncWrapperOptimization` (4 tests)
- `TestRealIntegrationScenarios` (5 tests - reduced from 6 after removing helper-only test)
- `TestConstantSynchronization` (4 tests)
- `TestSmokeTestGraphExecution` (4 tests - reduced from 5 after removing helper-only test)

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`pnpm lint`
- [x] 所有測試通過：`pytest`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] **新增功能/API 端點** → 更新 `ONBOARDING_GUIDE.md` - 新增「Running LangGraph E2E Tests」章節

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義

## Human Review Checklist

- [ ] 驗證 `_shutdown_autofixer_executor` 中的 lock 獲取是否正確（新增的線程安全改進）
- [ ] 確認 `test_autofixer_logs_disabled_reason_canary_excluded` 的條件檢查不會導致測試不穩定
- [ ] 確認移除的兩個測試確實只測試 helper 函數而非應用邏輯
- [ ] 確認 `"fixer"` 是 graph 中正確的 node 名稱（已通過 `graph.nodes` 驗證）

---

**Link to Devin run**: https://app.devin.ai/sessions/d677fe3dbfc945be974a95a828947be1
**Requested by**: Ryan Chen (ryan2939z@gmail.com) (@RC918)