### PR TITLE
test(sessions): add unit tests for polling toggle behavior (#2000)

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/pages/__tests__/Sessions.test.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/__tests__/Sessions.test.jsx
@@ -257,7 +257,10 @@ describe('Sessions Page - Polling Toggle Behavior (#2000)', () => {
       expect(apiClient.apiClientWithMeta).toHaveBeenCalledTimes(initialCallCount);
     });
 
-    it('should not poll when sessions list is empty', async () => {
+    // Note: When API returns empty sessions, component falls back to MOCK_SESSIONS
+    // which contains active sessions, so polling WILL happen. This is intentional
+    // behavior for demo/preview purposes (PR #2031).
+    it('should poll when sessions list is empty (falls back to mock data with active sessions)', async () => {
       apiClient.apiClientWithMeta.mockResolvedValue(mockEmptySessions);
 
       render(<Sessions />);
@@ -269,7 +272,8 @@ describe('Sessions Page - Polling Toggle Behavior (#2000)', () => {
         vi.advanceTimersByTime(10000);
       });
 
-      expect(apiClient.apiClientWithMeta).toHaveBeenCalledTimes(initialCallCount);
+      // Polling happens because MOCK_SESSIONS fallback contains active sessions
+      expect(apiClient.apiClientWithMeta.mock.calls.length).toBeGreaterThan(initialCallCount);
     });
   });
 


### PR DESCRIPTION
## 描述 (Description)

為 Sessions 頁面的 polling toggle 行為新增單元測試，涵蓋 PR #2024 實作的自動刷新功能。

測試涵蓋範圍：
- Auto-refresh toggle 狀態切換（預設啟用、開/關切換）
- 有活躍 sessions 時的 polling 行為（啟動、停止、恢復）
- 無活躍 sessions 時不進行 polling
- 空 sessions 時的 MOCK_SESSIONS fallback 行為（PR #2031）
- Polling 間隔驗證（10 秒）
- AbortController 整合（signal 傳遞至 API 呼叫）
- 元件卸載時的清理（interval 清除）

**Link to Devin run**: https://app.devin.ai/sessions/d62efb518d6547e3bdb93e10c5c6976b
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918

### Updates since last revision

**修正 MOCK_SESSIONS fallback 測試（最新）**：
- 測試 "should not poll when sessions list is empty" 已更新為 "should poll when sessions list is empty (falls back to mock data with active sessions)"
- PR #2031 新增了當 API 返回空 sessions 時使用 MOCK_SESSIONS 作為 fallback 的行為（用於 demo/preview）
- 由於 MOCK_SESSIONS 包含活躍 sessions，polling 會啟動，測試已更新以反映此預期行為

**Rebased on latest main (d822e188)**：此 PR 已 rebase 到最新的 main 分支，包含：
- PR #2007 (Sessions Counts Fix)
- PR #2031 (Task Plan Visualization)

**先前修正**：
- **i18n mock 穩定性**：`mockT` 定義在 `vi.mock()` factory 外部，確保跨渲染的穩定 identity，避免 `loadSessions` useCallback 的 `[t, filter]` 依賴導致無限重新渲染
- 測試數量：11 個

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 補充測試覆蓋率
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- Sessions.jsx 元件邏輯修改
- 其他頁面的測試覆蓋

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pnpm test`

### 測試步驟 (Test Steps)

1. `cd handoff/20250928/40_App/owner-console`
2. `pnpm test -- --run src/pages/__tests__/Sessions.test.jsx`

### 預期結果 (Expected Results)

所有 11 個測試案例通過

### 測試環境 (Test Environment)

- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- Sessions 頁面測試覆蓋率

### 新增的自動化測試 (New Automated Tests)

- `src/pages/__tests__/Sessions.test.jsx` - 11 個測試案例

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查


- [x] ESLint 通過（0 warnings）：`pnpm lint`
- [x] 所有測試通過：`pnpm test`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR（測試）

## Human Review Checklist

請特別注意以下項目：

1. **MOCK_SESSIONS fallback 測試（關鍵 - 最新修正）** - 測試 "should poll when sessions list is empty" 現在預期 polling 會發生，因為 PR #2031 新增了 MOCK_SESSIONS fallback。請確認此行為符合預期
2. **i18n Mock 穩定性** - `mockT` 必須定義在 `vi.mock()` factory 外部以維持穩定 identity。若定義在內部，`loadSessions` 的 `[t, filter]` 依賴會導致無限重新渲染
3. **Timer 測試穩定性** - 使用 `vi.useFakeTimers({ shouldAdvanceTime: true })` 的 timer 測試可能有 flakiness 風險
4. **測試斷言** - 測試使用 `getByTitle` 和 `getByText` 選擇器，與元件實作細節耦合
5. **Mock 資料結構** - Mock 資料需符合 `MOCK_SESSIONS` 結構（包含 `plan.tasks` 和 `logs` 陣列），已驗證與 #2031 Task Plan Visualization 相容