### PR TITLE
fix(tests): use valid UUID format in test task IDs

### DIFF
--- a/handoff/20250928/40_App/orchestrator/failure_recorder.py
+++ b/handoff/20250928/40_App/orchestrator/failure_recorder.py
@@ -398,7 +398,7 @@ class FailureRecorder:
                     error=f"Failure record not found: {failure_id}"
                 )
 
-            new_trace_id = f"replay-{failure_id[:8]}-{str(uuid.uuid4())[:8]}"
+            new_trace_id = f"replay-{failure_id[:8]}-{uuid.uuid4()}"
 
             target_repo = repo or failure.metadata.get("repo") or DEFAULT_REPLAY_REPO
 

--- a/handoff/20250928/40_App/orchestrator/tests/test_worker.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_worker.py
@@ -5,6 +5,7 @@ import pytest
 import json
 import time
 import threading
+import uuid
 from unittest.mock import Mock, patch, MagicMock, call
 from datetime import datetime, timezone
 
@@ -400,7 +401,7 @@ class TestCanaryDeployment:
         simple_count = 0
         
         for i in range(100):
-            task_id = f"boundary-task-{i:03d}"
+            task_id = f"boundary-task-{i:03d}-{uuid.uuid4()}"
             mock_execute.reset_mock()
             mock_run_orch.reset_mock()
             
@@ -427,7 +428,8 @@ class TestCanaryDeployment:
             delattr(mock_settings, 'use_langgraph_percent')
         mock_execute.return_value = ("https://github.com/pr/1", "success", "trace-123")
         
-        result = run_orchestrator_task("task-killswitch", "Test", "owner/repo")
+        task_id = f"task-killswitch-{uuid.uuid4()}"
+        result = run_orchestrator_task(task_id, "Test", "owner/repo")
         
         assert result["pr_url"] == "https://github.com/pr/1"
         mock_execute.assert_called_once()
@@ -445,7 +447,8 @@ class TestCanaryDeployment:
             "trace_id": "trace-456"
         }
         
-        result = run_orchestrator_task("task-override", "Test", "owner/repo")
+        task_id = f"task-override-{uuid.uuid4()}"
+        result = run_orchestrator_task(task_id, "Test", "owner/repo")
         
         assert result["pr_url"] == "https://github.com/pr/2"
         mock_run_orch.assert_called_once()


### PR DESCRIPTION
## 描述 (Description)

修復 Sentry 中的 `db_writer` 錯誤，這些錯誤是由測試 task ID 不包含有效 UUID 導致的。

`db_writer.py` 中的 `normalize_and_validate_uuid` 函數需要從 task ID 字串中提取有效的 UUID。當 task ID 完全不包含 UUID（如 `task-killswitch`、`boundary-task-001`）或只包含截斷的 UUID（如 `replay-xxx-{uuid[:8]}`）時，函數會拋出 `ValueError`，導致 DB write 失敗並在 Sentry 中產生錯誤。

**變更內容**：
- `test_worker.py`: 在測試 task ID 中附加完整 UUID
- `failure_recorder.py`: 在 replay trace ID 中使用完整 UUID 而非截斷版本

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. 執行 `pytest handoff/20250928/40_App/orchestrator/tests/test_worker.py -v`
2. 確認所有 canary deployment 測試通過

### 預期結果 (Expected Results)

- 所有測試通過
- 測試執行時不再產生 `ValueError: No valid UUID found` 錯誤

### 測試環境 (Test Environment)

- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- Canary deployment 測試
- Failure replay 功能（trace ID 格式變更）

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] 無新增 `any` 類型
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR，僅含測試修復

## Human Review Checklist

- [ ] 確認 `failure_recorder.py` 中 replay trace ID 格式變更（從 `replay-{id[:8]}-{uuid[:8]}` 到 `replay-{id[:8]}-{uuid}`）不會影響下游消費者
- [ ] 確認測試 task ID 變更不會影響 canary routing 測試的確定性（特別是 `test_canary_deterministic_same_task_id` 未被修改）

---


Link to Devin run: https://app.devin.ai/sessions/bdc1c4efd0fb4685ba1f7f912523bd01
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918