### PR TITLE
fix(sessions): return counts for all sessions regardless of filter

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
@@ -183,6 +183,8 @@ const Sessions = () => {
   const [filter, setFilter] = useState('all')
   const [autoRefresh, setAutoRefresh] = useState(true)
   const [isRefreshing, setIsRefreshing] = useState(false)
+  // Issue #1981: Use counts from API response instead of calculating locally
+  const [sessionCounts, setSessionCounts] = useState({ all: 0, running: 0, paused: 0, completed: 0, failed: 0 })
 
   // Monitor FCP (First Contentful Paint) performance metric
   useEffect(() => {
@@ -217,7 +219,10 @@ const Sessions = () => {
       const statusParam = filter !== 'all' ? `?status=${filter}` : ''
       const response = await apiClientWithMeta(`/api/sessions${statusParam}`, { method: 'GET' })
       const sessionsData = response.data?.sessions || []
+      // Issue #1981: Use counts from API response (calculated from all sessions, not filtered)
+      const countsData = response.data?.counts || { all: 0, running: 0, paused: 0, completed: 0, failed: 0 }
       setSessions(sessionsData)
+      setSessionCounts(countsData)
       
       setSelectedSession(prev => {
         if (!prev && sessionsData.length > 0) {
@@ -255,7 +260,10 @@ const Sessions = () => {
       if (signal?.aborted) return
       
       const sessionsData = response.data?.sessions || []
+      // Issue #1981: Use counts from API response (calculated from all sessions, not filtered)
+      const countsData = response.data?.counts || { all: 0, running: 0, paused: 0, completed: 0, failed: 0 }
       setSessions(sessionsData)
+      setSessionCounts(countsData)
       
       // Issue #1997: Return null instead of prev when session not found
       setSelectedSession(prev => {
@@ -429,13 +437,8 @@ const Sessions = () => {
     })
   }, [sessions, filter])
 
-  const sessionCounts = useMemo(() => ({
-    all: sessions.length,
-    running: sessions.filter(s => s.status === 'running').length,
-    paused: sessions.filter(s => s.status === 'paused').length,
-    completed: sessions.filter(s => s.status === 'completed').length,
-    failed: sessions.filter(s => s.status === 'failed').length
-  }), [sessions])
+  // Issue #1981: sessionCounts is now a state variable populated from API response
+  // This ensures counts reflect ALL sessions, not just the filtered/paginated ones
 
   // Issue #1991: DRY handler for session actions (pause/resume/cancel)
   const handleSessionAction = useCallback(async (sessionId, action, newStatus) => {


### PR DESCRIPTION
## 描述 (Description)

修正 Sessions UI 中 `sessionCounts` 在套用狀態篩選時顯示錯誤計數的問題。

**問題**：當使用者套用狀態篩選（如 "running"）時，API 只回傳篩選後的 sessions，但前端從這個篩選後的陣列計算 `sessionCounts`，導致計數不正確（例如顯示 "1 running, 0 completed" 但實際上有 5 個 completed sessions）。

**解決方案**：
- ~~Backend：在套用篩選前先計算所有 sessions 的計數，並在 API response 中回傳 `counts` 物件~~ (已在 PR #2009 合併)
- Frontend：使用 API 回傳的 `counts` 而非從篩選後的 sessions 陣列計算

Closes #1981

## Updates since last revision

**Rebased on latest main (61ad9b7f)**：此 PR 已 rebase 到最新的 main 分支，現在只包含前端變更：
- 新增 `sessionCounts` state variable 來儲存 API 回傳的計數
- 更新 `loadSessions` 和 `refreshSessionsSilently` 從 API response 提取 `counts`
- 移除 `useMemo` 計算（改用 API 資料）

Backend 的 counts 邏輯已在 PR #2009 (Redis 效能優化) 中合併。

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- Redis 效能優化 (#1980) - 已合併
- API 語意重構 (#1989, #1990, #1992) - 已合併於 #2020
- 前端 DRY 重構 (#1991) - 已合併於 #2024

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [x] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. 開啟 Sessions 頁面，確認 filter tabs 顯示正確的計數
2. 點選 "Running" filter，確認計數仍顯示所有狀態的正確數量（不只是 running）
3. 點選其他 filters (Paused, Completed, Failed)，確認計數保持一致
4. 等待 auto-refresh 觸發，確認計數仍然正確

### 預期結果 (Expected Results)

無論套用哪個狀態篩選，filter tabs 上的計數應該始終顯示所有 sessions 的正確計數。

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`pnpm lint`
- [ ] TypeScript 類型檢查通過：`pnpm typecheck`
- [ ] 所有測試通過：`pnpm test`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
- [x] 避免使用已廢棄的目錄
- [x] 不在 src/** 中導入已廢棄的模組

## Human Review Checklist

- [ ] 確認 `loadSessions` 和 `refreshSessionsSilently` 都正確提取並設定 `counts`
- [ ] 確認前端 fallback 值 `{ all: 0, running: 0, paused: 0, completed: 0, failed: 0 }` 適當
- [ ] 考慮是否有 session status 不在預期集合中的 edge cases
- [ ] 確認 rebase 後沒有遺漏任何必要的變更

---

**Link to Devin run**: https://app.devin.ai/sessions/d62efb518d6547e3bdb93e10c5c6976b
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918