### PR TITLE
security(vscode-ide): truncate error logs to prevent sensitive data leakage (#2075)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py
@@ -990,5 +990,6 @@ class TestTruncateErrorMessage:
             + "x" * 1000
         )
         result = _truncate_error_message(sensitive_message, max_length=100)
-        assert len(result) < len(sensitive_message)
-        assert "sk-secret-key-12345" not in result or len(result) <= 100 + len("... [truncated]")
+        assert len(result) == 100 + len("... [truncated]")
+        assert result.endswith("... [truncated]")
+        assert "sk-secret-key-12345" not in result

--- a/handoff/20250928/40_App/orchestrator/meta_agent/vscode_ide.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/vscode_ide.py
@@ -44,7 +44,7 @@ MCP_RETRY_DELAY = 1.0  # seconds
 MCP_ERROR_LOG_MAX_LENGTH = 500  # Max characters for error logs (Issue #2075)
 
 
-def _truncate_error_message(message: str, max_length: int = MCP_ERROR_LOG_MAX_LENGTH) -> str:
+def _truncate_error_message(message: Optional[str], max_length: int = MCP_ERROR_LOG_MAX_LENGTH) -> Optional[str]:
     """
     Truncate error message to prevent sensitive data leakage in logs.
 


### PR DESCRIPTION
## 描述 (Description)

修復 MCP HTTP 客戶端在錯誤回應時可能洩漏敏感資訊的安全問題。

當 MCP server 回傳錯誤時，完整的 `error_text` 會被記錄到日誌中。如果錯誤回應包含 stack traces、環境變數或 tokens，這些敏感資訊可能會被洩漏。

**變更內容**:
- 新增 `MCP_ERROR_LOG_MAX_LENGTH = 500` 常數
- 新增 `_truncate_error_message()` 輔助函數
- 在 `_execute_mcp_command()` 中對所有錯誤訊息套用截斷：
  - HTTP 錯誤回應 (非 200 狀態碼)
  - aiohttp.ClientError 例外
  - 一般 Exception 處理

## Updates since last revision

- **Type hints 改善**: `_truncate_error_message()` 參數和回傳值改為 `Optional[str]`，提升類型安全
- **測試斷言修復**: `test_truncate_sensitive_data_scenario` 的斷言從 `or` 條件改為嚴格驗證，確保測試有效性

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)** - 安全性改善

## 本 PR 不處理 (Out of Scope)

- 更進階的敏感資料過濾（如 regex 匹配 API keys）
- 日誌加密或安全儲存

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

```bash
cd ~/repos/morningai
source .venv/bin/activate
PYTHONPATH="$PWD/handoff/20250928/40_App/orchestrator:$PYTHONPATH" \
  pytest handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py::TestTruncateErrorMessage -v
```

### 預期結果 (Expected Results)

8 個測試全部通過，涵蓋：
- 短訊息不截斷
- 剛好達到長度限制的訊息不截斷
- 超長訊息被截斷並加上 `... [truncated]` 後綴
- 空字串和 None 的處理
- 自訂長度限制
- 保留訊息開頭（最有用的除錯資訊）
- 敏感資料場景驗證（確保 API keys 被截斷）

### 新增的自動化測試 (New Automated Tests)

- `test_vscode_ide.py::TestTruncateErrorMessage` (8 個測試案例)

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)


- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`flake8`
- [x] 所有測試通過：8/8 passed
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## Human Review Checklist

- [ ] 確認 500 字元的截斷限制是否適當
- [ ] 確認截斷後的錯誤訊息（不只是日誌）對呼叫端的除錯是否足夠
- [ ] 確認 `Optional[str]` 類型標註正確處理 `None` 和空字串

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR，僅含 API/邏輯變更

---

Closes #2075

**Link to Devin run**: https://app.devin.ai/sessions/84ac33fd7eed4a2cbf30e2078c42dbff
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918