### PR TITLE
fix(tokens): add base color tokens for shared-ui components (#2058)

### DIFF
--- a/handoff/20250928/40_App/frontend-dashboard/public/tokens.json
+++ b/handoff/20250928/40_App/frontend-dashboard/public/tokens.json
@@ -1,5 +1,20 @@
 {
   "color": {
+    "base": {
+      "primary": "#4D7CFE",
+      "primary-foreground": "#ffffff",
+      "background": "#ffffff",
+      "foreground": "#1A1A2E",
+      "input": "#E8ECEF",
+      "ring": "#4D7CFE",
+      "border": "#E8ECEF",
+      "muted": "#F2F4F6",
+      "muted-foreground": "#778CA2",
+      "accent": "#F2F4F6",
+      "accent-foreground": "#1A1A2E",
+      "destructive": "#ef4444",
+      "destructive-foreground": "#ffffff"
+    },
     "primary": {
       "50": "#EEF2FF",
       "100": "#E0E7FF",

--- a/handoff/20250928/40_App/owner-console/public/tokens.json
+++ b/handoff/20250928/40_App/owner-console/public/tokens.json
@@ -1,5 +1,20 @@
 {
   "color": {
+    "base": {
+      "primary": "#4D7CFE",
+      "primary-foreground": "#ffffff",
+      "background": "#ffffff",
+      "foreground": "#1A1A2E",
+      "input": "#E8ECEF",
+      "ring": "#4D7CFE",
+      "border": "#E8ECEF",
+      "muted": "#F2F4F6",
+      "muted-foreground": "#778CA2",
+      "accent": "#F2F4F6",
+      "accent-foreground": "#1A1A2E",
+      "destructive": "#ef4444",
+      "destructive-foreground": "#ffffff"
+    },
     "primary": {
       "50": "#EEF2FF",
       "100": "#E0E7FF",

--- a/handoff/20250928/40_App/owner-console/src/index.css
+++ b/handoff/20250928/40_App/owner-console/src/index.css
@@ -14,6 +14,22 @@
   --container-6xl: 72rem;    /* 1152px - max-w-6xl */
   --container-7xl: 80rem;    /* 1280px - max-w-7xl */
 
+  /* Base Color Tokens - Required for shared-ui components (Switch, etc.) */
+  /* These tokens are used by Tailwind v4 utilities like bg-primary, bg-input, etc. */
+  --color-primary: #4D7CFE;
+  --color-primary-foreground: #ffffff;
+  --color-background: #ffffff;
+  --color-foreground: #1A1A2E;
+  --color-input: #E8ECEF;
+  --color-ring: #4D7CFE;
+  --color-border: #E8ECEF;
+  --color-muted: #F2F4F6;
+  --color-muted-foreground: #778CA2;
+  --color-accent: #F2F4F6;
+  --color-accent-foreground: #1A1A2E;
+  --color-destructive: #ef4444;
+  --color-destructive-foreground: #ffffff;
+
   /* Semantic Color Tokens - Design System */
   /* Error colors (red) - for error states, destructive actions */
   --color-error-50: #fef2f2;

--- a/packages/shared-ui/scripts/compile-tokens.js
+++ b/packages/shared-ui/scripts/compile-tokens.js
@@ -21,6 +21,15 @@ function generateCSSVariables(tokens, prefix = '') {
   let css = '';
   
   for (const [key, value] of Object.entries(tokens)) {
+    // Special handling for "base" tokens - generate without "base-" prefix
+    // These are the tokens that Tailwind v4 utilities like bg-primary expect
+    if (key === 'base' && typeof value === 'object') {
+      for (const [baseKey, baseValue] of Object.entries(value)) {
+        css += `  --color-${baseKey}: ${baseValue};\n`;
+      }
+      continue;
+    }
+    
     const varName = prefix ? `${prefix}-${key}` : key;
     
     if (typeof value === 'object' && value !== null && !Array.isArray(value)) {

--- a/packages/shared-ui/src/tokens.json
+++ b/packages/shared-ui/src/tokens.json
@@ -1,5 +1,20 @@
 {
   "color": {
+    "base": {
+      "primary": "#4D7CFE",
+      "primary-foreground": "#ffffff",
+      "background": "#ffffff",
+      "foreground": "#1A1A2E",
+      "input": "#E8ECEF",
+      "ring": "#4D7CFE",
+      "border": "#E8ECEF",
+      "muted": "#F2F4F6",
+      "muted-foreground": "#778CA2",
+      "accent": "#F2F4F6",
+      "accent-foreground": "#1A1A2E",
+      "destructive": "#ef4444",
+      "destructive-foreground": "#ffffff"
+    },
     "primary": {
       "50": "#EEF2FF",
       "100": "#E0E7FF",


### PR DESCRIPTION
## 描述 (Description)

新增 base color tokens（`--color-primary`, `--color-input` 等）以修復 shared-ui Switch 元件不可見的問題。

**問題根因**：Tailwind v4 的 `bg-primary`、`bg-input` 等 utilities 期望 CSS 變數名稱為 `--color-primary`、`--color-input`（無數字後綴），但 owner-console 只有 `--color-primary-500`、`--color-input-200` 等（有數字後綴），導致 Switch 元件透明不可見。

**變更內容**：
- 在 shared-ui tokens.json 新增 "base" section 定義 base color tokens
- 更新 compile-tokens.js 特殊處理 "base" tokens（生成時不加 "base-" 前綴）
- 在 owner-console @theme block 新增對應的 base color tokens
- 同步 production apps 的 tokens.json（frontend-dashboard、owner-console）以通過 Design Tokens Drift Check

Closes #2058

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- 其他 shared-ui 元件的 token 對齊（如有需要將作為後續 issue）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests) - `pnpm test`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [x] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 進入 Sessions 頁面
2. 確認 auto-refresh Switch 元件可見（藥丸形狀的 toggle）
3. 點擊 Switch 切換狀態
4. 確認 off 狀態：灰色軌道，白色圓形 thumb 在左側
5. 確認 on 狀態：藍紫色軌道，thumb 移到右側

### 預期結果 (Expected Results)

- Switch 元件正確顯示為藥丸形狀的 toggle
- off/on 狀態視覺正確

### 實際結果 (Actual Results)

- 本地測試驗證通過：Switch 在 off/on 狀態均正確渲染

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- Sessions 頁面的 auto-refresh Switch 元件
- 任何使用 shared-ui Switch 元件的頁面

## ⚠️ 人工審查重點 (Human Review Checklist)

- [ ] **Token 值確認**：確認 base token 的顏色值符合設計系統規範
- [ ] **Vercel Preview 驗證**：在 preview 環境確認 Switch 元件可見且正確渲染
- [ ] **Token 一致性**：shared-ui tokens.json、owner-console index.css、和 public/tokens.json 的 base tokens 值應一致

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 我已檢查 `@morningai/shared-ui` 是否有可用的元件
- [x] 我沒有在應用層重複實作已存在於 shared-ui 的元件
- [x] 如使用設計 tokens，我已從 `@morningai/shared-ui` 匯入而非硬編碼

### Shared-UI Import 合規性（強制）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過：`pnpm lint`
- [x] 所有測試通過：`pnpm test`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式

---

**Link to Devin run**: https://app.devin.ai/sessions/533ababa6fe04b2da9416b7ae3261877
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918