### PR TITLE
perf(vscode-ide): share aiohttp ClientSession for connection reuse (#2076)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/meta_agent/vscode_ide.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/vscode_ide.py
@@ -307,7 +307,38 @@ class VSCodeIDEService:
         """Initialize the VS Code IDE service"""
         self._sessions: Dict[str, IDESession] = {}
         self._lock = asyncio.Lock()
+        self._http_session: Optional[aiohttp.ClientSession] = None
+        self._http_session_lock = asyncio.Lock()
         logger.info("[VSCodeIDEService] Initialized")
+
+    async def _get_http_session(self) -> aiohttp.ClientSession:
+        """
+        Get or create the shared aiohttp ClientSession.
+
+        Issue #2076: Reuse ClientSession for better connection pooling,
+        DNS caching, and reduced connection overhead.
+
+        Returns:
+            Shared aiohttp ClientSession instance
+        """
+        if self._http_session is None or self._http_session.closed:
+            async with self._http_session_lock:
+                if self._http_session is None or self._http_session.closed:
+                    self._http_session = aiohttp.ClientSession()
+                    logger.debug("[VSCodeIDEService] Created shared HTTP session")
+        return self._http_session
+
+    async def close(self) -> None:
+        """
+        Close the service and release resources.
+
+        Issue #2076: Properly close the shared ClientSession to release
+        TCP connections and other resources.
+        """
+        if self._http_session is not None and not self._http_session.closed:
+            await self._http_session.close()
+            self._http_session = None
+            logger.info("[VSCodeIDEService] Closed shared HTTP session")
 
     async def create_session(
         self,
@@ -942,29 +973,30 @@ class VSCodeIDEService:
 
         for attempt in range(MCP_MAX_RETRIES):
             try:
+                http_session = await self._get_http_session()
                 timeout = aiohttp.ClientTimeout(total=timeout_seconds)
-                async with aiohttp.ClientSession(timeout=timeout) as http_session:
-                    async with http_session.post(
-                        url,
-                        json=payload,
-                        headers={"Content-Type": "application/json"},
-                    ) as response:
-                        if response.status == 200:
-                            data = await response.json()
-                            logger.debug(
-                                "[VSCodeIDEService] MCP command %s succeeded",
-                                endpoint
-                            )
-                            return {"success": True, **data}
-                        else:
-                            error_text = await response.text()
-                            # Issue #2075: Truncate error logs to prevent sensitive data leakage
-                            truncated_error = _truncate_error_message(error_text)
-                            logger.warning(
-                                "[VSCodeIDEService] MCP command %s failed: %s - %s",
-                                endpoint, response.status, truncated_error
-                            )
-                            last_error = f"HTTP {response.status}: {truncated_error}"
+                async with http_session.post(
+                    url,
+                    json=payload,
+                    headers={"Content-Type": "application/json"},
+                    timeout=timeout,
+                ) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        logger.debug(
+                            "[VSCodeIDEService] MCP command %s succeeded",
+                            endpoint
+                        )
+                        return {"success": True, **data}
+                    else:
+                        error_text = await response.text()
+                        # Issue #2075: Truncate error logs to prevent sensitive data leakage
+                        truncated_error = _truncate_error_message(error_text)
+                        logger.warning(
+                            "[VSCodeIDEService] MCP command %s failed: %s - %s",
+                            endpoint, response.status, truncated_error
+                        )
+                        last_error = f"HTTP {response.status}: {truncated_error}"
 
             except asyncio.TimeoutError:
                 last_error = f"Request timeout after {timeout_seconds}s"


### PR DESCRIPTION
## 描述 (Description)

根據 aiohttp 官方建議，重用 `ClientSession` 以獲得更好的效能。此 PR 將 `_execute_mcp_command` 從每次請求建立新 session 改為使用共享的 `ClientSession`。

**變更內容：**
- 新增 `_http_session` 屬性用於共享 ClientSession
- 新增 `_get_http_session()` 方法，使用 lazy initialization 和 double-checked locking
- 新增 `close()` 方法用於正確釋放資源
- 更新 `_execute_mcp_command()` 使用共享 session，timeout 改為 per-request 設定

**效能改善：**
- TCP 連線重用（connection pooling）
- DNS 解析結果快取
- 減少建立/關閉連線的開銷

Closes #2076

**Link to Devin run**: https://app.devin.ai/sessions/dd753b8a5a30407f82d99b45db89de38
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- 應用程式 shutdown 時自動呼叫 `close()` 的機制（需要在 orchestrator 層級處理）
- Phase 3: #2069 (mocker.patch.object)
- Phase 4: #2043, #2044 (文件更新)

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest test_vscode_ide.py`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [ ] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

```bash
cd ~/repos/morningai
source .venv/bin/activate
pytest handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py -v
```

### 預期結果 (Expected Results)

- 78 tests passed ✓

### 受影響的區域 (Affected Areas)

- 所有透過 `_execute_mcp_command` 執行的 MCP 操作（file read/write, shell execute 等）

## Human Review Checklist

- [ ] Double-checked locking pattern 在 asyncio 環境下是否正確
- [ ] Per-request timeout 設定是否正確運作（從 ClientSession 層級改為 request 層級）
- [ ] 是否需要在 orchestrator shutdown 時呼叫 `close()` 方法
- [ ] `_http_session.closed` 檢查是否足以處理所有 session 失效情況

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)


- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] 所有測試通過（78 passed）
- [x] flake8 lint 通過
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新（inline docstrings 已包含說明）

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR，僅含邏輯優化