### PR TITLE
fix(owner-console): add base tokens to @theme block for Tailwind v4

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/index.css
+++ b/handoff/20250928/40_App/owner-console/src/index.css
@@ -129,6 +129,15 @@
   --color-cyan-700: #00A3B2;
   --color-cyan-800: #008290;
   --color-cyan-900: #00616E;
+
+  /* Base tokens for shared-ui components (Switch, Button, Input, etc.) */
+  /* These are required for Tailwind v4 to generate bg-primary, bg-input, bg-background utilities */
+  /* Format: Complete CSS color values (hsl() or hex) - NOT raw HSL components */
+  --color-primary: hsl(226 70% 55%);
+  --color-input: hsl(214.3 31.8% 75%);
+  --color-background: hsl(0 0% 100%);
+  --color-foreground: hsl(222.2 84% 4.9%);
+  --color-ring: var(--color-foreground);
 }
 
 /* iotask Semantic Design Tokens */


### PR DESCRIPTION
## 描述 (Description)

將 shared-ui 元件所需的 base tokens（`--color-primary`, `--color-input`, `--color-background`, `--color-foreground`, `--color-ring`）加入 `@theme` 區塊，使 Tailwind v4 能夠生成 `bg-primary`、`bg-input`、`bg-background` 等 utilities。

這些 tokens 之前只定義在 `:root` 區塊，雖然提供了 CSS 變數值，但 Tailwind v4 需要在 `@theme` 區塊中定義才能生成對應的 utility classes。

Closes #2058

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- 移除 `:root` 區塊中的重複 token 定義（保留以確保向後相容）
- 其他 shared-ui 元件（Button, Tabs, Popover）的 token 對齊

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [x] 視覺回歸測試 (Visual Regression Tests) - VRT
- [x] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. 訪問 Owner Console 的 Sessions 頁面
2. 檢查 Switch 元件的 ON/OFF 狀態是否正確渲染顏色
3. 確認 `bg-primary`、`bg-input` 等 utilities 在編譯後的 CSS 中存在

### 預期結果 (Expected Results)

- Switch 元件 ON 狀態顯示藍色（primary）
- Switch 元件 OFF 狀態顯示灰色（input）
- Tailwind v4 正確生成 shared-ui 元件所需的 utility classes

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- 所有使用 shared-ui Switch 元件的頁面
- 可能影響其他使用 `bg-primary`、`bg-input` 等 utilities 的元件

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更（僅 CSS tokens）

### Shared-UI Import 合規性（強制）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過：`pnpm lint`
- [x] Build 通過：`pnpm build`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 設計 PR 僅含 UI/文案/樣式；工程 PR 僅含 API/邏輯

---


**Human Review Checklist:**
- [ ] 確認 `@theme` 區塊的 token 格式（`hsl(...)` 完整值）與 `:root` 區塊的格式（raw HSL components）是否為預期行為
- [ ] 確認 Tailwind v4 是否正確生成 `bg-primary`、`bg-input` 等 utilities
- [ ] 在 Preview URL 測試 Switch 元件的 ON/OFF 狀態渲染

---

**Link to Devin run**: https://app.devin.ai/sessions/dd753b8a5a30407f82d99b45db89de38
**Requested by**: Ryan Chen (ryan2939z@gmail.com) (@RC918)