### PR TITLE
refactor(owner-console): align Sessions page with Dashboard design system

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/locales/en-US.json
+++ b/handoff/20250928/40_App/owner-console/src/locales/en-US.json
@@ -462,6 +462,8 @@
             },
               "list": {
                 "title": "Sessions",
+                "subtitle": "Select a session to view details",
+                "count": "total",
                 "noSessions": "No sessions found",
                 "empty": "No Sessions",
                 "emptySubtitle": "No sessions match the current filter"

--- a/handoff/20250928/40_App/owner-console/src/locales/zh-TW.json
+++ b/handoff/20250928/40_App/owner-console/src/locales/zh-TW.json
@@ -461,6 +461,8 @@
           },
           "list": {
             "title": "會話列表",
+            "subtitle": "選擇一個會話以查看詳情",
+            "count": "個",
             "noSessions": "找不到會話",
             "empty": "沒有會話",
             "emptySubtitle": "沒有符合目前篩選條件的會話"

--- a/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
@@ -983,74 +983,78 @@ const Sessions = () => {
 
       {/* Main Content: Session List + Details */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Session List */}
-        <div className="space-y-3">
-          <h2 className="text-sm font-medium text-[var(--text-secondary)] px-1">
-            {t('sessions.list.title', 'Sessions')} ({filteredSessions.length})
-          </h2>
-          
-          {filteredSessions.length === 0 ? (
-            <SectionCard
-              title={t('sessions.list.empty', 'No Sessions')}
-              subtitle={t('sessions.list.emptySubtitle', 'No sessions match the current filter')}
-            >
-              <div className="py-4 text-center">
-                <Activity className="w-12 h-12 text-neutral-300 mx-auto" />
+        {/* Session List - Wrapped in SectionCard for Dashboard consistency */}
+        <SectionCard
+          title={t('sessions.list.title', 'Sessions')}
+          subtitle={t('sessions.list.subtitle', 'Select a session to view details')}
+          action={
+            <span className="text-xs text-[var(--text-secondary)]">
+              {filteredSessions.length} {t('sessions.list.count', 'total')}
+            </span>
+          }
+        >
+          <div className="space-y-3">
+            {filteredSessions.length === 0 ? (
+              <div className="py-8 text-center">
+                <Activity className="w-12 h-12 text-neutral-300 mx-auto mb-2" />
+                <p className="text-sm text-[var(--text-secondary)]">
+                  {t('sessions.list.emptySubtitle', 'No sessions match the current filter')}
+                </p>
               </div>
-            </SectionCard>
-          ): (
-            filteredSessions.map((session) => (
-              <button
-                key={session.id}
-                onClick={() => handleSessionSelect(session)}
-                className={`w-full text-left rounded-xl border p-4 transition-all ${
-                  selectedSession?.id === session.id
-                    ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20'
-                    : 'border-[var(--border)] bg-[var(--surface)] hover:border-primary-300'
-                }`}
-              >
-                <div className="space-y-2">
-                  <div className="flex items-start justify-between">
-                    <div className="flex-1 min-w-0 overflow-hidden">
-                      <p className="text-sm font-semibold text-[var(--text-primary)] truncate">
-                        {session.title}
-                      </p>
-                      <p className="text-xs text-[var(--text-secondary)] mt-1 truncate">
-                        {session.goal}
-                      </p>
+            ): (
+              filteredSessions.map((session) => (
+                <button
+                  key={session.id}
+                  onClick={() => handleSessionSelect(session)}
+                  className={`w-full text-left rounded-lg border p-3 transition-all ${
+                    selectedSession?.id === session.id
+                      ? 'border-primary-500 bg-primary-50 dark:bg-primary-900/20 shadow-sm'
+                      : 'border-[var(--border)] bg-[var(--surface-muted)] hover:border-primary-300 hover:shadow-sm'
+                  }`}
+                >
+                  <div className="space-y-2">
+                    <div className="flex items-start justify-between">
+                      <div className="flex-1 min-w-0 overflow-hidden">
+                        <p className="text-sm font-semibold text-[var(--text-primary)] truncate">
+                          {session.title}
+                        </p>
+                        <p className="text-xs text-[var(--text-secondary)] mt-1 truncate">
+                          {session.goal}
+                        </p>
+                      </div>
+                      <ChevronRight className={`w-4 h-4 ml-2 flex-shrink-0 ${
+                        selectedSession?.id === session.id ? 'text-primary-500' : 'text-neutral-400'
+                      }`} />
                     </div>
-                    <ChevronRight className={`w-4 h-4 ml-2 flex-shrink-0 ${
-                      selectedSession?.id === session.id ? 'text-primary-500' : 'text-neutral-400'
-                    }`} />
-                  </div>
-                  
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <Badge variant={getStatusBadgeVariant(session.status)} className="text-xs">
-                      {getStatusIcon(session.status)}
-                      <span>{t(`sessions.status.${session.status}`, session.status)}</span>
-                    </Badge>
                     
-                    {session.requiresApproval && (
-                      <Badge variant="warning" className="text-xs">
-                        <AlertTriangle />
-                        <span>{t('sessions.needsApproval', 'Needs Approval')}</span>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <Badge variant={getStatusBadgeVariant(session.status)} className="text-xs">
+                        {getStatusIcon(session.status)}
+                        <span>{t(`sessions.status.${session.status}`, session.status)}</span>
                       </Badge>
-                    )}
+                      
+                      {session.requiresApproval && (
+                        <Badge variant="warning" className="text-xs">
+                          <AlertTriangle />
+                          <span>{t('sessions.needsApproval', 'Needs Approval')}</span>
+                        </Badge>
+                      )}
+                    </div>
+                    
+                    <div className="flex items-center justify-between text-xs text-[var(--text-secondary)]">
+                      <span>{formatRelativeTime(session.updatedAt)}</span>
+                      <span className={getConfidenceColor(session.confidence)}>
+                        {t('sessions.confidence', 'Confidence')}: {Math.round(session.confidence * 100)}%
+                      </span>
+                    </div>
+                    
+                    <Progress value={session.progress} className="h-1" />
                   </div>
-                  
-                  <div className="flex items-center justify-between text-xs text-[var(--text-secondary)]">
-                    <span>{formatRelativeTime(session.updatedAt)}</span>
-                    <span className={getConfidenceColor(session.confidence)}>
-                      {t('sessions.confidence', 'Confidence')}: {Math.round(session.confidence * 100)}%
-                    </span>
-                  </div>
-                  
-                  <Progress value={session.progress} className="h-1" />
-                </div>
-              </button>
-            ))
-          )}
-        </div>
+                </button>
+              ))
+            )}
+          </div>
+        </SectionCard>
 
         {/* Session Details */}
         <div className="lg:col-span-2">


### PR DESCRIPTION
## 描述 (Description)

將 Sessions 頁面的會話列表包裝在 `SectionCard` 元件中，使其與 Dashboard 頁面的設計模式保持一致。這是 Phase 1 試點優化的一部分，目標是系統化地將 Dashboard 的設計語言應用到其他頁面。

**變更內容：**
- 將會話列表包裝在 `SectionCard` 中，添加 title、subtitle 和 action props
- 調整個別會話項目的樣式：`rounded-xl p-4` → `rounded-lg p-3`（嵌套卡片應更小）
- 背景色從 `bg-[var(--surface)]` 改為 `bg-[var(--surface-muted)]`
- 選中和懸停狀態添加 `shadow-sm` 以提供更好的互動反饋
- 新增 i18n 翻譯鍵（en-US 和 zh-TW）

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- 會話詳情面板的樣式調整（已使用一致的卡片樣式）
- 其他頁面的設計系統對齊（將在後續 PR 處理）
- 任何行為邏輯變更（純視覺優化）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [x] 視覺回歸測試 (Visual Regression Tests) - VRT
- [x] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 訪問 Owner Console 的 Sessions 頁面
2. 確認會話列表現在包裝在帶有標題和副標題的 SectionCard 中
3. 確認個別會話項目的樣式更緊湊（較小的圓角和內距）
4. 測試懸停和選中狀態的陰影效果
5. 測試空狀態顯示
6. 切換語言確認 i18n 翻譯正確

### 預期結果 (Expected Results)

- 會話列表視覺上與 Dashboard 的 SectionCard 風格一致
- 個別會話項目作為嵌套卡片，樣式更輕量
- 互動狀態（懸停、選中）有明顯的視覺反饋

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline
- [ ] Staging 環境

### 受影響的區域 (Affected Areas)

- Sessions 頁面的會話列表區域
- 不影響會話詳情面板或任何功能邏輯

## i18n 檢查清單（強制）

- [x] 所有用戶可見字串使用 `t()` 或 `<Trans>`（無硬編碼字串）
- [x] 新 translation keys 已加入 `en-US.json` 和 `zh-TW.json`
- [x] Translation keys 使用適當的命名空間（`sessions.list.subtitle`, `sessions.list.count`）
- [x] ESLint i18n 規則通過
- [ ] 已測試語言切換（待 Preview URL 可用後測試）

## 設計系統檢查 (Design System Checklist)

- [x] 我已檢查 `@morningai/shared-ui` 是否有可用的元件
- [x] 使用現有的 `SectionCard` 元件
- [ ] 不適用 - 此 PR 不包含新 UI 元件

### Shared-UI Import 合規性（強制）

- [x] 使用 `@morningai/shared-ui` 的 `SectionCard`、`Badge`、`Progress` 元件
- [x] 無直接 import UI 元件庫
- [x] ESLint `no-restricted-imports` 規則通過

## 程式碼品質檢查

- [x] ESLint 通過：`pnpm lint`
- [x] Build 通過：`pnpm build`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 設計 PR 僅含 UI/文案/樣式
- [x] 無行為邏輯變更

---

**Human Review Checklist:**
- [ ] 確認 SectionCard 包裝後的視覺效果符合預期
- [ ] 確認空狀態顯示正確
- [ ] 確認 i18n 翻譯在兩種語言下都正確顯示

---

**Link to Devin run**: https://app.devin.ai/sessions/dd753b8a5a30407f82d99b45db89de38
**Requested by**: Ryan Chen (ryan2939z@gmail.com) (@RC918)