### PR TITLE
feat(sessions-ui): Apply Phase 1 UI Standardization to Sessions Page

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
@@ -7,7 +7,9 @@ import {
   TabsList, 
   TabsTrigger, 
   Skeleton,
-  Progress
+  Progress,
+  StatCard,
+  SectionCard
 } from '@morningai/shared-ui'
 import { 
   Play,
@@ -531,152 +533,179 @@ const Sessions = () => {
         />
       )}
 
-      {/* Stats Cards */}
+      {/* Stats Cards - KPI Row */}
       <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-        {[
-          { key: 'all', label: t('sessions.filter.all', 'All'), icon: Activity },
-          { key: 'running', label: t('sessions.filter.running', 'Running'), icon: Play },
-          { key: 'paused', label: t('sessions.filter.paused', 'Paused'), icon: Pause },
-          { key: 'completed', label: t('sessions.filter.completed', 'Completed'), icon: CheckCircle },
-          { key: 'failed', label: t('sessions.filter.failed', 'Failed'), icon: XCircle }
-        ].map(({ key, label, icon: Icon }) => (
-          <button
-            key={key}
-            onClick={() => handleFilterChange(key)}
-            className={`rounded-xl border p-4 text-left transition-all ${
-              filter === key
-                ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
-                : 'border-[var(--border)] bg-[var(--surface)] hover:border-primary-300'
-            }`}
-          >
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-sm text-[var(--text-secondary)]">{label}</p>
-              <Icon className={`w-5 h-5 ${filter === key ? 'text-primary-500' : 'text-neutral-400'}`} />
-            </div>
-            <p className="text-2xl font-bold text-[var(--text-primary)]">
-              {sessionCounts[key]}
-            </p>
-          </button>
-        ))}
+        <button 
+          type="button"
+          onClick={() => handleFilterChange('all')}
+          className={`cursor-pointer transition-all rounded-xl text-left ${filter === 'all' ? 'ring-2 ring-primary-500' : ''}`}
+        >
+          <StatCard
+            label={t('sessions.filter.all', 'All')}
+            value={String(sessionCounts.all)}
+            icon={<Activity className="w-5 h-5" />}
+            variant="blue"
+          />
+        </button>
+        <button 
+          type="button"
+          onClick={() => handleFilterChange('running')}
+          className={`cursor-pointer transition-all rounded-xl text-left ${filter === 'running' ? 'ring-2 ring-primary-500' : ''}`}
+        >
+          <StatCard
+            label={t('sessions.filter.running', 'Running')}
+            value={String(sessionCounts.running)}
+            icon={<Play className="w-5 h-5" />}
+            variant="green"
+          />
+        </button>
+        <button 
+          type="button"
+          onClick={() => handleFilterChange('paused')}
+          className={`cursor-pointer transition-all rounded-xl text-left ${filter === 'paused' ? 'ring-2 ring-primary-500' : ''}`}
+        >
+          <StatCard
+            label={t('sessions.filter.paused', 'Paused')}
+            value={String(sessionCounts.paused)}
+            icon={<Pause className="w-5 h-5" />}
+            variant="yellow"
+          />
+        </button>
+        <button 
+          type="button"
+          onClick={() => handleFilterChange('completed')}
+          className={`cursor-pointer transition-all rounded-xl text-left ${filter === 'completed' ? 'ring-2 ring-primary-500' : ''}`}
+        >
+          <StatCard
+            label={t('sessions.filter.completed', 'Completed')}
+            value={String(sessionCounts.completed)}
+            icon={<CheckCircle className="w-5 h-5" />}
+            variant="green"
+          />
+        </button>
+        <button 
+          type="button"
+          onClick={() => handleFilterChange('failed')}
+          className={`cursor-pointer transition-all rounded-xl text-left ${filter === 'failed' ? 'ring-2 ring-primary-500' : ''}`}
+        >
+          <StatCard
+            label={t('sessions.filter.failed', 'Failed')}
+            value={String(sessionCounts.failed)}
+            icon={<XCircle className="w-5 h-5" />}
+            variant="red"
+          />
+        </button>
       </div>
 
       {/* Main Content: Session List + Details */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Session List */}
