### PR TITLE
feat(lint): upgrade spacing ESLint rule to error mode (Phase 3)

### DIFF
--- a/docs/ui-ux/standard.md
+++ b/docs/ui-ux/standard.md
@@ -293,7 +293,7 @@ The following CI checks enforce these standards:
 |-------|----------|----------|
 | Shared-UI imports | `enforce-shared-ui.yml` | Yes (Stage 3) |
 | Hardcoded colors | ESLint `no-hardcoded-colors` | Yes |
-| Non-standard spacing | ESLint `no-non-standard-spacing` | No (warn mode) |
+| Non-standard spacing | ESLint `no-non-standard-spacing` | Yes (error mode) |
 | i18n strings | `i18n-check-required.yml` | Yes |
 | Design system audit | `design-system-audit.yml` | No (relaxed mode) |
 

--- a/handoff/20250928/40_App/owner-console/eslint.config.js
+++ b/handoff/20250928/40_App/owner-console/eslint.config.js
@@ -80,8 +80,9 @@ export default [
       // Use semantic tokens instead (error, success, warning, info, neutral, primary, accent)
       'custom/no-hardcoded-colors': 'warn',
       // Design system enforcement: prevent non-standard spacing utilities
-      // Use standardized spacing values (0, 1, 2, 4, 5, 6, 8)
-      'custom/no-non-standard-spacing': 'warn',
+      // Use standardized spacing values (0, 1, 2, 3, 4, 5, 6, 8)
+      // Phase 3: Upgraded to error mode after Phase 2.5 cleanup (PR #1901)
+      'custom/no-non-standard-spacing': 'error',
     },
   },
   {


### PR DESCRIPTION
## 描述 (Description)

Phase 3 of spacing enforcement for owner-console. This PR upgrades the `no-non-standard-spacing` ESLint rule from `warn` to `error` mode, making it a blocking CI check.

**Prerequisites completed:**
- Phase 2 (#1876): Implemented spacing ESLint rule in warn mode
- Phase 2.5 (#1901): Cleaned up all 29 spacing violations

**Changes:**
- Upgrade `custom/no-non-standard-spacing` from `warn` to `error` in ESLint config
- Update `docs/ui-ux/standard.md` to mark spacing rule as blocking
- Fix comment to include `3` in allowed spacing scale (0, 1, 2, 3, 4, 5, 6, 8)

Closes #1896

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 手動測試 (Manual Testing)
- [x] CI/CD Pipeline

### 測試步驟 (Test Steps)

1. Run `cd handoff/20250928/40_App/owner-console && npm run lint`
2. Verify 0 spacing errors (rule is now in error mode)
3. Try adding a non-standard spacing class (e.g., `mt-7`) to any component
4. Run lint again - should fail with error

### 預期結果 (Expected Results)

- Lint passes with 0 spacing errors on current codebase
- New non-standard spacing values will cause lint to fail (blocking CI)

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline

### Human Review Checklist

- [ ] Verify PR #1901 was merged and 0 spacing violations exist
- [ ] Confirm allowed spacing scale is correct: `0, 1, 2, 3, 4, 5, 6, 8`
- [ ] Verify documentation update accurately reflects the new blocking status

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`pnpm lint`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 已更新 `docs/ui-ux/standard.md` 中的 CI Enforcement 表格

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式
- [x] 避免使用已廢棄的目錄

---

**Link to Devin run:** https://app.devin.ai/sessions/cdce934f77ee43bb9af8f2f672bbf30a
**Requested by:** Ryan Chen (@RC918)