### PR TITLE
refactor(test): use pytest pythonpath instead of sys.path.insert

### DIFF
--- a/agents/ops_agent/tests/test_task_routing.py
+++ b/agents/ops_agent/tests/test_task_routing.py
@@ -6,12 +6,15 @@ Tests for Issue #1909 (misrouted task -> FAILED + event) and Issue #1910 (enqueu
 Note: Python path is configured via pytest.ini pythonpath setting.
 No manual sys.path manipulation needed.
 """
+# Standard library imports
 import logging
-
-import pytest
-import pytest_asyncio
 from unittest.mock import AsyncMock, MagicMock
 
+# Third-party imports
+import pytest
+import pytest_asyncio
+
+# Local imports
 from common.config.settings import settings
 from orchestrator.schemas.task_schema import UnifiedTask, TaskType, TaskPriority, TaskStatus
 from orchestrator.task_queue.redis_queue import RedisQueue, create_redis_queue


### PR DESCRIPTION
## 描述 (Description)

移除 `test_task_routing.py` 中的手動 `sys.path.insert` 操作，改為依賴 `pytest.ini` 中已配置的 `pythonpath` 設定。

**變更內容：**
- 移除 `os`, `sys` imports 和未使用的 `patch` import
- 移除 `sys.path.insert(0, project_root)` 行
- 新增 docstring 說明 pythonpath 配置方式
- 調整 import 順序為 PEP 8 標準（標準庫 → 第三方 → 本地）

這是 P4 測試基礎設施改進，參考 #1909, #1910。

### Updates since last revision

- 調整 import 順序為 PEP 8 標準順序
- 新增 section comments 區分 Standard library / Third-party / Local imports

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pnpm test`
- [x] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests) - Playwright
- [ ] 視覺回歸測試 (Visual Regression Tests) - VRT
- [ ] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 執行 `pytest agents/ops_agent/tests/test_task_routing.py -v`
2. 確認所有 8 個測試通過

### 預期結果 (Expected Results)

- 所有測試通過，模組 import 正常運作

### 實際結果 (Actual Results)

- 本地測試：8 passed in 2.57s
- CI：36 checks passed

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline
- [ ] Staging 環境
- [ ] 不同瀏覽器測試（如適用）

### 受影響的區域 (Affected Areas)

- `agents/ops_agent/tests/test_task_routing.py` - 僅 import 和 docstring 變更

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`pnpm lint`
- [x] TypeScript 類型檢查通過：`pnpm typecheck`
- [x] 無 `any` 類型（使用適當的類型定義）
- [x] 所有測試通過：`pnpm test`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
- [x] 避免使用已廢棄的目錄
- [x] 不在 src/** 中導入已廢棄的模組
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義


## ⚠️ 人工審查重點 (Human Review Checklist)

1. **pythonpath 配置驗證**：確認 `pytest.ini` 中的 `pythonpath` 設定（包含 `.`, `orchestrator` 等路徑）足以解析此測試檔案中的所有 imports（`common.config.settings`, `orchestrator.schemas.task_schema`, `orchestrator.task_queue.redis_queue`）

2. **PEP 8 import 順序**：確認 `unittest.mock` 正確歸類為標準庫（而非第三方）

---

**Link to Devin run**: https://app.devin.ai/sessions/0c7f9960bf804a6dadc3d4bc80597168
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918