-        <div className="space-y-3">
-          <h2 className="text-sm font-medium text-[var(--text-secondary)] px-1">
-            {t('sessions.list.title', 'Sessions')} ({filteredSessions.length})
-          </h2>
-          
-          {filteredSessions.length === 0 ? (
-            <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-8 text-center">
-              <Activity className="w-12 h-12 text-neutral-300 mx-auto mb-3" />
-              <p className="text-neutral-500">
-                {t('sessions.list.noSessions', 'No sessions found')}
-              </p>
-            </div>
-          ) : (
-            filteredSessions.map((session) => (
-              <button
-                key={session.id}
-                onClick={() => handleSessionSelect(session)}
-                className={`w-full text-left rounded-xl border p-4 transition-all ${
-                  selectedSession?.id === session.id
-                    ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
-                    : 'border-[var(--border)] bg-[var(--surface)] hover:border-primary-300'
-                }`}
-              >
-                <div className="space-y-2">
-                  <div className="flex items-start justify-between">
-                    <div className="flex-1 min-w-0 overflow-hidden">
-                      <p className="text-sm font-semibold text-[var(--text-primary)] truncate">
-                        {session.title}
-                      </p>
-                      <p className="text-xs text-[var(--text-secondary)] mt-1 truncate">
-                        {session.goal}
-                      </p>
+        <SectionCard
+          title={t('sessions.list.title', 'Sessions')}
+          subtitle={`${filteredSessions.length} ${t('sessions.list.count', 'sessions')}`}
+        >
+          <div className="space-y-3">
+            {filteredSessions.length === 0 ? (
+              <div className="p-8 text-center">
+                <Activity className="w-12 h-12 text-neutral-300 mx-auto mb-3" />
+                <p className="text-neutral-500">
+                  {t('sessions.list.noSessions', 'No sessions found')}
+                </p>
+              </div>
+            ) : (
+              filteredSessions.map((session) => (
+                <button
+                  key={session.id}
+                  onClick={() => handleSessionSelect(session)}
+                  className={`w-full text-left rounded-xl border p-4 transition-all ${
+                    selectedSession?.id === session.id
+                      ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
+                      : 'border-[var(--border)] bg-[var(--surface)] hover:border-primary-300'
+                  }`}
+                >
+                  <div className="space-y-2">
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1 min-w-0 overflow-hidden">
+                        <p className="text-sm font-semibold text-[var(--text-primary)] truncate">
+                          {session.title}
+                        </p>
+                        <p className="text-xs text-[var(--text-secondary)] mt-1 truncate">
+                          {session.goal}
+                        </p>
+                      </div>
+                      <ChevronRight className={`w-4 h-4 ml-2 flex-shrink-0 ${
+                        selectedSession?.id === session.id ? 'text-primary-500' : 'text-neutral-400'
+                      }`} />
                     </div>
-                    <ChevronRight className={`w-4 h-4 ml-2 flex-shrink-0 ${
-                      selectedSession?.id === session.id ? 'text-primary-500' : 'text-neutral-400'
-                    }`} />
-                  </div>
-                  
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <Badge variant={getStatusBadgeVariant(session.status)} className="text-xs">
-                      {getStatusIcon(session.status)}
-                      <span>{t(`sessions.status.${session.status}`, session.status)}</span>
-                    </Badge>
                     
-                    {session.requiresApproval && (
-                      <Badge variant="warning" className="text-xs">
-                        <AlertTriangle />
-                        <span>{t('sessions.needsApproval', 'Needs Approval')}</span>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge variant={getStatusBadgeVariant(session.status)} className="text-xs">
+                        {getStatusIcon(session.status)}
+                        <span>{t(`sessions.status.${session.status}`, session.status)}</span>
                       </Badge>
-                    )}
+                      
+                      {session.requiresApproval && (
+                        <Badge variant="warning" className="text-xs">
+                          <AlertTriangle />
+                          <span>{t('sessions.needsApproval', 'Needs Approval')}</span>
+                        </Badge>
+                      )}
+                    </div>
+                    
+                    <div className="flex items-center justify-between text-xs text-[var(--text-secondary)]">
+                      <span>{formatRelativeTime(session.updatedAt)}</span>
+                      <span className={getConfidenceColor(session.confidence)}>
+                        {t('sessions.confidence', 'Confidence')}: {Math.round(session.confidence * 100)}%
+                      </span>
+                    </div>
+                    
+                    <Progress value={session.progress} className="h-1" />
                   </div>
-                  
-                  <div className="flex items-center justify-between text-xs text-[var(--text-secondary)]">
-                    <span>{formatRelativeTime(session.updatedAt)}</span>
-                    <span className={getConfidenceColor(session.confidence)}>
-                      {t('sessions.confidence', 'Confidence')}: {Math.round(session.confidence * 100)}%
-                    </span>
-                  </div>
-                  
-                  <Progress value={session.progress} className="h-1" />
-                </div>
-              </button>
-            ))
-          )}
-        </div>
+                </button>
+              ))
+            )}
+          </div>
+        </SectionCard>
 
         {/* Session Details */}
         <div className="lg:col-span-2">
           {selectedSession ? (
-            <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-card">
-              {/* Session Header */}
-              <div className="px-5 py-4 border-b border-[var(--border)]">
-                <div className="flex items-start justify-between">
-                  <div>
-                    <h2 className="text-lg font-semibold text-[var(--text-primary)]">
-                      {selectedSession.title}
-                    </h2>
-                    <p className="text-sm text-[var(--text-secondary)] mt-1">
-                      {selectedSession.goal}
-                    </p>
-                  </div>
-                  <Badge variant={getStatusBadgeVariant(selectedSession.status)} className="text-xs">
-                    {getStatusIcon(selectedSession.status)}
-                    <span>{t(`sessions.status.${selectedSession.status}`, selectedSession.status)}</span>
-                  </Badge>
-                </div>
-                
-                {/* Session Actions */}
-                <div className="flex items-center gap-2 mt-4">
-                  {selectedSession.status === 'running' && (
-                    <AppleButton variant="outline" size="sm" haptic="light" onClick={() => handlePauseSession(selectedSession.id)}>
-                      <Pause className="w-4 h-4 mr-1" />
-                      {t('sessions.actions.pause', 'Pause')}
-                    </AppleButton>
-                  )}
-                  {selectedSession.status === 'paused' && (
-                    <AppleButton variant="outline" size="sm" haptic="light" onClick={() => handleResumeSession(selectedSession.id)}>
-                      <Play className="w-4 h-4 mr-1" />
-                      {t('sessions.actions.resume', 'Resume')}
-                    </AppleButton>
-                  )}
-                  {(selectedSession.status === 'running' || selectedSession.status === 'paused') && (
-                    <AppleButton variant="outline" size="sm" haptic="light" onClick={() => handleCancelSession(selectedSession.id)}>
-                      <StopCircle className="w-4 h-4 mr-1" />
-                      {t('sessions.actions.cancel', 'Cancel')}
-                    </AppleButton>
-                  )}
-                  {selectedSession.requiresApproval && (
-                    <AppleButton variant="default" size="sm" haptic="medium" disabled>
-                      <CheckCircle className="w-4 h-4 mr-1" />
-                      {t('sessions.actions.approve', 'Approve')}
-                    </AppleButton>
-                  )}
-                </div>
+            <SectionCard
+              title={selectedSession.title}
+              subtitle={selectedSession.goal}
+              action={
+                <Badge variant={getStatusBadgeVariant(selectedSession.status)} className="text-xs">
+                  {getStatusIcon(selectedSession.status)}
+                  <span>{t(`sessions.status.${selectedSession.status}`, selectedSession.status)}</span>
+                </Badge>
+              }
+            >
+              {/* Session Actions */}
+              <div className="flex items-center gap-2 mb-4">
+                {selectedSession.status === 'running' && (
+                  <AppleButton variant="outline" size="sm" haptic="light" onClick={() => handlePauseSession(selectedSession.id)}>
+                    <Pause className="w-4 h-4 mr-1" />
+                    {t('sessions.actions.pause', 'Pause')}
+                  </AppleButton>
+                )}
+                {selectedSession.status === 'paused' && (
+                  <AppleButton variant="outline" size="sm" haptic="light" onClick={() => handleResumeSession(selectedSession.id)}>
+                    <Play className="w-4 h-4 mr-1" />
+                    {t('sessions.actions.resume', 'Resume')}
+                  </AppleButton>
+                )}
+                {(selectedSession.status === 'running' || selectedSession.status === 'paused') && (
+                  <AppleButton variant="outline" size="sm" haptic="light" onClick={() => handleCancelSession(selectedSession.id)}>
+                    <StopCircle className="w-4 h-4 mr-1" />
+                    {t('sessions.actions.cancel', 'Cancel')}
+                  </AppleButton>
+                )}
+                {selectedSession.requiresApproval && (
+                  <AppleButton variant="default" size="sm" haptic="medium" disabled>
+                    <CheckCircle className="w-4 h-4 mr-1" />
+                    {t('sessions.actions.approve', 'Approve')}
+                  </AppleButton>
+                )}
               </div>
 
               {/* Session Content Tabs */}
@@ -825,7 +854,7 @@ const Sessions = () => {
               </Tabs>
 
               {/* Session Footer */}
-              <div className="px-5 py-3 border-t border-[var(--border)] text-xs text-[var(--text-secondary)]">
+              <div className="mt-4 pt-3 border-t border-[var(--border)] text-xs text-[var(--text-secondary)]">
                 <div className="flex items-center justify-between">
                   <span>
                     {t('sessions.startedAt', 'Started')}: {formatTimestamp(selectedSession.startedAt)}
@@ -842,14 +871,16 @@ const Sessions = () => {
                   )}
                 </div>
               </div>
-            </div>
+            </SectionCard>
           ) : (
-            <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] p-8 text-center">
-              <ListTodo className="w-16 h-16 text-neutral-300 mx-auto mb-4" />
-              <p className="text-neutral-500">
-                {t('sessions.selectSession', 'Select a session to view details')}
-              </p>
-            </div>
+            <SectionCard title={t('sessions.details.title', 'Session Details')}>
+              <div className="p-8 text-center">
+                <ListTodo className="w-16 h-16 text-neutral-300 mx-auto mb-4" />
+                <p className="text-neutral-500">
+                  {t('sessions.selectSession', 'Select a session to view details')}
+                </p>
+              </div>
+            </SectionCard>
           )}
         </div>
       </div>

