### PR TITLE
fix(sessions): sync MOCK_SESSIONS counts and add fallback to refresh

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
@@ -161,6 +161,23 @@ const MOCK_SESSIONS = Object.freeze([
 )
 
 /**
+ * Helper function to calculate session counts from a sessions array.
+ * Used when falling back to MOCK_SESSIONS to keep counts consistent with displayed sessions.
+ */
+const calculateSessionCounts = (sessionsArray) => {
+  return {
+    all: sessionsArray.length,
+    running: sessionsArray.filter(s => s.status === 'running').length,
+    paused: sessionsArray.filter(s => s.status === 'paused').length,
+    completed: sessionsArray.filter(s => s.status === 'completed').length,
+    failed: sessionsArray.filter(s => s.status === 'failed').length
+  }
+}
+
+// Pre-calculated counts for MOCK_SESSIONS to avoid recalculating on each fallback
+const MOCK_SESSIONS_COUNTS = calculateSessionCounts(MOCK_SESSIONS)
+
+/**
  * Sessions page for Meta Agent task execution monitoring.
  * 
  * Design: Follows Devin Sessions sidebar structure with MorningAI design system.
@@ -234,12 +251,15 @@ const Sessions = () => {
       
       // Use MOCK_SESSIONS as fallback when API returns empty (for demo/preview)
       // This allows users to see the TaskPlanTimeline, TaskEditor, and ApprovalWorkflow components
+      // Also sync counts with MOCK_SESSIONS to avoid UI inconsistency (counts showing 0 while list shows sessions)
       if (sessionsData.length === 0) {
         sessionsData = [...MOCK_SESSIONS]
+        setSessions(sessionsData)
+        setSessionCounts(MOCK_SESSIONS_COUNTS)
+      } else {
+        setSessions(sessionsData)
+        setSessionCounts(countsData)
       }
-      
-      setSessions(sessionsData)
-      setSessionCounts(countsData)
       
       setSelectedSession(prev => {
         if (!prev && sessionsData.length > 0) {
@@ -254,7 +274,9 @@ const Sessions = () => {
       })
       setError(errorMessage)
       // Use MOCK_SESSIONS as fallback on error (for demo/preview)
+      // Also sync counts with MOCK_SESSIONS to avoid UI inconsistency
       setSessions([...MOCK_SESSIONS])
+      setSessionCounts(MOCK_SESSIONS_COUNTS)
       setSelectedSession(MOCK_SESSIONS[0])
     } finally {
       setLoading(false)
@@ -279,11 +301,20 @@ const Sessions = () => {
       // Verify filter hasn't changed during request
       if (signal?.aborted) return
       
-      const sessionsData = response.data?.sessions || []
+      let sessionsData = response.data?.sessions || []
       // Issue #1981: Use counts from API response (calculated from all sessions, not filtered)
       const countsData = response.data?.counts || { all: 0, running: 0, paused: 0, completed: 0, failed: 0 }
-      setSessions(sessionsData)
-      setSessionCounts(countsData)
+      
+      // Use MOCK_SESSIONS as fallback when API returns empty (for demo/preview)
+      // Also sync counts with MOCK_SESSIONS to avoid UI inconsistency (counts showing 0 while list shows sessions)
+      if (sessionsData.length === 0) {
+        sessionsData = [...MOCK_SESSIONS]
+        setSessions(sessionsData)
+        setSessionCounts(MOCK_SESSIONS_COUNTS)
+      } else {
+        setSessions(sessionsData)
+        setSessionCounts(countsData)
+      }
       
       // Issue #1997: Return null instead of prev when session not found
       setSelectedSession(prev => {


### PR DESCRIPTION
## 描述 (Description)

修正 Sessions 頁面在使用 MOCK_SESSIONS fallback 時的 UI 不一致問題：

1. **問題 1**: 當 API 返回空 sessions 時，頂部計數顯示 0，但列表顯示 4 個 mock sessions
2. **問題 2**: 刷新後 sessions 會消失，因為 `refreshSessionsSilently` 沒有 MOCK_SESSIONS fallback

**修正內容**:
- 新增 `calculateSessionCounts` helper 函數計算 sessions 計數
- 預先計算 `MOCK_SESSIONS_COUNTS` 避免重複計算
- 在 `loadSessions` 和 `refreshSessionsSilently` 中同步更新 counts
- 在 error handler 中也同步 counts

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 修正 demo 模式下的 UI 不一致
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- 將 MOCK_SESSIONS fallback 邏輯抽取為共用函數（可作為後續 DRY 重構）
- 在 UI 上標註「Sample data」提示用戶這是示範資料

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pnpm test`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [x] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 開啟 Owner Console 的 Sessions 頁面
2. 確認頂部計數與列表 sessions 數量一致（All: 4, Running: 1, Paused: 1, Completed: 1, Failed: 1）
3. 點擊「Refresh」按鈕，確認 sessions 不會消失
4. 等待 auto-refresh polling，確認 sessions 保持顯示

### 預期結果 (Expected Results)

- 頂部計數與列表 sessions 數量一致
- 刷新後 sessions 保持顯示
- Polling 時 sessions 保持顯示

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- Sessions 頁面的 MOCK_SESSIONS fallback 行為
- Sessions 頁面的 polling/refresh 行為

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（純邏輯修正）

## 設計系統檢查 (Design System Checklist)


- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過：`pnpm lint`
- [x] 所有測試通過：`pnpm test` (11/11 tests)
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 API/邏輯
- [x] 避免使用已廢棄的目錄

## Human Review Checklist

- [ ] 確認 `MOCK_SESSIONS_COUNTS` 計算結果正確（應為 all: 4, running: 1, paused: 1, completed: 1, failed: 1）
- [ ] 確認 `loadSessions` 和 `refreshSessionsSilently` 的 fallback 邏輯一致
- [ ] 確認 error handler 中也正確同步 counts

---

**Link to Devin run**: https://app.devin.ai/sessions/533ababa6fe04b2da9416b7ae3261877
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918