### PR TITLE
refactor(sessions): DRY helper + TTL constant + status mapping

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/routes/sessions.py
+++ b/handoff/20250928/40_App/api-backend/src/routes/sessions.py
@@ -370,11 +370,12 @@ def pause_session(session_id):
             'paused_by': user_email,
             'timestamp': datetime.utcnow().isoformat()
         })
-    except ValueError:
-        return jsonify({'error': 'Session not found'}), 404
     except json.JSONDecodeError:
+        # Must be caught before ValueError since JSONDecodeError is a subclass of ValueError
         logger.exception("Failed to parse session %s", session_id)
         return jsonify({'error': 'Failed to parse session data'}), 500
+    except ValueError:
+        return jsonify({'error': 'Session not found'}), 404
     except Exception:
         logger.exception("Failed to pause session")
         return jsonify({'error': 'Failed to pause session'}), 500
@@ -422,11 +423,12 @@ def resume_session(session_id):
             'resumed_by': user_email,
             'timestamp': datetime.utcnow().isoformat()
         })
-    except ValueError:
-        return jsonify({'error': 'Session not found'}), 404
     except json.JSONDecodeError:
+        # Must be caught before ValueError since JSONDecodeError is a subclass of ValueError
         logger.exception("Failed to parse session %s", session_id)
         return jsonify({'error': 'Failed to parse session data'}), 500
+    except ValueError:
+        return jsonify({'error': 'Session not found'}), 404
     except Exception:
         logger.exception("Failed to resume session")
         return jsonify({'error': 'Failed to resume session'}), 500
@@ -483,11 +485,12 @@ def cancel_session(session_id):
             'reason': reason,
             'timestamp': datetime.utcnow().isoformat()
         })
-    except ValueError:
-        return jsonify({'error': 'Session not found'}), 404
     except json.JSONDecodeError:
+        # Must be caught before ValueError since JSONDecodeError is a subclass of ValueError
         logger.exception("Failed to parse session %s", session_id)
         return jsonify({'error': 'Failed to parse session data'}), 500
+    except ValueError:
+        return jsonify({'error': 'Session not found'}), 404
     except Exception:
         logger.exception("Failed to cancel session")
         return jsonify({'error': 'Failed to cancel session'}), 500

--- a/handoff/20250928/40_App/api-backend/tests/test_sessions_routes.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_sessions_routes.py
@@ -226,7 +226,8 @@ class TestResumeSessionEndpoint:
                 assert response.status_code == 200
                 data = response.get_json()
                 assert data['success'] is True
-                assert data['status'] == 'active'
+                # Issue #1989: status should be 'running' (frontend format) not 'active' (internal)
+                assert data['status'] == 'running'
                 assert 'resumed_by' in data
                 assert 'timestamp' in data
 


### PR DESCRIPTION
## 描述 (Description)

重構 Sessions API 控制端點，解決三個 follow-up issues：
- **#1989**: 控制端點回應使用 `STATUS_MAP` 確保前端狀態一致性（`active` → `running`）
- **#1990**: 新增 `_get_session_and_user()` DRY helper 減少重複程式碼
- **#1992**: 新增 `SESSION_TTL_SECONDS` 常數取代硬編碼的 `86400`

**重要行為變更**: `resume_session` 端點現在回傳 `status: 'running'` 而非 `status: 'active'`，與前端期望一致。

### Updates since last revision

修正 CI 測試失敗：
- **例外處理順序修正**: `json.JSONDecodeError` 必須在 `ValueError` 之前捕獲，因為 `JSONDecodeError` 是 `ValueError` 的子類別。原本的順序導致 JSON 解析錯誤被誤判為 404 而非 500。
- **測試更新**: `test_resume_session_success` 現在期望 `'running'` 而非 `'active'`（符合 #1989 規格）

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- #1983 sys.path 重構（將在 PR D 處理）
- 前端 DRY 重構（Phase 3）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `TestTransformSessionForFrontend` 全部通過
- [ ] 整合測試 (Integration Tests) - 需要完整環境
- [ ] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. 呼叫 `POST /api/sessions/{id}/pause` 確認回應 `status: 'paused'`
2. 呼叫 `POST /api/sessions/{id}/resume` 確認回應 `status: 'running'`（非 `active`）
3. 呼叫 `POST /api/sessions/{id}/cancel` 確認回應 `status: 'failed'`

### 受影響的區域 (Affected Areas)

- Sessions API 控制端點（pause/resume/cancel）
- 前端 Sessions UI 狀態顯示

## Human Review Checklist

- [ ] **確認例外處理順序正確**：`JSONDecodeError` 必須在 `ValueError` 之前（因為 JSONDecodeError 繼承自 ValueError）
- [ ] **確認 `resume_session` 回傳 `'running'` 而非 `'active'` 是正確行為**（前端是否期望此值？）
- [ ] 確認 `_get_session_and_user()` helper 的 tuple 回傳型別足夠清晰

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查


- [x] ESLint 通過（flake8 0 errors）
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位（若要改，先提 RFC）
- [x] 工程 PR 僅含 API/邏輯

---


**Link to Devin run**: https://app.devin.ai/sessions/533ababa6fe04b2da9416b7ae3261877
**Requested by**: Ryan Chen (ryan2939z@gmail.com) @RC918