### PR TITLE
feat(observability): Integrate record_transition for pipeline metrics

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -60,6 +60,19 @@ GOAL_TOKEN_MULTIPLIER = 2
 PLAN_STEP_TOKEN_MULTIPLIER = 100
 
 
+def _planner_success(
+    state: "AgentState",
+    metrics: OrchestratorMetrics,
+    start_time: float,
+    trace_id: str
+) -> "AgentState":
+    """Helper to record planner success metrics and transition"""
+    latency_ms = (time.time() - start_time) * 1000
+    metrics.record_node_complete("planner", trace_id, success=True, latency_ms=latency_ms)
+    metrics.record_transition("planner", "security_advisor", trace_id)
+    return state
+
+
 class AgentState(TypedDict):
     """
     State of the agent workflow
@@ -200,10 +213,7 @@ def planner_node(state: AgentState) -> AgentState:
                 "planning_time_ms": plan_data.get("planning_time_ms", 0)
             })
 
-            latency_ms = (time.time() - start_time) * 1000
-            metrics.record_node_complete("planner", trace_id, success=True, latency_ms=latency_ms)
-            metrics.record_transition("planner", "security_advisor", trace_id)
-            return state
+            return _planner_success(state, metrics, start_time, trace_id)
 
         except Exception as e:
             logger.error(f"[Planner] LLM planner failed, falling back to static: {e}", extra={
@@ -237,10 +247,7 @@ def planner_node(state: AgentState) -> AgentState:
         "planner_type": "static"
     })
 
-    latency_ms = (time.time() - start_time) * 1000
-    metrics.record_node_complete("planner", trace_id, success=True, latency_ms=latency_ms)
-    metrics.record_transition("planner", "security_advisor", trace_id)
-    return state
+    return _planner_success(state, metrics, start_time, trace_id)
 
 
 def security_advisor_node(state: AgentState) -> AgentState:


### PR DESCRIPTION
## 描述 (Description)

整合 `record_transition` 方法到 LangGraph orchestrator，為 5-Agent Advisory Pipeline 提供完整的轉換追蹤觀測性。

此 PR 新增：
- 在所有線性邊緣的 node 末尾添加 `record_transition` 調用
- 在條件邊緣的 router 函數中添加 `record_transition` 調用
- 提取 `_planner_success` helper 函數以減少重複代碼（DRY 原則）

**追蹤的轉換路徑：**
- 線性邊緣：planner → security_advisor → governance_advisor → cost_advisor → permission_advisor → reputation_advisor → executor, ci_monitor → reviewer → decision, fixer → executor
- 條件邊緣：executor → (executor|ci_monitor|fixer|finalizer), decision → (fixer|ci_monitor|finalizer)

**Link to Devin run**: https://app.devin.ai/sessions/d677fe3dbfc945be974a95a828947be1
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918

## Updates since last revision

- 根據 gemini-code-assist 評論，提取 `_planner_success` helper 函數
- LLM planner 和 static planner 路徑現在都使用共享的 helper
- 保持 LLM planner 成功路徑的 early-return 語義不變

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest test_orchestrator_metrics.py`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests) - Playwright
- [ ] 視覺回歸測試 (Visual Regression Tests) - VRT
- [x] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 運行 metrics 測試：`pytest handoff/20250928/40_App/orchestrator/tests/test_orchestrator_metrics.py -v -k "transition"`
2. 運行相關測試：`pytest handoff/20250928/40_App/orchestrator/tests/test_orchestrator_metrics.py handoff/20250928/40_App/orchestrator/tests/test_5agent_advisory_pipeline.py -v`

### 預期結果 (Expected Results)

- 所有 metrics 測試通過
- 129 個測試全部通過

### 實際結果 (Actual Results)

- 129 passed in 36.71s

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline
- [ ] Staging 環境
- [ ] 不同瀏覽器測試（如適用）

### 受影響的區域 (Affected Areas)

- `langgraph_orchestrator.py` - 所有 node 函數和 router 函數
- Redis metrics 存儲（如果啟用）

## Human Review Checklist

⚠️ **請特別審查以下項目**：

1. **`_planner_success` helper**：確認 helper 函數正確記錄 `record_node_complete` 和 `record_transition`，行為與原始重複代碼一致
2. **轉換名稱一致性**：確認 `record_transition` 中的 node 名稱與 `create_orchestrator_graph()` 中的名稱完全匹配
3. **條件邊緣邏輯**：確認 `should_continue_execution` 和 `should_fix_or_finalize` 的重構保持原有行為
4. **fixer 無條件記錄**：`fixer_node` 無論成功與否都記錄轉換到 `executor`（這符合 graph 定義，fixer 總是回到 executor）

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更


## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`flake8`
- [x] 無 `any` 類型（使用適當的類型定義）
- [x] 所有測試通過：129 passed
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新（`record_transition` 方法已有文檔）

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 API/邏輯
- [x] 避免使用已廢棄的目錄
- [x] 不在 src/** 中導入已廢棄的模組
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義（無新增環境變數）