### PR TITLE
fix(owner-console): use authenticatedFetch for cookie-based auth in dashboard API

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/lib/failures-experiments-api.js
+++ b/handoff/20250928/40_App/owner-console/src/lib/failures-experiments-api.js
@@ -4,13 +4,13 @@
  * Provides functions to interact with the failures and experiments API endpoints.
  * Phase 5 PR-6: Owner Console Dashboard
  * 
- * Auth Fix: Uses getAccessToken() from auth.ts for consistent token handling
- * - Production: token stored in-memory only (security)
- * - E2E tests: token stored in localStorage under 'morningai_access_token'
- * - Previous bug: used localStorage.getItem('token') which was never set
+ * Auth Fix: Uses authenticatedFetch() from auth.ts for proper cookie-based auth
+ * - Owner Console uses HttpOnly cookie-based authentication (not Bearer tokens)
+ * - authenticatedFetch handles: cookies, CSRF tokens, automatic token refresh
+ * - Previous bug: used raw fetch with Bearer token which doesn't work with cookie auth
  */
 
-import { getAccessToken } from './auth.ts';
+import { authenticatedFetch } from './auth.ts';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000'
 
@@ -19,13 +19,10 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000
  * @returns {Promise<{summary: Object, timestamp: string}>}
  */
 export async function getFailureSummary() {
-  const token = getAccessToken()
-  
-  const response = await fetch(`${API_BASE_URL}/api/failures/summary`, {
+  const response = await authenticatedFetch(`${API_BASE_URL}/api/failures/summary`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
+      'Content-Type': 'application/json'
     }
   })
 
@@ -47,17 +44,14 @@ export async function getFailureSummary() {
  * @returns {Promise<{failures: Array, count: number, limit: number, offset: number}>}
  */
 export async function getFailures({ limit = 50, offset = 0, error_type, task_type } = {}) {
-  const token = getAccessToken()
-  
   const params = new URLSearchParams({ limit: limit.toString(), offset: offset.toString() })
   if (error_type) params.append('error_type', error_type)
   if (task_type) params.append('task_type', task_type)
   
-  const response = await fetch(`${API_BASE_URL}/api/failures?${params}`, {
+  const response = await authenticatedFetch(`${API_BASE_URL}/api/failures?${params}`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
+      'Content-Type': 'application/json'
     }
   })
 
@@ -74,13 +68,10 @@ export async function getFailures({ limit = 50, offset = 0, error_type, task_typ
  * @returns {Promise<{metrics: Object, timestamp: string}>}
  */
 export async function getEvalMetrics() {
-  const token = getAccessToken()
-  
-  const response = await fetch(`${API_BASE_URL}/api/failures/eval/metrics`, {
+  const response = await authenticatedFetch(`${API_BASE_URL}/api/failures/eval/metrics`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
+      'Content-Type': 'application/json'
     }
   })
 
@@ -100,13 +91,10 @@ export async function getEvalMetrics() {
  * @returns {Promise<Object>}
  */
 export async function replayFailure(failureId, { repo } = {}) {
-  const token = getAccessToken()
-  
-  const response = await fetch(`${API_BASE_URL}/api/failures/${failureId}/replay`, {
+  const response = await authenticatedFetch(`${API_BASE_URL}/api/failures/${failureId}/replay`, {
     method: 'POST',
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
+      'Content-Type': 'application/json'
     },
     body: JSON.stringify({ repo })
   })
@@ -124,13 +112,10 @@ export async function replayFailure(failureId, { repo } = {}) {
  * @returns {Promise<{summary: Object, timestamp: string}>}
  */
 export async function getExperimentSummary() {
-  const token = getAccessToken()
-  
-  const response = await fetch(`${API_BASE_URL}/api/experiments/summary`, {
+  const response = await authenticatedFetch(`${API_BASE_URL}/api/experiments/summary`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
+      'Content-Type': 'application/json'
     }
   })
 
@@ -147,13 +132,10 @@ export async function getExperimentSummary() {
  * @returns {Promise<{experiments: Object, environment: string, active_experiments: Array}>}
  */
 export async function getExperiments() {
-  const token = getAccessToken()
-  
-  const response = await fetch(`${API_BASE_URL}/api/experiments`, {
+  const response = await authenticatedFetch(`${API_BASE_URL}/api/experiments`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
+      'Content-Type': 'application/json'
     }
   })
 
@@ -170,13 +152,10 @@ export async function getExperiments() {
  * @returns {Promise<{comparisons: Array, environment: string, active_experiments: Array}>}
  */
 export async function getExperimentComparison() {
-  const token = getAccessToken()
-  
-  const response = await fetch(`${API_BASE_URL}/api/experiments/comparison`, {
+  const response = await authenticatedFetch(`${API_BASE_URL}/api/experiments/comparison`, {
     method: 'GET',
     headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${token}`
+      'Content-Type': 'application/json'
     }
   })
 

--- a/handoff/20250928/40_App/owner-console/src/lib/failures-experiments-api.js
+++ b/handoff/20250928/40_App/owner-console/src/lib/failures-experiments-api.js
@@ -3,7 +3,14 @@
  * 
  * Provides functions to interact with the failures and experiments API endpoints.
  * Phase 5 PR-6: Owner Console Dashboard
+ * 
+ * Auth Fix: Uses getAccessToken() from auth.ts for consistent token handling
+ * - Production: token stored in-memory only (security)
+ * - E2E tests: token stored in localStorage under 'morningai_access_token'
+ * - Previous bug: used localStorage.getItem('token') which was never set
  */
+
+import { getAccessToken } from './auth.ts';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000'
 
@@ -12,7 +19,7 @@ const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:5000
  * @returns {Promise<{summary: Object, timestamp: string}>}
  */
 export async function getFailureSummary() {
-  const token = localStorage.getItem('token')
+  const token = getAccessToken()
   
   const response = await fetch(`${API_BASE_URL}/api/failures/summary`, {
     method: 'GET',
@@ -40,7 +47,7 @@ export async function getFailureSummary() {
  * @returns {Promise<{failures: Array, count: number, limit: number, offset: number}>}
  */
 export async function getFailures({ limit = 50, offset = 0, error_type, task_type } = {}) {
-  const token = localStorage.getItem('token')
+  const token = getAccessToken()
   
   const params = new URLSearchParams({ limit: limit.toString(), offset: offset.toString() })
   if (error_type) params.append('error_type', error_type)
@@ -67,7 +74,7 @@ export async function getFailures({ limit = 50, offset = 0, error_type, task_typ
  * @returns {Promise<{metrics: Object, timestamp: string}>}
  */
 export async function getEvalMetrics() {
-  const token = localStorage.getItem('token')
+  const token = getAccessToken()
   
   const response = await fetch(`${API_BASE_URL}/api/failures/eval/metrics`, {
     method: 'GET',
@@ -93,7 +100,7 @@ export async function getEvalMetrics() {
  * @returns {Promise<Object>}
  */
 export async function replayFailure(failureId, { repo } = {}) {
-  const token = localStorage.getItem('token')
+  const token = getAccessToken()
   
   const response = await fetch(`${API_BASE_URL}/api/failures/${failureId}/replay`, {
     method: 'POST',
@@ -117,7 +124,7 @@ export async function replayFailure(failureId, { repo } = {}) {
  * @returns {Promise<{summary: Object, timestamp: string}>}
  */
 export async function getExperimentSummary() {
-  const token = localStorage.getItem('token')
+  const token = getAccessToken()
   
   const response = await fetch(`${API_BASE_URL}/api/experiments/summary`, {
     method: 'GET',
@@ -140,7 +147,7 @@ export async function getExperimentSummary() {
  * @returns {Promise<{experiments: Object, environment: string, active_experiments: Array}>}
  */
 export async function getExperiments() {
-  const token = localStorage.getItem('token')
+  const token = getAccessToken()
   
   const response = await fetch(`${API_BASE_URL}/api/experiments`, {
     method: 'GET',
@@ -163,7 +170,7 @@ export async function getExperiments() {
  * @returns {Promise<{comparisons: Array, environment: string, active_experiments: Array}>}
  */
 export async function getExperimentComparison() {
-  const token = localStorage.getItem('token')
+  const token = getAccessToken()
   
   const response = await fetch(`${API_BASE_URL}/api/experiments/comparison`, {
     method: 'GET',


### PR DESCRIPTION
## 描述 (Description)

修復「失敗與實驗儀表板」(Failures & Experiments Dashboard) 的認證問題。

**根本原因**：`failures-experiments-api.js` 使用 raw `fetch()` 搭配 `Authorization: Bearer ${token}`，但 Owner Console 的認證系統是基於 **HttpOnly cookie**，而非 Bearer token。

原本的程式碼：
```javascript
const token = localStorage.getItem('token')  // 永遠是 null
const response = await fetch(url, {
  headers: { 'Authorization': `Bearer ${token}` }  // 發送 "Bearer null"
})
```

Owner Console 認證架構：
- 登入時，token 存在 HttpOnly cookies（JS 無法存取）
- `accessToken` 在 response 中是 **optional**（僅作為 cookie 被阻擋時的 fallback）
- 頁面重新整理後，in-memory token 會遺失

**修復方式**：改用 `authenticatedFetch()` from `auth.ts`，這是 Owner Console 的標準認證抽象層：
- 透過 `credentials: 'include'` 自動發送 cookies
- 自動處理 CSRF tokens
- 401 時自動 refresh token 並重試
- 僅在有 accessToken 時才加上 Bearer header（作為 fallback）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests) - `pnpm test`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests) - Playwright
- [ ] 視覺回歸測試 (Visual Regression Tests) - VRT
- [x] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 部署到 Vercel Preview 環境
2. 登入 Owner Console
3. 導航到「失敗與實驗」頁面 (`/failure-experiments`)
4. 確認儀表板資料正常載入（無 "載入儀表板資料失敗" 錯誤）
5. 重新整理頁面，確認資料仍可載入（驗證 cookie auth 正常運作）

### 預期結果 (Expected Results)

- 儀表板正常顯示失敗統計和實驗資料
- 無 "Authorization header missing" 或 "Not authenticated" 錯誤
- 頁面重新整理後仍可正常載入資料

### 測試環境 (Test Environment)

- [ ] 本地開發環境 (Local Development)
- [ ] CI/CD Pipeline
- [x] Staging 環境
- [ ] 不同瀏覽器測試

### 受影響的區域 (Affected Areas)

- 失敗與實驗儀表板 (`/failure-experiments`)
- 所有使用 `failures-experiments-api.js` 的元件

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [ ] ESLint 通過（0 warnings）：`pnpm lint`
- [ ] TypeScript 類型檢查通過：`pnpm typecheck`
- [x] 無 `any` 類型（使用適當的類型定義）
- [ ] 所有測試通過：`pnpm test`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 API/邏輯
- [x] 避免使用已廢棄的目錄
- [x] 不在 src/** 中導入已廢棄的模組

## Human Review Checklist

⚠️ **請特別注意以下項目**：

1. **Backend 相容性**：確認 `/api/failures/*` 和 `/api/experiments/*` endpoints 支援 cookie-based auth（與其他 v2 endpoints 相同）
2. **CSRF 處理**：`authenticatedFetch` 僅對 POST/PUT/PATCH/DELETE 加 CSRF token，GET 請求不加（這是正確行為）
3. **Health endpoints**：`checkFailuresHealth()` 和 `checkExperimentsHealth()` 仍使用 raw `fetch`（正確，因為不需要認證）
4. **Import 相容性**：`.js` 檔案 import `.ts` 模組（Vite 支援，但值得確認 build 正常）

---

Link to Devin run: https://app.devin.ai/sessions/bdc1c4efd0fb4685ba1f7f912523bd01
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918