### PR TITLE
fix: correct heredoc syntax and conditional artifact downloads in coverage-trend.yml

### DIFF
--- a/.github/workflows/coverage-trend.yml
+++ b/.github/workflows/coverage-trend.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Download API Backend coverage artifact
+        if: github.event.workflow_run.name == 'backend-ci'
         uses: dawidd6/action-download-artifact@v3
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
@@ -27,6 +28,7 @@ jobs:
         continue-on-error: true
       
       - name: Download Orchestrator coverage artifact
+        if: github.event.workflow_run.name == 'App Tests'
         uses: dawidd6/action-download-artifact@v3
         with:
           workflow: ${{ github.event.workflow_run.workflow_id }}
@@ -111,7 +113,7 @@ jobs:
         env:
           REDIS_URL: ${{ secrets.REDIS_URL }}
         run: |
-          python - <<'EOF'
+          python - <<'EOF' >> $GITHUB_STEP_SUMMARY
           import os
           import json
           import redis
@@ -161,4 +163,4 @@ jobs:
               
               print(f"| {module} | {current:.1f}% | {threshold}% | {status} | {trend} |")
           
-          EOF >> $GITHUB_STEP_SUMMARY
+          EOF


### PR DESCRIPTION
## 描述 (Description)

修復 Coverage Trend Tracking workflow 的兩個問題：

1. **Python SyntaxError 修復**: `>> $GITHUB_STEP_SUMMARY` 錯誤地放在 heredoc 結尾的 `EOF` 行，導致 Python 嘗試解析 `EOF >> $GITHUB_STEP_SUMMARY` 為 Python 語法而失敗。已將其移至 heredoc 開始行。

2. **條件式 artifact 下載**: 新增 `if` 條件，避免 "no artifacts found" 錯誤訊息：
   - API Backend artifact 僅在 `backend-ci` workflow 觸發時下載
   - Orchestrator artifact 僅在 `App Tests` workflow 觸發時下載

**錯誤日誌參考**:
```
SyntaxError: invalid syntax
  File "<stdin>", line 50
    EOF >> $GITHUB_STEP_SUMMARY
           ^
```

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [x] CI/CD Pipeline - 需要實際 workflow_run 事件觸發

### 測試步驟 (Test Steps)

1. 合併此 PR
2. 等待下一次 `backend-ci` 或 `App Tests` workflow 在 main 分支成功完成
3. 檢查 Coverage Trend Tracking workflow 是否成功執行

### 預期結果 (Expected Results)

- Coverage Trend Tracking workflow 成功完成（無 SyntaxError）
- 無 "no artifacts found" 錯誤訊息

### 測試環境 (Test Environment)

- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- Coverage Trend Tracking workflow
- GitHub Actions job summary 輸出

## ⚠️ 人工審查重點 (Human Review Checklist)

- [ ] **Heredoc 語法確認**: 確認 `python - <<'EOF' >> $GITHUB_STEP_SUMMARY` 是正確的 bash heredoc 語法
- [ ] **Workflow 名稱確認**: 確認 `'backend-ci'` 和 `'App Tests'` 與實際 workflow 名稱完全匹配
- [ ] **條件邏輯評估**: 如果 workflow 名稱變更，此條件會靜默失效

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] 無 TypeScript/JavaScript 變更
- [x] 僅修改 GitHub Actions workflow YAML

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此為純 CI workflow 修復
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義

---

**Link to Devin run**: https://app.devin.ai/sessions/500e2b54dec24d938ec79e8f3903499f
**Requested by**: Ryan Chen (@RC918)