--- a/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { 
   Badge, 
@@ -170,6 +170,8 @@ const MOCK_SESSIONS = Object.freeze([
  * - useCallback for event handlers to prevent unnecessary re-renders
  * - useMemo for derived values (filteredSessions, sessionCounts)
  */
+const POLLING_INTERVAL_MS = 10000
+
 const Sessions = () => {
   const { t } = useTranslation()
   const [loading, setLoading] = useState(true)
@@ -177,6 +179,9 @@ const Sessions = () => {
   const [sessions, setSessions] = useState([])
   const [selectedSession, setSelectedSession] = useState(null)
   const [filter, setFilter] = useState('all')
+  const [autoRefresh, setAutoRefresh] = useState(true)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+  const pollingIntervalRef = useRef(null)
 
   const loadSessions = useCallback(async () => {
     try {
@@ -208,6 +213,56 @@ const Sessions = () => {
   useEffect(() => {
     loadSessions()
   }, [loadSessions])
+
+  const refreshSessionsSilently = useCallback(async () => {
+    try {
+      setIsRefreshing(true)
+      const statusParam = filter !== 'all' ? `?status=${filter}` : ''
+      const response = await apiClientWithMeta(`/api/sessions${statusParam}`, { method: 'GET' })
+      const sessionsData = response.data?.sessions || []
+      setSessions(sessionsData)
+      
+      setSelectedSession(prev => {
+        if (prev) {
+          const updatedSession = sessionsData.find(s => s.id === prev.id)
+          return updatedSession || prev
+        }
+        return prev
+      })
+    } catch (err) {
+      console.error('Silent refresh failed:', err)
+    } finally {
+      setIsRefreshing(false)
+    }
+  }, [filter])
+
+  const hasActiveSessions = useMemo(() => {
+    return sessions.some(s => s.status === 'running' || s.status === 'paused')
+  }, [sessions])
+
+  useEffect(() => {
+    if (pollingIntervalRef.current) {
+      clearInterval(pollingIntervalRef.current)
+      pollingIntervalRef.current = null
+    }
+
+    if (autoRefresh && hasActiveSessions && !loading) {
+      pollingIntervalRef.current = setInterval(() => {
+        refreshSessionsSilently()
+      }, POLLING_INTERVAL_MS)
+    }
+
+    return () => {
+      if (pollingIntervalRef.current) {
+        clearInterval(pollingIntervalRef.current)
+        pollingIntervalRef.current = null
+      }
+    }
+  }, [autoRefresh, hasActiveSessions, loading, refreshSessionsSilently])
+
+  const handleToggleAutoRefresh = useCallback(() => {
+    setAutoRefresh(prev => !prev)
+  }, [])
 
   // Memoized filter handler
   const handleFilterChange = useCallback((newFilter) => {
@@ -436,10 +491,36 @@ const Sessions = () => {
             {t('sessions.subtitle', 'Monitor and manage Meta Agent task execution sessions')}
           </p>
         </div>
-        <AppleButton onClick={loadSessions} variant="outline" haptic="light" disabled={loading}>
-          <RotateCcw className="w-4 h-4 mr-2" />
-          {t('common.refresh', 'Refresh')}
-        </AppleButton>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={handleToggleAutoRefresh}
+            className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-all ${
+              autoRefresh
+                ? 'bg-growth-10 text-growth border border-growth-20'
+                : 'bg-neutral-100 text-neutral-500 border border-neutral-200 dark:bg-neutral-800 dark:border-neutral-700'
+            }`}
+            title={autoRefresh 
+              ? t('sessions.autoRefresh.enabled', 'Auto-refresh enabled (10s)')
+              : t('sessions.autoRefresh.disabled', 'Auto-refresh disabled')
+            }
+          >
+            <div className={`w-2 h-2 rounded-full ${
+              autoRefresh && hasActiveSessions
+                ? 'bg-growth animate-pulse'
+                : autoRefresh
+                  ? 'bg-growth'
+                  : 'bg-neutral-400'
+            }`} />
+            <span>{t('sessions.autoRefresh.label', 'Auto')}</span>
+            {isRefreshing && (
+              <RotateCcw className="w-3 h-3 animate-spin" />
+            )}
+          </button>
+          <AppleButton onClick={loadSessions} variant="outline" haptic="light" disabled={loading}>
+            <RotateCcw className="w-4 h-4 mr-2" />
+            {t('common.refresh', 'Refresh')}
+          </AppleButton>
+        </div>
       </div>
 
       {error && (

--- a/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
@@ -174,6 +174,13 @@ const MOCK_SESSIONS = Object.freeze([
  */
 const POLLING_INTERVAL_MS = 10000
 
+/**
+ * Temporary fallback to MOCK_SESSIONS when API returns empty data.
+ * This allows the UI to demonstrate all data states (Issue #16, PR 1: Sessions UI 骨架).
+ * Will be removed once backend has real session data (PR 2: 後端 API 整合).
+ */
+const USE_MOCK_SESSIONS_FALLBACK = true
+
 const Sessions = () => {
   const { t } = useTranslation()
   const [loading, setLoading] = useState(true)
@@ -192,7 +199,13 @@ const Sessions = () => {
       
       const statusParam = filter !== 'all' ? `?status=${filter}` : ''
       const response = await apiClientWithMeta(`/api/sessions${statusParam}`, { method: 'GET' })
-      const sessionsData = response.data?.sessions || []
+      let sessionsData = response.data?.sessions || []
+      
+      // Fallback to MOCK_SESSIONS when API returns empty data (Issue #16, PR 1: Sessions UI 骨架)
+      if (sessionsData.length === 0 && USE_MOCK_SESSIONS_FALLBACK) {
+        sessionsData = [...MOCK_SESSIONS]
+      }
+      
       setSessions(sessionsData)
       
       setSelectedSession(prev => {
@@ -207,6 +220,12 @@ const Sessions = () => {
         logContext: 'Sessions.loadSessions'
       })
       setError(errorMessage)
+      
+      // Also fallback to MOCK_SESSIONS on error if enabled
+      if (USE_MOCK_SESSIONS_FALLBACK) {
+        setSessions([...MOCK_SESSIONS])
+        setSelectedSession(MOCK_SESSIONS[0])
+      }
     } finally {
       setLoading(false)
     }
@@ -221,7 +240,13 @@ const Sessions = () => {
       setIsRefreshing(true)
       const statusParam = filter !== 'all' ? `?status=${filter}` : ''
       const response = await apiClientWithMeta(`/api/sessions${statusParam}`, { method: 'GET' })
-      const sessionsData = response.data?.sessions || []
+      let sessionsData = response.data?.sessions || []
+      
+      // Fallback to MOCK_SESSIONS when API returns empty data (Issue #16, PR 1: Sessions UI 骨架)
+      if (sessionsData.length === 0 && USE_MOCK_SESSIONS_FALLBACK) {
+        sessionsData = [...MOCK_SESSIONS]
+      }
+      
       setSessions(sessionsData)
       
       setSelectedSession(prev => {

--- a/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
@@ -872,6 +872,18 @@ const Sessions = () => {
                 </div>
               </div>
             </SectionCard>
+          ) : filteredSessions.length === 0 ? (
+            <SectionCard title={t('sessions.details.title', 'Session Details')}>
+              <div className="p-8 text-center">
+                <Activity className="w-16 h-16 text-neutral-300 mx-auto mb-4" />
+                <p className="text-neutral-500">
+                  {t('sessions.details.noSessions', 'No sessions available')}
+                </p>
+                <p className="text-sm text-neutral-400 mt-2">
+                  {t('sessions.details.noSessionsHint', 'Sessions will appear here when agents start executing tasks')}
+                </p>
+              </div>
+            </SectionCard>
           ) : (
             <SectionCard title={t('sessions.details.title', 'Session Details')}>
               <div className="p-8 text-center">


### PR DESCRIPTION
## 描述 (Description)

為 Sessions 頁面套用 Phase 1 UI 標準化，將自訂卡片元件遷移至 `@morningai/shared-ui` 的 `StatCard` 和 `SectionCard` 元件。此 PR 基於 PR #1993 的 auto-refresh 功能進行擴展。

**主要變更：**
- KPI Row：將 5 個自訂 filter 按鈕遷移至 `StatCard` 元件，使用適當的 variant（blue/green/yellow/red）
- Session List：使用 `SectionCard` 包裝，統一標題和副標題樣式
- Session Details：使用 `SectionCard` 包裝，支援 action slot 顯示狀態 Badge
- 保留 PR #1993 的 auto-refresh polling 功能（10 秒輪詢）

**Link to Devin run:** https://app.devin.ai/sessions/b769a624cc764a78afb518ff5a75e750
**Requested by:** Ryan Chen (ryan2939z@gmail.com) @RC918

---

### Updates since last revision

**新增 MOCK_SESSIONS Fallback 機制：**
- 新增 `USE_MOCK_SESSIONS_FALLBACK` flag 控制 mock 資料行為
- 當 API 回傳空資料時，自動使用 `MOCK_SESSIONS` 作為 fallback
- 此機制符合 Issue #16 的 3-PR 計畫：PR 1 為 UI 骨架（Mock Data）
- 當後端有真實資料後（PR 2: 後端 API 整合），將移除此 fallback

**新增 Session Details 三態邏輯：**
- 無 sessions 時：顯示「No sessions available」empty state
- 有 sessions 但未選擇時：顯示「Select a session to view details」
- 已選擇 session 時：顯示完整詳情

**已解決 Merge Conflicts：**
- 已與 main 分支合併，解決 Sessions.jsx 中的衝突
- 保留 MOCK_SESSIONS fallback 邏輯

---

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)** - 必須立即處理，阻擋主線進度
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 重要但不阻擋主線
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)** - 可排期處理

**對應 GitHub Labels**: `P1`

## 本 PR 不處理 (Out of Scope)

- 新增 i18n translation keys 到 JSON 檔案（需要 follow-up PR）
- Phase 2 元件實作（TenantListItem, PolicyCard 等）
- 後端 API 整合（Issue #16, PR 2）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [x] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. 登入 Owner Console 並進入 Sessions 頁面
2. 確認頁面顯示 4 筆 mock sessions（因 `USE_MOCK_SESSIONS_FALLBACK = true`）
3. 確認 KPI Row 顯示 5 個 StatCard（All/Running/Paused/Completed/Failed）
4. 點擊各 StatCard 確認 filter 功能正常，選中狀態顯示 ring-2 邊框
5. 確認 Session List 使用 SectionCard 包裝，顯示標題和數量
6. 選擇一個 session，確認 Session Details 使用 SectionCard 包裝
7. 確認 Auto-refresh 功能仍正常運作

### 預期結果 (Expected Results)

- Mock sessions 正確顯示（4 筆資料）
- StatCard 顯示正確的 variant 顏色和圖示
- SectionCard 統一了標題樣式
- Filter 選中狀態有明顯的視覺回饋（ring-2）
- Auto-refresh 功能不受影響

### 測試環境 (Test Environment)

- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- Sessions 頁面 KPI Row
- Sessions 頁面 Session List 區塊
- Sessions 頁面 Session Details 區塊

## i18n 檢查清單（強制）

- [x] 所有用戶可見字串使用 `t()` 或 `<Trans>`（無硬編碼字串）
- [ ] 新 translation keys 已加入 `en-US.json` 和 `zh-TW.json`（需要 follow-up）
- [x] Translation keys 使用適當的命名空間（例如：`sessions.list.count`）
- [x] ESLint i18n 規則通過

**注意**：新增的 i18n keys 使用 fallback 字串，需要 follow-up PR 補齊翻譯：
- `sessions.list.count`
- `sessions.details.title`
- `sessions.details.noSessions`
- `sessions.details.noSessionsHint`

## 設計系統檢查 (Design System Checklist)

- [x] 我已檢查 `@morningai/shared-ui` 是否有可用的元件
- [x] 如使用設計 tokens，我已從 `@morningai/shared-ui` 匯入而非硬編碼

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 我已使用 `@morningai/shared-ui` 元件（StatCard, SectionCard）
- [x] ESLint `no-restricted-imports` 規則通過
- [x] CI 的 "Audit UI Library Imports" 檢查通過

## 程式碼品質檢查

- [x] ESLint 通過（0 errors, 47 warnings - 皆為既有警告）
- [x] 程式碼遵循現有模式和慣例
- [x] 使用 `<button type="button">` 包裝 StatCard 確保無障礙性

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 UI/邏輯

---

## 🔍 Human Review Checklist

請特別檢查以下項目：

1. **MOCK_SESSIONS Fallback 行為** - `Sessions.jsx:177-182`, `Sessions.jsx:199-207`, `Sessions.jsx:220-228`, `Sessions.jsx:240-248`
   - `USE_MOCK_SESSIONS_FALLBACK = true` 是硬編碼的臨時行為
   - Fallback 同時在 API 回傳空資料和 API 錯誤時觸發
   - 確認這是否符合 Issue #16 的預期行為

2. **三態條件渲染** - `Sessions.jsx:895-920`
   - `filteredSessions.length === 0` → 顯示 "No sessions available"
   - `!selectedSession` → 顯示 "Select a session"
   - `selectedSession` → 顯示完整詳情
   - 確認邏輯順序正確

3. **StatCard variant 選擇** - `Sessions.jsx:557-612`
   - "running" 和 "completed" 都使用 `variant="green"`，是否應該區分？
   - 建議 "running" 使用 `variant="blue"` 以區分進行中 vs 已完成

4. **Accessibility** - `Sessions.jsx:557-612`
   - StatCard 使用 `<button type="button">` 包裝，確保鍵盤導航正常
   - `ring-2 ring-primary-500` 選中狀態是否足夠明顯


5. **Missing i18n keys** - 需要 follow-up PR 補齊：
   - `sessions.list.count`
   - `sessions.details.title`
   - `sessions.details.noSessions`
   - `sessions.details.noSessionsHint`