### PR TITLE
refactor(tests): @testing-library best practices + long-tail sensitive file tests

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/src/components/__tests__/LoginPage.test.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/__tests__/LoginPage.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 import LoginPage from '../LoginPage'
 
@@ -20,7 +21,7 @@ vi.mock('@/components/ui/apple-button', () => ({
 vi.mock('@/components/ui/apple-input', () => ({
   AppleInput: ({ label, ...props }: { label?: string; [key: string]: any }) => (
     <div>
-      {label && <label>{label}</label>}
+      {label && <label htmlFor={props.id}>{label}</label>}
       <input {...props} />
     </div>
   )
@@ -44,79 +45,123 @@ vi.mock('framer-motion', () => ({
 }))
 
 const renderLoginPage = () => {
-  return render(
+  const user = userEvent.setup()
+  const result = render(
     <BrowserRouter>
       <LoginPage onLogin={vi.fn()} />
     </BrowserRouter>
   )
+  return { ...result, user }
 }
 
 describe('LoginPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   describe('Rendering', () => {
     it('should render without crashing', () => {
       const { container } = renderLoginPage()
-      expect(container).toBeTruthy()
+      // Submit button exists (text may be i18n key in test environment)
+      const submitButton = container.querySelector('button[type="submit"]')
+      expect(submitButton).toBeInTheDocument()
     })
 
     it('should render email input field', () => {
-      const { container } = renderLoginPage()
-      const emailInput = container.querySelector('input[name="email"]')
-      expect(emailInput).toBeTruthy()
+      renderLoginPage()
+      // Use getByRole for email input (type="email" gives it textbox role)
+      const emailInput = screen.getByRole('textbox')
+      expect(emailInput).toBeInTheDocument()
+      expect(emailInput).toHaveAttribute('name', 'email')
+      expect(emailInput).toHaveAttribute('type', 'email')
     })
 
     it('should render password input field', () => {
       const { container } = renderLoginPage()
-      const passwordInput = container.querySelector('input[name="password"]')
-      expect(passwordInput).toBeTruthy()
+      // Password inputs don't have a role, query by attribute
+      const passwordInput = container.querySelector('input[type="password"]')
+      expect(passwordInput).toBeInTheDocument()
+      expect(passwordInput).toHaveAttribute('name', 'password')
     })
 
     it('should render submit button', () => {
       const { container } = renderLoginPage()
       const submitButton = container.querySelector('button[type="submit"]')
-      expect(submitButton).toBeTruthy()
+      expect(submitButton).toBeInTheDocument()
     })
 
     it('should render SSO buttons', () => {
-      const { container } = renderLoginPage()
-      const buttons = container.querySelectorAll('button[type="button"]')
-      // Should have Google, Apple, and GitHub SSO buttons
-      expect(buttons.length).toBeGreaterThanOrEqual(3)
+      renderLoginPage()
+      // Query SSO buttons by aria-label (these have proper aria-labels)
+      const googleButton = screen.getByRole('button', { name: /google/i })
+      const appleButton = screen.getByRole('button', { name: /apple/i })
+      const githubButton = screen.getByRole('button', { name: /github/i })
+      
+      expect(googleButton).toBeInTheDocument()
+      expect(appleButton).toBeInTheDocument()
+      expect(githubButton).toBeInTheDocument()
     })
 
     it('should render forgot password link', () => {
       const { container } = renderLoginPage()
+      // Link href is reliable even when text is i18n key
       const forgotPasswordLink = container.querySelector('a[href="/forgot-password"]')
-      expect(forgotPasswordLink).toBeTruthy()
+      expect(forgotPasswordLink).toBeInTheDocument()
     })
   })
 
   describe('Form Interaction', () => {
     it('should update email field on change', async () => {
-      const { container } = renderLoginPage()
-      const emailInput = container.querySelector('input[name="email"]') as HTMLInputElement
+      const { user } = renderLoginPage()
+      const emailInput = screen.getByRole('textbox')
       
-      expect(emailInput).not.toBeNull()
-      emailInput.value = 'test@example.com'
-      emailInput.dispatchEvent(new Event('change', { bubbles: true }))
-      expect(emailInput.value).toBe('test@example.com')
+      await user.clear(emailInput)
+      await user.type(emailInput, 'test@example.com')
+      
+      expect(emailInput).toHaveValue('test@example.com')
     })
 
     it('should update password field on change', async () => {
-      const { container } = renderLoginPage()
-      const passwordInput = container.querySelector('input[name="password"]') as HTMLInputElement
-      
+      const { user, container } = renderLoginPage()
+      const passwordInput = container.querySelector('input[type="password"]') as HTMLInputElement
       expect(passwordInput).not.toBeNull()
-      passwordInput.value = 'testpassword'
-      passwordInput.dispatchEvent(new Event('change', { bubbles: true }))
-      expect(passwordInput.value).toBe('testpassword')
+      
+      await user.clear(passwordInput)
+      await user.type(passwordInput, 'testpassword')
+      
+      expect(passwordInput).toHaveValue('testpassword')
     })
   })
 
   describe('Accessibility', () => {
     it('should have accessible SSO button labels', () => {
+      renderLoginPage()
+      
+      // All SSO buttons should have aria-labels
+      const googleButton = screen.getByRole('button', { name: /google/i })
+      const appleButton = screen.getByRole('button', { name: /apple/i })
+      const githubButton = screen.getByRole('button', { name: /github/i })
+      
+      expect(googleButton).toHaveAccessibleName()
+      expect(appleButton).toHaveAccessibleName()
+      expect(githubButton).toHaveAccessibleName()
+    })
+
+    it('should have proper form structure', () => {
       const { container } = renderLoginPage()
-      const ssoButtons = container.querySelectorAll('button[aria-label]')
-      expect(ssoButtons.length).toBeGreaterThanOrEqual(3)
+      
+      // Form should exist
+      const form = container.querySelector('form')
+      expect(form).toBeInTheDocument()
+      
+      // Email input should exist with proper attributes
+      const emailInput = screen.getByRole('textbox')
+      expect(emailInput).toHaveAttribute('required')
+      
+      // Password input should exist with proper attributes
+      const passwordInput = container.querySelector('input[type="password"]')
+      expect(passwordInput).toBeInTheDocument()
+      expect(passwordInput).toHaveAttribute('required')
     })
   })
 })

--- a/handoff/20250928/40_App/frontend-dashboard/src/components/__tests__/SignupPage.test.tsx
+++ b/handoff/20250928/40_App/frontend-dashboard/src/components/__tests__/SignupPage.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest'
-import { render } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 import SignupPage from '../SignupPage'
 
@@ -19,7 +20,7 @@ vi.mock('@/components/ui/apple-button', () => ({
 vi.mock('@/components/ui/apple-input', () => ({
   AppleInput: ({ label, ...props }: { label: string; [key: string]: any }) => (
     <div>
-      {label && <label>{label}</label>}
+      {label && <label htmlFor={props.id}>{label}</label>}
       <input {...props} />
     </div>
   )
@@ -43,111 +44,159 @@ vi.mock('framer-motion', () => ({
 }))
 
 const renderSignupPage = () => {
-  return render(
+  const user = userEvent.setup()
+  const result = render(
     <BrowserRouter>
       <SignupPage />
     </BrowserRouter>
   )
+  return { ...result, user }
 }
 
 describe('SignupPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   describe('Rendering', () => {
     it('should render without crashing', () => {
       const { container } = renderSignupPage()
-      expect(container).toBeTruthy()
+      // Submit button exists (text may be i18n key in test environment)
+      const submitButton = container.querySelector('button[type="submit"]')
+      expect(submitButton).toBeInTheDocument()
     })
 
     it('should render full name input field', () => {
       const { container } = renderSignupPage()
       const fullNameInput = container.querySelector('input[name="fullName"]')
-      expect(fullNameInput).toBeTruthy()
+      expect(fullNameInput).toBeInTheDocument()
+      expect(fullNameInput).toHaveAttribute('type', 'text')
     })
 
     it('should render email input field', () => {
       const { container } = renderSignupPage()
       const emailInput = container.querySelector('input[name="email"]')
-      expect(emailInput).toBeTruthy()
+      expect(emailInput).toBeInTheDocument()
+      expect(emailInput).toHaveAttribute('type', 'email')
     })
 
     it('should render password input field', () => {
       const { container } = renderSignupPage()
       const passwordInput = container.querySelector('input[name="password"]')
-      expect(passwordInput).toBeTruthy()
+      expect(passwordInput).toBeInTheDocument()
+      expect(passwordInput).toHaveAttribute('type', 'password')
     })
 
     it('should render confirm password input field', () => {
       const { container } = renderSignupPage()
       const confirmPasswordInput = container.querySelector('input[name="confirmPassword"]')
-      expect(confirmPasswordInput).toBeTruthy()
+      expect(confirmPasswordInput).toBeInTheDocument()
+      expect(confirmPasswordInput).toHaveAttribute('type', 'password')
     })
 
     it('should render submit button', () => {
       const { container } = renderSignupPage()
       const submitButton = container.querySelector('button[type="submit"]')
-      expect(submitButton).toBeTruthy()
+      expect(submitButton).toBeInTheDocument()
     })
 
     it('should render SSO buttons', () => {
-      const { container } = renderSignupPage()
-      const buttons = container.querySelectorAll('button[type="button"]')
-      // Should have Google, Apple, and GitHub SSO buttons
-      expect(buttons.length).toBeGreaterThanOrEqual(3)
+      renderSignupPage()
+      // Query SSO buttons by aria-label (these have proper aria-labels)
+      const googleButton = screen.getByRole('button', { name: /google/i })
+      const appleButton = screen.getByRole('button', { name: /apple/i })
+      const githubButton = screen.getByRole('button', { name: /github/i })
+      
+      expect(googleButton).toBeInTheDocument()
+      expect(appleButton).toBeInTheDocument()
+      expect(githubButton).toBeInTheDocument()
     })
 
     it('should render login link', () => {
       const { container } = renderSignupPage()
+      // Link href is reliable even when text is i18n key
       const loginLink = container.querySelector('a[href="/login"]')
-      expect(loginLink).toBeTruthy()
+      expect(loginLink).toBeInTheDocument()
     })
   })
 
   describe('Form Interaction', () => {
     it('should update full name field on change', async () => {
-      const { container } = renderSignupPage()
+      const { user, container } = renderSignupPage()
       const fullNameInput = container.querySelector('input[name="fullName"]') as HTMLInputElement
-      
       expect(fullNameInput).not.toBeNull()
-      fullNameInput.value = 'John Doe'
-      fullNameInput.dispatchEvent(new Event('change', { bubbles: true }))
-      expect(fullNameInput.value).toBe('John Doe')
+      
+      await user.clear(fullNameInput)
+      await user.type(fullNameInput, 'John Doe')
+      
+      expect(fullNameInput).toHaveValue('John Doe')
     })
 
     it('should update email field on change', async () => {
-      const { container } = renderSignupPage()
+      const { user, container } = renderSignupPage()
       const emailInput = container.querySelector('input[name="email"]') as HTMLInputElement
-      
       expect(emailInput).not.toBeNull()
-      emailInput.value = 'test@example.com'
-      emailInput.dispatchEvent(new Event('change', { bubbles: true }))
-      expect(emailInput.value).toBe('test@example.com')
+      
+      await user.clear(emailInput)
+      await user.type(emailInput, 'test@example.com')
+      
+      expect(emailInput).toHaveValue('test@example.com')
     })
 
     it('should update password field on change', async () => {
-      const { container } = renderSignupPage()
+      const { user, container } = renderSignupPage()
       const passwordInput = container.querySelector('input[name="password"]') as HTMLInputElement
-      
       expect(passwordInput).not.toBeNull()
-      passwordInput.value = 'testpassword123'
-      passwordInput.dispatchEvent(new Event('change', { bubbles: true }))
-      expect(passwordInput.value).toBe('testpassword123')
+      
+      await user.clear(passwordInput)
+      await user.type(passwordInput, 'testpassword123')
+      
+      expect(passwordInput).toHaveValue('testpassword123')
     })
 
     it('should update confirm password field on change', async () => {
-      const { container } = renderSignupPage()
+      const { user, container } = renderSignupPage()
       const confirmPasswordInput = container.querySelector('input[name="confirmPassword"]') as HTMLInputElement
-      
       expect(confirmPasswordInput).not.toBeNull()
-      confirmPasswordInput.value = 'testpassword123'
-      confirmPasswordInput.dispatchEvent(new Event('change', { bubbles: true }))
-      expect(confirmPasswordInput.value).toBe('testpassword123')
+      
+      await user.clear(confirmPasswordInput)
+      await user.type(confirmPasswordInput, 'testpassword123')
+      
+      expect(confirmPasswordInput).toHaveValue('testpassword123')
     })
   })
 
   describe('Accessibility', () => {
     it('should have accessible SSO button labels', () => {
+      renderSignupPage()
+      
+      // All SSO buttons should have aria-labels
+      const googleButton = screen.getByRole('button', { name: /google/i })
+      const appleButton = screen.getByRole('button', { name: /apple/i })
+      const githubButton = screen.getByRole('button', { name: /github/i })
+      
+      expect(googleButton).toHaveAccessibleName()
+      expect(appleButton).toHaveAccessibleName()
+      expect(githubButton).toHaveAccessibleName()
+    })
+
+    it('should have proper form structure', () => {
       const { container } = renderSignupPage()
-      const ssoButtons = container.querySelectorAll('button[aria-label]')
-      expect(ssoButtons.length).toBeGreaterThanOrEqual(3)
+      
+      // Form should exist
+      const form = container.querySelector('form')
+      expect(form).toBeInTheDocument()
+      
+      // All required inputs should exist
+      const fullNameInput = container.querySelector('input[name="fullName"]')
+      const emailInput = container.querySelector('input[name="email"]')
+      const passwordInput = container.querySelector('input[name="password"]')
+      const confirmPasswordInput = container.querySelector('input[name="confirmPassword"]')
+      
+      expect(fullNameInput).toBeInTheDocument()
+      expect(emailInput).toBeInTheDocument()
+      expect(passwordInput).toBeInTheDocument()
+      expect(confirmPasswordInput).toBeInTheDocument()
     })
   })
 })

--- a/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_semantic_rules.py
+++ b/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_semantic_rules.py
@@ -524,6 +524,159 @@ class TestSensitiveFileValidation:
         assert "fly.toml" in SENSITIVE_FILE_PATTERNS
 
 
+class TestLongTailSensitiveFiles:
+    """Test long-tail sensitive file patterns (Follow-up PR)
+    
+    These tests cover additional deployment and configuration files
+    that may contain sensitive information like API keys, database URLs,
+    or infrastructure secrets.
+    """
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_render_yaml_blocked(self, mock_load):
+        """Should block render.yaml files (Render deployment config)"""
+        validator = SemanticRulesValidator()
+        # Add render.yaml to blocked patterns for this test
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["render.yaml"]
+        
+        is_valid, violation = validator.validate_sensitive_file("render.yaml")
+        assert is_valid is False
+        assert violation is not None
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_render_yaml_in_subdirectory_blocked(self, mock_load):
+        """Should block render.yaml in subdirectories"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["render.yaml"]
+        
+        is_valid, violation = validator.validate_sensitive_file("deploy/render.yaml")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_vercel_json_blocked(self, mock_load):
+        """Should block vercel.json files (Vercel deployment config)"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["vercel.json"]
+        
+        is_valid, violation = validator.validate_sensitive_file("vercel.json")
+        assert is_valid is False
+        assert violation is not None
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_docker_compose_yml_blocked(self, mock_load):
+        """Should block docker-compose.yml files (may contain secrets)"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["docker-compose.yml", "docker-compose.yaml"]
+        
+        is_valid, violation = validator.validate_sensitive_file("docker-compose.yml")
+        assert is_valid is False
+        assert violation is not None
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_docker_compose_yaml_blocked(self, mock_load):
+        """Should block docker-compose.yaml files"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["docker-compose.yml", "docker-compose.yaml"]
+        
+        is_valid, violation = validator.validate_sensitive_file("docker-compose.yaml")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_railway_json_blocked(self, mock_load):
+        """Should block railway.json files (Railway deployment config)"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["railway.json"]
+        
+        is_valid, violation = validator.validate_sensitive_file("railway.json")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_netlify_toml_blocked(self, mock_load):
+        """Should block netlify.toml files (Netlify deployment config)"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["netlify.toml"]
+        
+        is_valid, violation = validator.validate_sensitive_file("netlify.toml")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_heroku_yml_blocked(self, mock_load):
+        """Should block heroku.yml files (Heroku deployment config)"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["heroku.yml"]
+        
+        is_valid, violation = validator.validate_sensitive_file("heroku.yml")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_app_yaml_blocked(self, mock_load):
+        """Should block app.yaml files (Google Cloud App Engine config)"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["app.yaml"]
+        
+        is_valid, violation = validator.validate_sensitive_file("app.yaml")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_terraform_tfvars_blocked(self, mock_load):
+        """Should block terraform.tfvars files (Terraform variables with secrets)"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + [".tfvars"]
+        
+        is_valid, violation = validator.validate_sensitive_file("terraform.tfvars")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_secrets_yaml_blocked(self, mock_load):
+        """Should block secrets.yaml files (Kubernetes secrets)"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["secrets.yaml", "secrets.yml"]
+        
+        is_valid, violation = validator.validate_sensitive_file("k8s/secrets.yaml")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_kubeconfig_blocked(self, mock_load):
+        """Should block kubeconfig files"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["kubeconfig"]
+        
+        is_valid, violation = validator.validate_sensitive_file(".kube/kubeconfig")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_aws_credentials_blocked(self, mock_load):
+        """Should block AWS credentials files"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["credentials"]
+        
+        is_valid, violation = validator.validate_sensitive_file(".aws/credentials")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+    @patch('semantic_rules.SemanticRulesValidator._load_settings')
+    def test_validate_gcloud_config_blocked(self, mock_load):
+        """Should block gcloud configuration files"""
+        validator = SemanticRulesValidator()
+        validator.blocked_file_patterns = list(SENSITIVE_FILE_PATTERNS) + ["application_default_credentials.json"]
+        
+        is_valid, violation = validator.validate_sensitive_file(".config/gcloud/application_default_credentials.json")
+        assert is_valid is False
+        assert violation.rule_type == "sensitive_file"
+
+
 class TestCommandValidation:
     """Test command validation (Phase 1 Security Foundation)"""
 


### PR DESCRIPTION
## 描述 (Description)

Follow-up PR to Phase 1 Coverage Improvements (#1938). This PR includes two improvements:

**Frontend Test Refactoring:**
- Refactored `LoginPage.test.tsx` and `SignupPage.test.tsx` to use @testing-library best practices
- Replaced `container.querySelector` with `screen.getBy*` queries where applicable
- Replaced manual `dispatchEvent` with `userEvent` API for realistic user interactions
- Added `beforeEach` cleanup and proper async/await patterns
- Added new accessibility tests for form structure validation

**Backend Long-tail Sensitive File Tests:**
- Added `TestLongTailSensitiveFiles` class with 14 new tests covering additional deployment config patterns:
  - render.yaml, vercel.json, docker-compose.yml/yaml
  - railway.json, netlify.toml, heroku.yml, app.yaml
  - terraform.tfvars, secrets.yaml/yml, kubeconfig
  - AWS credentials, gcloud application_default_credentials.json

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pnpm test`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests) - Playwright
- [ ] 視覺回歸測試 (Visual Regression Tests) - VRT
- [ ] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. Run frontend tests: `cd handoff/20250928/40_App/frontend-dashboard && pnpm test`
2. Run backend tests: `cd handoff/20250928/40_App/orchestrator/project_engineer/tests && python -m pytest test_semantic_rules.py -v`

### 預期結果 (Expected Results)

- Frontend: 24 tests passing (10 LoginPage + 14 SignupPage)
- Backend: 73 tests passing (including 14 new long-tail sensitive file tests)

### 實際結果 (Actual Results)

- Frontend: ✅ 24 passed
- Backend: ✅ 73 passed

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [ ] CI/CD Pipeline
- [ ] Staging 環境
- [ ] 不同瀏覽器測試（如適用）

### 受影響的區域 (Affected Areas)

- Frontend test files only (no production code changes)
- Backend test files only (no production code changes)

### 新增的自動化測試 (New Automated Tests)

- `TestLongTailSensitiveFiles` class (14 tests) in `test_semantic_rules.py`
- New accessibility test `should have proper form structure` in LoginPage.test.tsx and SignupPage.test.tsx

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`pnpm lint`
- [x] TypeScript 類型檢查通過：`pnpm typecheck`
- [x] 無 `any` 類型（使用適當的類型定義）
- [x] 所有測試通過：`pnpm test`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒
- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
- [x] 避免使用已廢棄的目錄（如 `tools/frontend-lab`）
- [x] 不在 src/** 中導入已廢棄的模組
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義

## 🔍 Human Review Checklist

1. **userEvent API usage**: Verify async/await patterns are correct in form interaction tests
2. **Long-tail patterns**: The new tests add patterns dynamically to `blocked_file_patterns` - this tests the validation mechanism but doesn't add these to the production blocklist. Consider if any should be added to `SENSITIVE_FILE_PATTERNS` constant.
3. **Password input queries**: Still uses `container.querySelector` for password inputs since they don't have an accessible role - this is expected behavior.

---

*This PR was created with assistance from [Devin](https://app.devin.ai/sessions/a62e88e90a3d4ae9bdfb1b0228fdc440) on behalf of Ryan Chen*