### PR TITLE
feat(meta-agent): implement VS Code IDE integration for task execution (#1822)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/meta_agent/__init__.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/__init__.py
@@ -57,6 +57,20 @@ from .vm_provisioner import (
     VMStatus,
     vm_provisioner,
 )
+from .vscode_ide import (
+    FileContent,
+    IDESession,
+    IDESessionStatus,
+    Language,
+    LintResult,
+    SearchResult,
+    TestResult,
+    TestStatus,
+    TestSuiteResult,
+    VSCodeIDEService,
+    get_vscode_ide_service,
+    vscode_ide_service,
+)
 
 __all__ = [
     # Goal Parser
@@ -113,4 +127,17 @@ __all__ = [
     "VMConfig",
     "TaskVM",
     "vm_provisioner",
+    # VS Code IDE
+    "VSCodeIDEService",
+    "IDESession",
+    "IDESessionStatus",
+    "Language",
+    "FileContent",
+    "SearchResult",
+    "LintResult",
+    "TestResult",
+    "TestStatus",
+    "TestSuiteResult",
+    "get_vscode_ide_service",
+    "vscode_ide_service",
 ]

--- a/handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py
@@ -1,0 +1,864 @@
+"""
+Unit tests for VS Code IDE Integration
+
+Tests cover:
+- IDE session lifecycle (create, close, get)
+- File operations (open, edit)
+- Code search
+- Code formatting
+- Linting
+- Test execution
+- LSP support
+- File tree navigation
+- Terminal command execution
+- Language detection
+- Session statistics
+"""
+
+import pytest
+from datetime import datetime
+
+from meta_agent.vscode_ide import (
+    FileContent,
+    IDESession,
+    IDESessionStatus,
+    Language,
+    LintResult,
+    SearchResult,
+    TestResult,
+    TestStatus,
+    TestSuiteResult,
+    VSCodeIDEService,
+    get_vscode_ide_service,
+    vscode_ide_service,
+)
+
+
+class TestDataclasses:
+    """Tests for dataclass serialization"""
+
+    def test_file_content_to_dict(self):
+        """Test FileContent serialization"""
+        content = FileContent(
+            path="test.py",
+            content="print('hello')",
+            language=Language.PYTHON,
+            line_count=1,
+            size_bytes=14,
+            last_modified=datetime(2024, 1, 1, 12, 0, 0),
+        )
+        result = content.to_dict()
+
+        assert result["path"] == "test.py"
+        assert result["content"] == "print('hello')"
+        assert result["language"] == "python"
+        assert result["line_count"] == 1
+        assert result["size_bytes"] == 14
+        assert result["last_modified"] == "2024-01-01T12:00:00"
+
+    def test_file_content_to_dict_no_language(self):
+        """Test FileContent serialization without language"""
+        content = FileContent(path="test.txt", content="hello")
+        result = content.to_dict()
+
+        assert result["language"] is None
+        assert result["last_modified"] is None
+
+    def test_search_result_to_dict(self):
+        """Test SearchResult serialization"""
+        result = SearchResult(
+            file_path="test.py",
+            line_number=10,
+            line_content="def test():",
+            match_start=4,
+            match_end=8,
+            context_before=["# comment"],
+            context_after=["    pass"],
+        )
+        data = result.to_dict()
+
+        assert data["file_path"] == "test.py"
+        assert data["line_number"] == 10
+        assert data["line_content"] == "def test():"
+        assert data["match_start"] == 4
+        assert data["match_end"] == 8
+        assert data["context_before"] == ["# comment"]
+        assert data["context_after"] == ["    pass"]
+
+    def test_lint_result_to_dict(self):
+        """Test LintResult serialization"""
+        result = LintResult(
+            file_path="test.py",
+            line_number=5,
+            column=10,
+            severity="error",
+            message="undefined variable",
+            rule_id="E001",
+        )
+        data = result.to_dict()
+
+        assert data["file_path"] == "test.py"
+        assert data["line_number"] == 5
+        assert data["column"] == 10
+        assert data["severity"] == "error"
+        assert data["message"] == "undefined variable"
+        assert data["rule_id"] == "E001"
+
+    def test_test_result_to_dict(self):
+        """Test TestResult serialization"""
+        result = TestResult(
+            test_name="test_example",
+            status=TestStatus.PASSED,
+            duration_ms=100.5,
+            file_path="test_example.py",
+            line_number=10,
+        )
+        data = result.to_dict()
+
+        assert data["test_name"] == "test_example"
+        assert data["status"] == "passed"
+        assert data["duration_ms"] == 100.5
+        assert data["file_path"] == "test_example.py"
+        assert data["line_number"] == 10
+
+    def test_test_result_failed_with_error(self):
+        """Test TestResult with failure details"""
+        result = TestResult(
+            test_name="test_fail",
+            status=TestStatus.FAILED,
+            duration_ms=50.0,
+            error_message="AssertionError",
+            stack_trace="Traceback...",
+        )
+        data = result.to_dict()
+
+        assert data["status"] == "failed"
+        assert data["error_message"] == "AssertionError"
+        assert data["stack_trace"] == "Traceback..."
+
+    def test_test_suite_result_to_dict(self):
+        """Test TestSuiteResult serialization"""
+        tests = [
+            TestResult("test1", TestStatus.PASSED, 100.0),
+            TestResult("test2", TestStatus.FAILED, 50.0),
+        ]
+        suite = TestSuiteResult(
+            suite_name="my_suite",
+            tests=tests,
+            total_duration_ms=150.0,
+            passed_count=1,
+            failed_count=1,
+            skipped_count=0,
+            error_count=0,
+        )
+        data = suite.to_dict()
+
+        assert data["suite_name"] == "my_suite"
+        assert len(data["tests"]) == 2
+        assert data["total_duration_ms"] == 150.0
+        assert data["passed_count"] == 1
+        assert data["failed_count"] == 1
+
+    def test_ide_session_to_dict(self):
+        """Test IDESession serialization"""
+        session = IDESession(
+            session_id="ide-test-12345678",
+            vm_id="vm-test-12345678",
+            task_id="task-12345678",
+            status=IDESessionStatus.READY,
+            created_at=datetime(2024, 1, 1, 12, 0, 0),
+            workspace_path="/workspace",
+            vscode_endpoint="http://localhost:8443",
+            mcp_endpoint="http://localhost:8080",
+            active_file="/workspace/test.py",
+            open_files=["/workspace/test.py"],
+            last_activity=datetime(2024, 1, 1, 12, 30, 0),
+            metadata={"key": "value"},
+        )
+        data = session.to_dict()
+
+        assert data["session_id"] == "ide-test-12345678"
+        assert data["vm_id"] == "vm-test-12345678"
+        assert data["task_id"] == "task-12345678"
+        assert data["status"] == "ready"
+        assert data["created_at"] == "2024-01-01T12:00:00"
+        assert data["workspace_path"] == "/workspace"
+        assert data["vscode_endpoint"] == "http://localhost:8443"
+        assert data["mcp_endpoint"] == "http://localhost:8080"
+        assert data["active_file"] == "/workspace/test.py"
+        assert data["open_files"] == ["/workspace/test.py"]
+        assert data["last_activity"] == "2024-01-01T12:30:00"
+        assert data["metadata"] == {"key": "value"}
+
+    def test_ide_session_to_dict_minimal(self):
+        """Test IDESession serialization with minimal data"""
+        session = IDESession(
+            session_id="ide-test-12345678",
+            vm_id="vm-test-12345678",
+            task_id="task-12345678",
+            status=IDESessionStatus.INITIALIZING,
+            created_at=datetime(2024, 1, 1, 12, 0, 0),
+        )
+        data = session.to_dict()
+
+        assert data["last_activity"] is None
+        assert data["error"] is None
+        assert data["active_file"] is None
+
+
+class TestEnums:
+    """Tests for enum values"""
+
+    def test_ide_session_status_values(self):
+        """Test IDESessionStatus enum values"""
+        assert IDESessionStatus.INITIALIZING.value == "initializing"
+        assert IDESessionStatus.READY.value == "ready"
+        assert IDESessionStatus.ACTIVE.value == "active"
+        assert IDESessionStatus.SUSPENDED.value == "suspended"
+        assert IDESessionStatus.CLOSED.value == "closed"
+        assert IDESessionStatus.ERROR.value == "error"
+
+    def test_test_status_values(self):
+        """Test TestStatus enum values"""
+        assert TestStatus.PENDING.value == "pending"
+        assert TestStatus.RUNNING.value == "running"
+        assert TestStatus.PASSED.value == "passed"
+        assert TestStatus.FAILED.value == "failed"
+        assert TestStatus.SKIPPED.value == "skipped"
+        assert TestStatus.ERROR.value == "error"
+
+    def test_language_values(self):
+        """Test Language enum values"""
+        assert Language.PYTHON.value == "python"
+        assert Language.TYPESCRIPT.value == "typescript"
+        assert Language.JAVASCRIPT.value == "javascript"
+        assert Language.GO.value == "go"
+        assert Language.RUST.value == "rust"
+        assert Language.JAVA.value == "java"
+
+
+class TestVSCodeIDEService:
+    """Tests for VSCodeIDEService"""
+
+    @pytest.fixture
+    def service(self):
+        """Create a fresh VSCodeIDEService instance"""
+        return VSCodeIDEService()
+
+    @pytest.fixture
+    def mock_session(self):
+        """Create a mock IDE session"""
+        return IDESession(
+            session_id="ide-test-12345678",
+            vm_id="vm-test-12345678",
+            task_id="task-12345678",
+            status=IDESessionStatus.READY,
+            created_at=datetime.now(),
+            workspace_path="/workspace",
+            vscode_endpoint="http://localhost:8443",
+            mcp_endpoint="http://localhost:8080",
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_session(self, service):
+        """Test creating an IDE session"""
+        session = await service.create_session(
+            vm_id="vm-test-12345678",
+            task_id="task-12345678",
+            mcp_endpoint="http://localhost:8080",
+            workspace_path="/workspace",
+        )
+
+        assert session.session_id.startswith("ide-task-123")
+        assert session.vm_id == "vm-test-12345678"
+        assert session.task_id == "task-12345678"
+        assert session.status == IDESessionStatus.READY
+        assert session.workspace_path == "/workspace"
+        assert session.vscode_endpoint == "http://localhost:8443"
+        assert session.mcp_endpoint == "http://localhost:8080"
+
+    @pytest.mark.asyncio
+    async def test_create_session_custom_workspace(self, service):
+        """Test creating session with custom workspace"""
+        session = await service.create_session(
+            vm_id="vm-test",
+            task_id="task-test",
+            mcp_endpoint="http://localhost:8080",
+            workspace_path="/custom/workspace",
+        )
+
+        assert session.workspace_path == "/custom/workspace"
+
+    @pytest.mark.asyncio
+    async def test_close_session(self, service):
+        """Test closing an IDE session"""
+        session = await service.create_session(
+            vm_id="vm-test",
+            task_id="task-test",
+            mcp_endpoint="http://localhost:8080",
+        )
+
+        result = await service.close_session(session.session_id)
+
+        assert result is True
+        closed_session = await service.get_session(session.session_id)
+        assert closed_session.status == IDESessionStatus.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_close_nonexistent_session(self, service):
+        """Test closing a non-existent session"""
+        result = await service.close_session("nonexistent-session")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_get_session(self, service):
+        """Test getting a session by ID"""
+        created = await service.create_session(
+            vm_id="vm-test",
+            task_id="task-test",
+            mcp_endpoint="http://localhost:8080",
+        )
+
+        session = await service.get_session(created.session_id)
+
+        assert session is not None
+        assert session.session_id == created.session_id
+
+    @pytest.mark.asyncio
+    async def test_get_session_nonexistent(self, service):
+        """Test getting a non-existent session"""
+        session = await service.get_session("nonexistent")
+        assert session is None
+
+    @pytest.mark.asyncio
+    async def test_get_session_for_task(self, service):
+        """Test getting session by task ID"""
+        await service.create_session(
+            vm_id="vm-test",
+            task_id="task-12345678",
+            mcp_endpoint="http://localhost:8080",
+        )
+
+        session = await service.get_session_for_task("task-12345678")
+
+        assert session is not None
+        assert session.task_id == "task-12345678"
+
+    @pytest.mark.asyncio
+    async def test_get_session_for_task_closed(self, service):
+        """Test that closed sessions are not returned"""
+        created = await service.create_session(
+            vm_id="vm-test",
+            task_id="task-12345678",
+            mcp_endpoint="http://localhost:8080",
+        )
+        await service.close_session(created.session_id)
+
+        session = await service.get_session_for_task("task-12345678")
+        assert session is None
+
+    @pytest.mark.asyncio
+    async def test_open_file(self, service, mock_session):
+        """Test opening a file"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.open_file(mock_session, "test.py")
+
+        assert result["success"] is True
+        assert mock_session.active_file == "/workspace/test.py"
+        assert "/workspace/test.py" in mock_session.open_files
+        assert mock_session.status == IDESessionStatus.ACTIVE
+
+    @pytest.mark.asyncio
+    async def test_open_file_closed_session(self, service, mock_session):
+        """Test opening file in closed session"""
+        mock_session.status = IDESessionStatus.CLOSED
+
+        result = await service.open_file(mock_session, "test.py")
+
+        assert result["success"] is False
+        assert "closed" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_edit_file(self, service, mock_session):
+        """Test editing a file"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.edit_file(
+            mock_session,
+            "test.py",
+            "print('hello world')"
+        )
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_edit_file_closed_session(self, service, mock_session):
+        """Test editing file in closed session"""
+        mock_session.status = IDESessionStatus.CLOSED
+
+        result = await service.edit_file(mock_session, "test.py", "content")
+
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_search_code(self, service, mock_session):
+        """Test searching code"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.search_code(mock_session, "def test")
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_search_code_with_pattern(self, service, mock_session):
+        """Test searching code with file pattern"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.search_code(
+            mock_session,
+            "import",
+            file_pattern="*.py"
+        )
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_search_code_closed_session(self, service, mock_session):
+        """Test searching in closed session"""
+        mock_session.status = IDESessionStatus.CLOSED
+
+        result = await service.search_code(mock_session, "test")
+
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_format_code_python(self, service, mock_session):
+        """Test formatting Python code"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.format_code(
+            mock_session,
+            "test.py",
+            Language.PYTHON
+        )
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_format_code_auto_detect(self, service, mock_session):
+        """Test formatting with auto-detected language"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.format_code(mock_session, "test.py")
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_format_code_unknown_language(self, service, mock_session):
+        """Test formatting with unknown file type"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.format_code(mock_session, "test.xyz")
+
+        assert result["success"] is False
+        assert "detect" in result["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_format_code_closed_session(self, service, mock_session):
+        """Test formatting in closed session"""
+        mock_session.status = IDESessionStatus.CLOSED
+
+        result = await service.format_code(mock_session, "test.py")
+
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_run_linter_python(self, service, mock_session):
+        """Test running Python linter"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.run_linter(
+            mock_session,
+            "test.py",
+            Language.PYTHON
+        )
+
+        assert "lint_results" in result
+
+    @pytest.mark.asyncio
+    async def test_run_linter_auto_detect(self, service, mock_session):
+        """Test linting with auto-detected language"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.run_linter(mock_session, "test.ts")
+
+        assert "lint_results" in result
+
+    @pytest.mark.asyncio
+    async def test_run_linter_closed_session(self, service, mock_session):
+        """Test linting in closed session"""
+        mock_session.status = IDESessionStatus.CLOSED
+
+        result = await service.run_linter(mock_session, "test.py")
+
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_run_tests(self, service, mock_session):
+        """Test running tests"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.run_tests(mock_session)
+
+        assert "test_suite" in result
+
+    @pytest.mark.asyncio
+    async def test_run_tests_with_path(self, service, mock_session):
+        """Test running tests with specific path"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.run_tests(
+            mock_session,
+            test_path="tests/test_example.py"
+        )
+
+        assert "test_suite" in result
+
+    @pytest.mark.asyncio
+    async def test_run_tests_with_pattern(self, service, mock_session):
+        """Test running tests with pattern filter"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.run_tests(
+            mock_session,
+            test_pattern="test_specific",
+            language=Language.PYTHON
+        )
+
+        assert "test_suite" in result
+
+    @pytest.mark.asyncio
+    async def test_run_tests_closed_session(self, service, mock_session):
+        """Test running tests in closed session"""
+        mock_session.status = IDESessionStatus.CLOSED
+
+        result = await service.run_tests(mock_session)
+
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_start_lsp(self, service, mock_session):
+        """Test starting LSP server"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.start_lsp(mock_session, Language.PYTHON)
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_start_lsp_closed_session(self, service, mock_session):
+        """Test starting LSP in closed session"""
+        mock_session.status = IDESessionStatus.CLOSED
+
+        result = await service.start_lsp(mock_session, Language.PYTHON)
+
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_get_file_tree(self, service, mock_session):
+        """Test getting file tree"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.get_file_tree(mock_session)
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_file_tree_custom_path(self, service, mock_session):
+        """Test getting file tree with custom path"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.get_file_tree(mock_session, path="src", max_depth=2)
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_get_file_tree_closed_session(self, service, mock_session):
+        """Test getting file tree in closed session"""
+        mock_session.status = IDESessionStatus.CLOSED
+
+        result = await service.get_file_tree(mock_session)
+
+        assert result["success"] is False
+
+    @pytest.mark.asyncio
+    async def test_execute_terminal_command(self, service, mock_session):
+        """Test executing terminal command"""
+        service._sessions[mock_session.session_id] = mock_session
+
+        result = await service.execute_terminal_command(mock_session, "ls -la")
+
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_execute_terminal_command_closed_session(
+        self, service, mock_session
+    ):
+        """Test executing command in closed session"""
+        mock_session.status = IDESessionStatus.CLOSED
+
+        result = await service.execute_terminal_command(mock_session, "ls")
+
+        assert result["success"] is False
+
+
+class TestLanguageDetection:
+    """Tests for language detection"""
+
+    @pytest.fixture
+    def service(self):
+        return VSCodeIDEService()
+
+    def test_detect_python(self, service):
+        """Test detecting Python files"""
+        assert service._detect_language("test.py") == Language.PYTHON
+
+    def test_detect_typescript(self, service):
+        """Test detecting TypeScript files"""
+        assert service._detect_language("test.ts") == Language.TYPESCRIPT
+        assert service._detect_language("test.tsx") == Language.TYPESCRIPT
+
+    def test_detect_javascript(self, service):
+        """Test detecting JavaScript files"""
+        assert service._detect_language("test.js") == Language.JAVASCRIPT
+        assert service._detect_language("test.jsx") == Language.JAVASCRIPT
+
+    def test_detect_go(self, service):
+        """Test detecting Go files"""
+        assert service._detect_language("test.go") == Language.GO
+
+    def test_detect_rust(self, service):
+        """Test detecting Rust files"""
+        assert service._detect_language("test.rs") == Language.RUST
+
+    def test_detect_java(self, service):
+        """Test detecting Java files"""
+        assert service._detect_language("Test.java") == Language.JAVA
+
+    def test_detect_unknown(self, service):
+        """Test unknown file types"""
+        assert service._detect_language("test.xyz") is None
+        assert service._detect_language("test.txt") is None
+        assert service._detect_language("Makefile") is None
+
+
+class TestOutputParsing:
+    """Tests for output parsing"""
+
+    @pytest.fixture
+    def service(self):
+        return VSCodeIDEService()
+
+    def test_parse_grep_output(self, service):
+        """Test parsing grep output"""
+        output = """test.py:10:def test_function():
+test.py:20:def another_function():
+utils.py:5:def helper():"""
+
+        results = service._parse_grep_output(output)
+
+        assert len(results) == 3
+        assert results[0].file_path == "test.py"
+        assert results[0].line_number == 10
+        assert results[0].line_content == "def test_function():"
+        assert results[1].line_number == 20
+        assert results[2].file_path == "utils.py"
+
+    def test_parse_grep_output_empty(self, service):
+        """Test parsing empty grep output"""
+        results = service._parse_grep_output("")
+        assert len(results) == 0
+
+    def test_parse_grep_output_invalid_lines(self, service):
+        """Test parsing grep output with invalid lines"""
+        output = """test.py:10:valid line
+invalid line without colons
+:invalid:format
+test.py:abc:non-numeric line"""
+
+        results = service._parse_grep_output(output)
+
+        assert len(results) == 1
+        assert results[0].file_path == "test.py"
+
+    def test_parse_lint_output(self, service):
+        """Test parsing lint output"""
+        output = """test.py:10:5: undefined variable 'x'
+test.py:20:1: missing docstring"""
+
+        results = service._parse_lint_output(output, Language.PYTHON)
+
+        assert len(results) == 2
+        assert results[0].file_path == "test.py"
+        assert results[0].line_number == 10
+        assert results[0].column == 5
+        assert "undefined" in results[0].message
+
+    def test_parse_lint_output_empty(self, service):
+        """Test parsing empty lint output"""
+        results = service._parse_lint_output("", Language.PYTHON)
+        assert len(results) == 0
+
+    def test_parse_test_output_passed(self, service):
+        """Test parsing test output with passed tests"""
+        output = """test_one PASSED
+test_two PASSED
+test_three passed"""
+
+        result = service._parse_test_output(output, Language.PYTHON)
+
+        assert result.passed_count == 3
+        assert result.failed_count == 0
+
+    def test_parse_test_output_mixed(self, service):
+        """Test parsing test output with mixed results"""
+        output = """test_one PASSED
+test_two FAILED
+test_three SKIPPED
+test_four ERROR"""
+
+        result = service._parse_test_output(output, Language.PYTHON)
+
+        assert result.passed_count == 1
+        assert result.failed_count == 1
+        assert result.skipped_count == 1
+        assert result.error_count == 1
+
+
+class TestSessionStatistics:
+    """Tests for session statistics"""
+
+    @pytest.fixture
+    def service(self):
+        return VSCodeIDEService()
+
+    @pytest.mark.asyncio
+    async def test_get_active_sessions(self, service):
+        """Test getting active sessions"""
+        await service.create_session(
+            vm_id="vm-1",
+            task_id="task-1",
+            mcp_endpoint="http://localhost:8080",
+        )
+        session2 = await service.create_session(
+            vm_id="vm-2",
+            task_id="task-2",
+            mcp_endpoint="http://localhost:8080",
+        )
+        await service.close_session(session2.session_id)
+
+        active = service.get_active_sessions()
+
+        assert len(active) == 1
+        assert active[0].task_id == "task-1"
+
+    @pytest.mark.asyncio
+    async def test_get_session_stats(self, service):
+        """Test getting session statistics"""
+        await service.create_session(
+            vm_id="vm-1",
+            task_id="task-1",
+            mcp_endpoint="http://localhost:8080",
+        )
+        session2 = await service.create_session(
+            vm_id="vm-2",
+            task_id="task-2",
+            mcp_endpoint="http://localhost:8080",
+        )
+        await service.close_session(session2.session_id)
+
+        stats = service.get_session_stats()
+
+        assert stats["total_sessions"] == 2
+        assert stats["active_sessions"] == 1
+        assert stats["status_counts"]["ready"] == 1
+        assert stats["status_counts"]["closed"] == 1
+
+
+class TestGlobalInstance:
+    """Tests for global service instance"""
+
+    def test_global_instance_exists(self):
+        """Test that global instance exists"""
+        assert vscode_ide_service is not None
+        assert isinstance(vscode_ide_service, VSCodeIDEService)
+
+    def test_get_vscode_ide_service(self):
+        """Test get_vscode_ide_service function"""
+        service = get_vscode_ide_service()
+        assert service is vscode_ide_service
+
+
+class TestFormatterAndLinterConfig:
+    """Tests for formatter and linter configuration"""
+
+    def test_formatters_defined(self):
+        """Test that formatters are defined for all languages"""
+        service = VSCodeIDEService()
+
+        assert Language.PYTHON in service.FORMATTERS
+        assert Language.TYPESCRIPT in service.FORMATTERS
+        assert Language.JAVASCRIPT in service.FORMATTERS
+        assert Language.GO in service.FORMATTERS
+        assert Language.RUST in service.FORMATTERS
+        assert Language.JAVA in service.FORMATTERS
+
+    def test_linters_defined(self):
+        """Test that linters are defined for all languages"""
+        service = VSCodeIDEService()
+
+        assert Language.PYTHON in service.LINTERS
+        assert Language.TYPESCRIPT in service.LINTERS
+        assert Language.JAVASCRIPT in service.LINTERS
+        assert Language.GO in service.LINTERS
+        assert Language.RUST in service.LINTERS
+        assert Language.JAVA in service.LINTERS
+
+    def test_test_runners_defined(self):
+        """Test that test runners are defined for all languages"""
+        service = VSCodeIDEService()
+
+        assert Language.PYTHON in service.TEST_RUNNERS
+        assert Language.TYPESCRIPT in service.TEST_RUNNERS
+        assert Language.JAVASCRIPT in service.TEST_RUNNERS
+        assert Language.GO in service.TEST_RUNNERS
+        assert Language.RUST in service.TEST_RUNNERS
+        assert Language.JAVA in service.TEST_RUNNERS
+
+    def test_formatter_commands(self):
+        """Test formatter command strings"""
+        service = VSCodeIDEService()
+
+        assert "black" in service.FORMATTERS[Language.PYTHON]
+        assert "prettier" in service.FORMATTERS[Language.TYPESCRIPT]
+        assert "gofmt" in service.FORMATTERS[Language.GO]
+        assert "rustfmt" in service.FORMATTERS[Language.RUST]
+
+    def test_linter_commands(self):
+        """Test linter command strings"""
+        service = VSCodeIDEService()
+
+        assert "ruff" in service.LINTERS[Language.PYTHON]
+        assert "eslint" in service.LINTERS[Language.TYPESCRIPT]
+        assert "golangci-lint" in service.LINTERS[Language.GO]
+        assert "clippy" in service.LINTERS[Language.RUST]
+
+    def test_test_runner_commands(self):
+        """Test test runner command strings"""
+        service = VSCodeIDEService()
+
+        assert "pytest" in service.TEST_RUNNERS[Language.PYTHON]
+        assert "npm test" in service.TEST_RUNNERS[Language.TYPESCRIPT]
+        assert "go test" in service.TEST_RUNNERS[Language.GO]
+        assert "cargo test" in service.TEST_RUNNERS[Language.RUST]

--- a/handoff/20250928/40_App/orchestrator/meta_agent/vscode_ide.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/vscode_ide.py
@@ -1,0 +1,932 @@
+"""
+VS Code IDE Integration - Built-in IDE Editing and Testing
+
+This module provides VS Code IDE integration for task execution environments,
+enabling code editing, testing, and development workflows within isolated VMs.
+
+Issue: #1822 - 整合開發工具 (Integrate Development Tools)
+Milestone: M5 - Meta Agent 優化
+
+Architecture:
+    TaskVM → VSCodeIDEService → code-server → IDE Features
+                                    ↓
+                            - File editing
+                            - Code search
+                            - Linting/formatting
+                            - Test execution
+                            - LSP integration
+
+Features:
+    - File operations (open, edit, save)
+    - Code search and navigation
+    - Code formatting and linting
+    - Test execution and results
+    - Language Server Protocol support
+    - Terminal/shell access
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class IDESessionStatus(Enum):
+    """IDE session lifecycle status"""
+    INITIALIZING = "initializing"  # Session being created
+    READY = "ready"  # Session ready for use
+    ACTIVE = "active"  # Session in active use
+    SUSPENDED = "suspended"  # Session temporarily suspended
+    CLOSED = "closed"  # Session closed
+    ERROR = "error"  # Session in error state
+
+
+class TestStatus(Enum):
+    """Test execution status"""
+    PENDING = "pending"
+    RUNNING = "running"
+    PASSED = "passed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    ERROR = "error"
+
+
+class Language(Enum):
+    """Supported programming languages"""
+    PYTHON = "python"
+    TYPESCRIPT = "typescript"
+    JAVASCRIPT = "javascript"
+    GO = "go"
+    RUST = "rust"
+    JAVA = "java"
+
+
+@dataclass
+class FileContent:
+    """Represents file content with metadata"""
+    path: str
+    content: str
+    language: Optional[Language] = None
+    line_count: int = 0
+    size_bytes: int = 0
+    last_modified: Optional[datetime] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization"""
+        return {
+            "path": self.path,
+            "content": self.content,
+            "language": self.language.value if self.language else None,
+            "line_count": self.line_count,
+            "size_bytes": self.size_bytes,
+            "last_modified": (
+                self.last_modified.isoformat() if self.last_modified else None
+            ),
+        }
+
+
+@dataclass
+class SearchResult:
+    """Represents a code search result"""
+    file_path: str
+    line_number: int
+    line_content: str
+    match_start: int = 0
+    match_end: int = 0
+    context_before: List[str] = field(default_factory=list)
+    context_after: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization"""
+        return {
+            "file_path": self.file_path,
+            "line_number": self.line_number,
+            "line_content": self.line_content,
+            "match_start": self.match_start,
+            "match_end": self.match_end,
+            "context_before": self.context_before,
+            "context_after": self.context_after,
+        }
+
+
+@dataclass
+class LintResult:
+    """Represents a linting result"""
+    file_path: str
+    line_number: int
+    column: int
+    severity: str  # error, warning, info
+    message: str
+    rule_id: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization"""
+        return {
+            "file_path": self.file_path,
+            "line_number": self.line_number,
+            "column": self.column,
+            "severity": self.severity,
+            "message": self.message,
+            "rule_id": self.rule_id,
+        }
+
+
+@dataclass
+class TestResult:
+    """Represents a test execution result"""
+    test_name: str
+    status: TestStatus
+    duration_ms: float = 0.0
+    error_message: Optional[str] = None
+    stack_trace: Optional[str] = None
+    file_path: Optional[str] = None
+    line_number: Optional[int] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization"""
+        return {
+            "test_name": self.test_name,
+            "status": self.status.value,
+            "duration_ms": self.duration_ms,
+            "error_message": self.error_message,
+            "stack_trace": self.stack_trace,
+            "file_path": self.file_path,
+            "line_number": self.line_number,
+        }
+
+
+@dataclass
+class TestSuiteResult:
+    """Represents a test suite execution result"""
+    suite_name: str
+    tests: List[TestResult]
+    total_duration_ms: float = 0.0
+    passed_count: int = 0
+    failed_count: int = 0
+    skipped_count: int = 0
+    error_count: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization"""
+        return {
+            "suite_name": self.suite_name,
+            "tests": [t.to_dict() for t in self.tests],
+            "total_duration_ms": self.total_duration_ms,
+            "passed_count": self.passed_count,
+            "failed_count": self.failed_count,
+            "skipped_count": self.skipped_count,
+            "error_count": self.error_count,
+        }
+
+
+@dataclass
+class IDESession:
+    """Represents an IDE session for a task VM"""
+    session_id: str
+    vm_id: str
+    task_id: str
+    status: IDESessionStatus
+    created_at: datetime
+    workspace_path: str = "/workspace"
+    vscode_endpoint: Optional[str] = None
+    mcp_endpoint: Optional[str] = None
+    active_file: Optional[str] = None
+    open_files: List[str] = field(default_factory=list)
+    last_activity: Optional[datetime] = None
+    error: Optional[str] = None
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for serialization"""
+        return {
+            "session_id": self.session_id,
+            "vm_id": self.vm_id,
+            "task_id": self.task_id,
+            "status": self.status.value,
+            "created_at": self.created_at.isoformat(),
+            "workspace_path": self.workspace_path,
+            "vscode_endpoint": self.vscode_endpoint,
+            "mcp_endpoint": self.mcp_endpoint,
+            "active_file": self.active_file,
+            "open_files": self.open_files,
+            "last_activity": (
+                self.last_activity.isoformat() if self.last_activity else None
+            ),
+            "error": self.error,
+            "metadata": self.metadata,
+        }
+
+
+class VSCodeIDEService:
+    """
+    VS Code IDE integration service for task execution environments.
+
+    This service provides IDE capabilities through code-server, enabling:
+    - File editing and management
+    - Code search and navigation
+    - Linting and formatting
+    - Test execution
+    - Language Server Protocol support
+    """
+
+    # Default ports for code-server
+    DEFAULT_VSCODE_PORT = 8443
+    DEFAULT_MCP_PORT = 8080
+
+    # Supported formatters by language
+    FORMATTERS: Dict[Language, str] = {
+        Language.PYTHON: "black",
+        Language.TYPESCRIPT: "prettier --write",
+        Language.JAVASCRIPT: "prettier --write",
+        Language.GO: "gofmt -w",
+        Language.RUST: "rustfmt",
+        Language.JAVA: "google-java-format -i",
+    }
+
+    # Supported linters by language
+    LINTERS: Dict[Language, str] = {
+        Language.PYTHON: "ruff check",
+        Language.TYPESCRIPT: "eslint",
+        Language.JAVASCRIPT: "eslint",
+        Language.GO: "golangci-lint run",
+        Language.RUST: "cargo clippy",
+        Language.JAVA: "checkstyle",
+    }
+
+    # Supported test runners by language
+    TEST_RUNNERS: Dict[Language, str] = {
+        Language.PYTHON: "pytest -v --tb=short",
+        Language.TYPESCRIPT: "npm test",
+        Language.JAVASCRIPT: "npm test",
+        Language.GO: "go test -v",
+        Language.RUST: "cargo test",
+        Language.JAVA: "mvn test",
+    }
+
+    def __init__(self):
+        """Initialize the VS Code IDE service"""
+        self._sessions: Dict[str, IDESession] = {}
+        self._lock = asyncio.Lock()
+        logger.info("[VSCodeIDEService] Initialized")
+
+    async def create_session(
+        self,
+        vm_id: str,
+        task_id: str,
+        mcp_endpoint: str,
+        workspace_path: str = "/workspace",
+    ) -> IDESession:
+        """
+        Create a new IDE session for a task VM.
+
+        Args:
+            vm_id: ID of the VM
+            task_id: ID of the task
+            mcp_endpoint: MCP endpoint URL for the VM
+            workspace_path: Path to the workspace directory
+
+        Returns:
+            IDESession instance
+        """
+        import uuid
+
+        session_id = f"ide-{task_id[:8]}-{uuid.uuid4().hex[:8]}"
+
+        # Derive VS Code endpoint from MCP endpoint
+        vscode_endpoint = mcp_endpoint.replace(
+            str(self.DEFAULT_MCP_PORT),
+            str(self.DEFAULT_VSCODE_PORT)
+        )
+
+        session = IDESession(
+            session_id=session_id,
+            vm_id=vm_id,
+            task_id=task_id,
+            status=IDESessionStatus.INITIALIZING,
+            created_at=datetime.now(),
+            workspace_path=workspace_path,
+            vscode_endpoint=vscode_endpoint,
+            mcp_endpoint=mcp_endpoint,
+        )
+
+        async with self._lock:
+            self._sessions[session_id] = session
+
+        # Initialize the IDE session
+        try:
+            await self._initialize_session(session)
+            session.status = IDESessionStatus.READY
+            session.last_activity = datetime.now()
+            logger.info(
+                "[VSCodeIDEService] Created session %s for task %s",
+                session_id, task_id[:8]
+            )
+        except Exception as e:
+            logger.error(
+                "[VSCodeIDEService] Failed to initialize session %s: %s",
+                session_id, e
+            )
+            session.status = IDESessionStatus.ERROR
+            session.error = str(e)
+
+        return session
+
+    async def _initialize_session(self, session: IDESession) -> None:
+        """Initialize the IDE session (start code-server if needed)"""
+        # In a real implementation, this would:
+        # 1. Check if code-server is running
+        # 2. Start code-server if not running
+        # 3. Configure workspace settings
+        # 4. Install necessary extensions
+        pass
+
+    async def close_session(self, session_id: str) -> bool:
+        """
+        Close an IDE session.
+
+        Args:
+            session_id: ID of the session to close
+
+        Returns:
+            True if session was closed successfully
+        """
+        async with self._lock:
+            session = self._sessions.get(session_id)
+            if not session:
+                return False
+
+            session.status = IDESessionStatus.CLOSED
+            session.last_activity = datetime.now()
+            logger.info("[VSCodeIDEService] Closed session %s", session_id)
+            return True
+
+    async def get_session(self, session_id: str) -> Optional[IDESession]:
+        """Get an IDE session by ID"""
+        return self._sessions.get(session_id)
+
+    async def get_session_for_task(self, task_id: str) -> Optional[IDESession]:
+        """Get the IDE session for a task"""
+        for session in self._sessions.values():
+            if session.task_id == task_id and session.status != IDESessionStatus.CLOSED:
+                return session
+        return None
+
+    async def open_file(
+        self,
+        session: IDESession,
+        file_path: str,
+    ) -> Dict[str, Any]:
+        """
+        Open a file in the IDE.
+
+        Args:
+            session: IDE session
+            file_path: Path to the file (relative to workspace)
+
+        Returns:
+            Dict with success status and file content
+        """
+        if session.status == IDESessionStatus.CLOSED:
+            return {"success": False, "error": "Session is closed"}
+
+        try:
+            result = await self._execute_mcp_command(
+                session,
+                "file/read",
+                {"file_path": file_path}
+            )
+
+            if result.get("success"):
+                full_path = f"{session.workspace_path}/{file_path}"
+                if full_path not in session.open_files:
+                    session.open_files.append(full_path)
+                session.active_file = full_path
+                session.last_activity = datetime.now()
+                session.status = IDESessionStatus.ACTIVE
+
+            return result
+        except Exception as e:
+            logger.error(
+                "[VSCodeIDEService] Failed to open file %s: %s",
+                file_path, e
+            )
+            return {"success": False, "error": str(e)}
+
+    async def edit_file(
+        self,
+        session: IDESession,
+        file_path: str,
+        content: str,
+    ) -> Dict[str, Any]:
+        """
+        Edit a file in the IDE.
+
+        Args:
+            session: IDE session
+            file_path: Path to the file (relative to workspace)
+            content: New file content
+
+        Returns:
+            Dict with success status
+        """
+        if session.status == IDESessionStatus.CLOSED:
+            return {"success": False, "error": "Session is closed"}
+
+        try:
+            result = await self._execute_mcp_command(
+                session,
+                "file/write",
+                {"file_path": file_path, "content": content}
+            )
+
+            if result.get("success"):
+                session.last_activity = datetime.now()
+
+            return result
+        except Exception as e:
+            logger.error(
+                "[VSCodeIDEService] Failed to edit file %s: %s",
+                file_path, e
+            )
+            return {"success": False, "error": str(e)}
+
+    async def search_code(
+        self,
+        session: IDESession,
+        query: str,
+        file_pattern: Optional[str] = None,
+        context_lines: int = 2,
+    ) -> Dict[str, Any]:
+        """
+        Search for code in the workspace.
+
+        Args:
+            session: IDE session
+            query: Search query (regex supported)
+            file_pattern: Optional file pattern to filter (e.g., '*.py')
+            context_lines: Number of context lines to include
+
+        Returns:
+            Dict with success status and search results
+        """
+        if session.status == IDESessionStatus.CLOSED:
+            return {"success": False, "error": "Session is closed"}
+
+        try:
+            # Build grep command
+            include_flag = f" --include='{file_pattern}'" if file_pattern else ""
+            context_flag = f" -C {context_lines}" if context_lines > 0 else ""
+            command = f"grep -rn{context_flag} '{query}' .{include_flag}"
+
+            result = await self._execute_shell_command(session, command)
+
+            if result.get("success"):
+                session.last_activity = datetime.now()
+                # Parse grep output into SearchResult objects
+                results = self._parse_grep_output(result.get("stdout", ""))
+                result["results"] = [r.to_dict() for r in results]
+
+            return result
+        except Exception as e:
+            logger.error(
+                "[VSCodeIDEService] Failed to search code: %s", e
+            )
+            return {"success": False, "error": str(e)}
+
+    def _parse_grep_output(self, output: str) -> List[SearchResult]:
+        """Parse grep output into SearchResult objects"""
+        results = []
+        for line in output.strip().split("\n"):
+            if not line or ":" not in line:
+                continue
+            try:
+                # Format: file:line:content
+                parts = line.split(":", 2)
+                if len(parts) >= 3:
+                    results.append(SearchResult(
+                        file_path=parts[0],
+                        line_number=int(parts[1]),
+                        line_content=parts[2],
+                    ))
+            except (ValueError, IndexError):
+                continue
+        return results
+
+    async def format_code(
+        self,
+        session: IDESession,
+        file_path: str,
+        language: Optional[Language] = None,
+    ) -> Dict[str, Any]:
+        """
+        Format code using language-specific formatter.
+
+        Args:
+            session: IDE session
+            file_path: Path to the file to format
+            language: Programming language (auto-detected if not provided)
+
+        Returns:
+            Dict with success status
+        """
+        if session.status == IDESessionStatus.CLOSED:
+            return {"success": False, "error": "Session is closed"}
+
+        # Auto-detect language if not provided
+        if not language:
+            language = self._detect_language(file_path)
+
+        if not language:
+            return {"success": False, "error": "Could not detect language"}
+
+        formatter = self.FORMATTERS.get(language)
+        if not formatter:
+            return {"success": False, "error": f"No formatter for {language.value}"}
+
+        try:
+            command = f"{formatter} {file_path}"
+            result = await self._execute_shell_command(session, command)
+
+            if result.get("success"):
+                session.last_activity = datetime.now()
+
+            return result
+        except Exception as e:
+            logger.error(
+                "[VSCodeIDEService] Failed to format %s: %s",
+                file_path, e
+            )
+            return {"success": False, "error": str(e)}
+
+    async def run_linter(
+        self,
+        session: IDESession,
+        file_path: str,
+        language: Optional[Language] = None,
+    ) -> Dict[str, Any]:
+        """
+        Run linter on code.
+
+        Args:
+            session: IDE session
+            file_path: Path to the file to lint
+            language: Programming language (auto-detected if not provided)
+
+        Returns:
+            Dict with success status and lint results
+        """
+        if session.status == IDESessionStatus.CLOSED:
+            return {"success": False, "error": "Session is closed"}
+
+        # Auto-detect language if not provided
+        if not language:
+            language = self._detect_language(file_path)
+
+        if not language:
+            return {"success": False, "error": "Could not detect language"}
+
+        linter = self.LINTERS.get(language)
+        if not linter:
+            return {"success": False, "error": f"No linter for {language.value}"}
+
+        try:
+            command = f"{linter} {file_path}"
+            result = await self._execute_shell_command(session, command)
+
+            session.last_activity = datetime.now()
+
+            # Parse linter output into LintResult objects
+            lint_results = self._parse_lint_output(
+                result.get("stdout", "") + result.get("stderr", ""),
+                language
+            )
+            result["lint_results"] = [r.to_dict() for r in lint_results]
+
+            return result
+        except Exception as e:
+            logger.error(
+                "[VSCodeIDEService] Failed to lint %s: %s",
+                file_path, e
+            )
+            return {"success": False, "error": str(e)}
+
+    def _parse_lint_output(
+        self,
+        output: str,
+        language: Language
+    ) -> List[LintResult]:
+        """Parse linter output into LintResult objects"""
+        results = []
+        for line in output.strip().split("\n"):
+            if not line:
+                continue
+            try:
+                # Generic parsing - format varies by linter
+                # Most linters use: file:line:column: message
+                parts = line.split(":", 3)
+                if len(parts) >= 4:
+                    results.append(LintResult(
+                        file_path=parts[0],
+                        line_number=int(parts[1]) if parts[1].isdigit() else 0,
+                        column=int(parts[2]) if parts[2].isdigit() else 0,
+                        severity="error",
+                        message=parts[3].strip(),
+                    ))
+            except (ValueError, IndexError):
+                continue
+        return results
+
+    async def run_tests(
+        self,
+        session: IDESession,
+        test_path: Optional[str] = None,
+        language: Optional[Language] = None,
+        test_pattern: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Run tests in the workspace.
+
+        Args:
+            session: IDE session
+            test_path: Path to test file or directory (default: workspace root)
+            language: Programming language (auto-detected if not provided)
+            test_pattern: Optional pattern to filter tests
+
+        Returns:
+            Dict with success status and test results
+        """
+        if session.status == IDESessionStatus.CLOSED:
+            return {"success": False, "error": "Session is closed"}
+
+        # Auto-detect language if not provided
+        if not language:
+            language = self._detect_project_language(session)
+
+        if not language:
+            return {"success": False, "error": "Could not detect project language"}
+
+        test_runner = self.TEST_RUNNERS.get(language)
+        if not test_runner:
+            return {"success": False, "error": f"No test runner for {language.value}"}
+
+        try:
+            # Build test command
+            command = test_runner
+            if test_path:
+                command = f"{command} {test_path}"
+            if test_pattern and language == Language.PYTHON:
+                command = f"{command} -k '{test_pattern}'"
+
+            result = await self._execute_shell_command(session, command)
+
+            session.last_activity = datetime.now()
+
+            # Parse test output into TestSuiteResult
+            test_suite = self._parse_test_output(
+                result.get("stdout", "") + result.get("stderr", ""),
+                language
+            )
+            result["test_suite"] = test_suite.to_dict()
+
+            return result
+        except Exception as e:
+            logger.error(
+                "[VSCodeIDEService] Failed to run tests: %s", e
+            )
+            return {"success": False, "error": str(e)}
+
+    def _parse_test_output(
+        self,
+        output: str,
+        language: Language
+    ) -> TestSuiteResult:
+        """Parse test output into TestSuiteResult"""
+        tests = []
+        passed = 0
+        failed = 0
+        skipped = 0
+        errors = 0
+
+        # Simple parsing - real implementation would be language-specific
+        for line in output.strip().split("\n"):
+            if "PASSED" in line or "passed" in line:
+                passed += 1
+            elif "FAILED" in line or "failed" in line:
+                failed += 1
+            elif "SKIPPED" in line or "skipped" in line:
+                skipped += 1
+            elif "ERROR" in line or "error" in line:
+                errors += 1
+
+        return TestSuiteResult(
+            suite_name="test_suite",
+            tests=tests,
+            passed_count=passed,
+            failed_count=failed,
+            skipped_count=skipped,
+            error_count=errors,
+        )
+
+    async def start_lsp(
+        self,
+        session: IDESession,
+        language: Language,
+    ) -> Dict[str, Any]:
+        """
+        Start Language Server Protocol server for a language.
+
+        Args:
+            session: IDE session
+            language: Programming language
+
+        Returns:
+            Dict with success status and LSP server info
+        """
+        if session.status == IDESessionStatus.CLOSED:
+            return {"success": False, "error": "Session is closed"}
+
+        try:
+            result = await self._execute_mcp_command(
+                session,
+                "lsp/start",
+                {"language": language.value}
+            )
+
+            if result.get("success"):
+                session.last_activity = datetime.now()
+
+            return result
+        except Exception as e:
+            logger.error(
+                "[VSCodeIDEService] Failed to start LSP for %s: %s",
+                language.value, e
+            )
+            return {"success": False, "error": str(e)}
+
+    async def get_file_tree(
+        self,
+        session: IDESession,
+        path: str = ".",
+        max_depth: int = 3,
+    ) -> Dict[str, Any]:
+        """
+        Get file tree structure.
+
+        Args:
+            session: IDE session
+            path: Root path (default: workspace root)
+            max_depth: Maximum depth to traverse
+
+        Returns:
+            Dict with success status and file tree
+        """
+        if session.status == IDESessionStatus.CLOSED:
+            return {"success": False, "error": "Session is closed"}
+
+        try:
+            command = (
+                f"tree -L {max_depth} "
+                f"-I 'node_modules|__pycache__|.git|.venv' {path}"
+            )
+            result = await self._execute_shell_command(session, command)
+
+            if result.get("success"):
+                session.last_activity = datetime.now()
+
+            return result
+        except Exception as e:
+            logger.error(
+                "[VSCodeIDEService] Failed to get file tree: %s", e
+            )
+            return {"success": False, "error": str(e)}
+
+    async def execute_terminal_command(
+        self,
+        session: IDESession,
+        command: str,
+        timeout_seconds: int = 60,
+    ) -> Dict[str, Any]:
+        """
+        Execute a command in the terminal.
+
+        Args:
+            session: IDE session
+            command: Command to execute
+            timeout_seconds: Command timeout in seconds
+
+        Returns:
+            Dict with success status and command output
+        """
+        if session.status == IDESessionStatus.CLOSED:
+            return {"success": False, "error": "Session is closed"}
+
+        try:
+            result = await self._execute_shell_command(
+                session,
+                command,
+                timeout_seconds
+            )
+
+            if result.get("success"):
+                session.last_activity = datetime.now()
+
+            return result
+        except Exception as e:
+            logger.error(
+                "[VSCodeIDEService] Failed to execute command: %s", e
+            )
+            return {"success": False, "error": str(e)}
+
+    async def _execute_mcp_command(
+        self,
+        session: IDESession,
+        endpoint: str,
+        payload: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Execute a command via MCP endpoint"""
+        # In a real implementation, this would make HTTP requests to the MCP server
+        # For now, return a mock response
+        return {
+            "success": True,
+            "endpoint": endpoint,
+            "payload": payload,
+        }
+
+    async def _execute_shell_command(
+        self,
+        session: IDESession,
+        command: str,
+        timeout_seconds: int = 60,
+    ) -> Dict[str, Any]:
+        """Execute a shell command in the VM"""
+        # In a real implementation, this would execute via MCP shell API
+        # For now, return a mock response
+        return {
+            "success": True,
+            "command": command,
+            "stdout": "",
+            "stderr": "",
+            "exit_code": 0,
+        }
+
+    def _detect_language(self, file_path: str) -> Optional[Language]:
+        """Detect programming language from file extension"""
+        extension_map = {
+            ".py": Language.PYTHON,
+            ".ts": Language.TYPESCRIPT,
+            ".tsx": Language.TYPESCRIPT,
+            ".js": Language.JAVASCRIPT,
+            ".jsx": Language.JAVASCRIPT,
+            ".go": Language.GO,
+            ".rs": Language.RUST,
+            ".java": Language.JAVA,
+        }
+
+        for ext, lang in extension_map.items():
+            if file_path.endswith(ext):
+                return lang
+        return None
+
+    def _detect_project_language(self, session: IDESession) -> Optional[Language]:
+        """Detect primary project language from workspace"""
+        # In a real implementation, this would check for:
+        # - pyproject.toml / setup.py → Python
+        # - package.json → TypeScript/JavaScript
+        # - go.mod → Go
+        # - Cargo.toml → Rust
+        # - pom.xml / build.gradle → Java
+        return Language.PYTHON  # Default to Python
+
+    def get_active_sessions(self) -> List[IDESession]:
+        """Get all active IDE sessions"""
+        return [
+            s for s in self._sessions.values()
+            if s.status not in [IDESessionStatus.CLOSED, IDESessionStatus.ERROR]
+        ]
+
+    def get_session_stats(self) -> Dict[str, Any]:
+        """Get statistics about IDE sessions"""
+        sessions = list(self._sessions.values())
+        status_counts = {}
+        for session in sessions:
+            status = session.status.value
+            status_counts[status] = status_counts.get(status, 0) + 1
+
+        return {
+            "total_sessions": len(sessions),
+            "active_sessions": len(self.get_active_sessions()),
+            "status_counts": status_counts,
+        }
+
+
+# Global IDE service instance
+vscode_ide_service = VSCodeIDEService()
+
+
+def get_vscode_ide_service() -> VSCodeIDEService:
+    """Get the global VS Code IDE service instance"""
+    return vscode_ide_service

--- a/handoff/20250928/40_App/orchestrator/tests/test_meta_agent_vscode_ide.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_meta_agent_vscode_ide.py
@@ -1,0 +1,41 @@
+"""
+Wrapper test file for VS Code IDE integration tests.
+
+This file imports and re-exports tests from meta_agent/tests/test_vscode_ide.py
+to ensure they are discovered by CI which runs `pytest tests/`.
+
+Issue: #1822 - 整合開發工具 (Integrate Development Tools)
+Milestone: M5 - Meta Agent 優化
+"""
+
+import sys
+from pathlib import Path
+
+# Add orchestrator to path for imports
+orchestrator_path = Path(__file__).parent.parent
+if str(orchestrator_path) not in sys.path:
+    sys.path.insert(0, str(orchestrator_path))
+
+# Import all test classes from the original test file
+from meta_agent.tests.test_vscode_ide import (  # noqa: E402
+    TestDataclasses,
+    TestEnums,
+    TestVSCodeIDEService,
+    TestLanguageDetection,
+    TestOutputParsing,
+    TestSessionStatistics,
+    TestGlobalInstance,
+    TestFormatterAndLinterConfig,
+)
+
+# Re-export all test classes so pytest discovers them
+__all__ = [
+    "TestDataclasses",
+    "TestEnums",
+    "TestVSCodeIDEService",
+    "TestLanguageDetection",
+    "TestOutputParsing",
+    "TestSessionStatistics",
+    "TestGlobalInstance",
+    "TestFormatterAndLinterConfig",
+]


### PR DESCRIPTION
## 描述 (Description)

實作 VS Code IDE 整合服務，為任務執行環境提供 IDE 功能。此 PR 完成 #1822 的「內建 VS Code IDE 編輯與測試」項目。

**新增功能：**
- `VSCodeIDEService` - IDE 會話管理服務
- 檔案操作（開啟、編輯、儲存）
- 程式碼搜尋與導航
- 程式碼格式化與 Linting
- 測試執行
- Language Server Protocol (LSP) 支援
- 終端機命令執行
- 多語言支援（Python, TypeScript, JavaScript, Go, Rust, Java）

**注意**：`_execute_mcp_command` 和 `_execute_shell_command` 目前為 mock 實作，實際 MCP 整合將在後續 PR 完成。

## PR 類型與優先級 (PR Type & Priority)

- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 重要但不阻擋主線

## 本 PR 不處理 (Out of Scope)

- 實際 MCP HTTP 請求整合（目前為 mock）
- 與 VM Provisioner 的完整整合
- code-server 啟動/管理邏輯
- 進階語言偵測（目前預設為 Python）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

```bash
cd ~/repos/morningai
source .venv/bin/activate
PYTHONPATH="$PWD/handoff/20250928/40_App/orchestrator:$PYTHONPATH" \
  pytest handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py -v
```

### 預期結果 (Expected Results)

69 個測試全部通過

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- `meta_agent` 模組（新增 exports）

### 新增的自動化測試 (New Automated Tests)

- `meta_agent/tests/test_vscode_ide.py` - 69 個測試案例
- `tests/test_meta_agent_vscode_ide.py` - CI wrapper

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`flake8`
- [x] 所有測試通過：69/69 passed
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新


## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯
- [x] 避免使用已廢棄的目錄

## Human Review Checklist

請特別注意以下項目：

1. **Mock 實作方式** - `_execute_mcp_command` 和 `_execute_shell_command` 目前回傳 mock 資料，這是否符合此階段的預期？
2. **語言偵測邏輯** - `_detect_project_language` 目前預設回傳 Python，後續需要改進
3. **Port 轉換邏輯** - VS Code endpoint 透過將 8080 替換為 8443 來推導，假設特定的 port mapping 慣例

---

**Link to Devin run**: https://app.devin.ai/sessions/8f1641122ec54272acf0bcc4ff7ab504
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918