### PR TITLE
feat: add RQ_MAX_JOBS env var for worker memory management

### DIFF
--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -358,7 +358,16 @@ JOB_TIMEOUT = int(os.getenv("RQ_JOB_TIMEOUT", "600"))
 # This helps prevent memory accumulation from LangGraph MemorySaver checkpoints
 # Set to 0 or None to disable (process unlimited jobs)
 # Recommended: 10-20 for LangGraph workloads to prevent OOM
-MAX_JOBS = int(os.getenv("RQ_MAX_JOBS", "0")) or None
+_raw_max_jobs = os.getenv("RQ_MAX_JOBS", "0")
+try:
+    MAX_JOBS = int(_raw_max_jobs) or None
+except ValueError:
+    import logging
+    logging.getLogger(__name__).warning(
+        f"Invalid value for RQ_MAX_JOBS: '{_raw_max_jobs}'. "
+        "Must be an integer. Defaulting to 0 (unlimited)."
+    )
+    MAX_JOBS = None
 
 @job(RQ_QUEUE_NAME, connection=redis_client_rq, retry=Retry(max=3, interval=[10, 30, 60]), timeout=JOB_TIMEOUT)
 def run_orchestrator_task(task_id: str, question: str, repo: str):


### PR DESCRIPTION
## 描述 (Description)

新增 `RQ_MAX_JOBS` 環境變數，讓 Worker 在處理指定數量的任務後自動退出，由容器編排器 (Render) 重新啟動。這有助於防止 LangGraph MemorySaver checkpoint 累積導致的 OOM (Out of Memory) 問題。

**背景**: Worker 在 4GB 記憶體下仍然發生 OOM，根本原因是 LangGraph MemorySaver 在每個 workflow node 保存完整的 AgentState snapshot，記憶體會隨任務累積。

**變更內容**:
- 新增 `RQ_MAX_JOBS` 環境變數 (預設: 0 = 無限制)
- 建議 LangGraph workload 設定為 10-20
- 在 feature flags snapshot 和 worker configuration 日誌中記錄 `max_jobs` 值

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [x] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. 在 Render Worker 環境變數中設定 `RQ_MAX_JOBS=10`
2. 設定 `USE_LANGGRAPH_PERCENT=10` 啟用 LangGraph 路徑
3. 觸發 15-20 個 FAQ 任務
4. 觀察 Worker 日誌，確認處理 10 個任務後自動退出並重啟
5. 確認無 OOM 事件發生

### 預期結果 (Expected Results)

- Worker 啟動日誌顯示 `"max_jobs": 10`
- Worker 處理 10 個任務後正常退出
- Render 自動重啟 Worker
- 無 OOM 事件

### 測試環境 (Test Environment)

- [ ] 本地開發環境 (Local Development)
- [ ] CI/CD Pipeline
- [x] Staging 環境

### 受影響的區域 (Affected Areas)

- RQ Worker 生命週期管理
- LangGraph 任務處理

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] 無 `any` 類型（使用適當的類型定義）
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [ ] **新增/修改環境變數** → 更新 `config/env.schema.yaml` 和 `docs/ENVIRONMENTS.md`

⚠️ **待辦**: 部署驗證後，應將 `RQ_MAX_JOBS` 加入 `config/env.schema.yaml` 和 `docs/ENVIRONMENTS.md`

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 API/邏輯


## Human Review Checklist

請特別檢查：
1. `int(os.getenv("RQ_MAX_JOBS", "0")) or None` 邏輯是否正確 (0 → None)
2. RQ Worker 的 `max_jobs` 參數行為是否符合預期
3. 日誌是否正確記錄 `max_jobs` 值

---

*This PR was created with assistance from [Devin](https://app.devin.ai/sessions/8f5221bd950f42679cead9dd488a6430)*
*Requested by: Ryan*