### PR TITLE
docs(orchestrator): add cross-process limitation note and environment settings (#2043, #2044)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/docs/TERMINAL_ACCESS.md
+++ b/handoff/20250928/40_App/orchestrator/docs/TERMINAL_ACCESS.md
@@ -63,6 +63,34 @@ Only if the capability check passes, the command is forwarded to the VM's shell 
 User/Service → execute_terminal_command() → _has_terminal_capability() → _execute_shell_command() → MCP → VM Shell
 ```
 
+## Environment Settings Guide
+
+The following table provides recommended settings for terminal access capability across different deployment environments:
+
+| Environment | Recommended Setting | Description |
+|-------------|---------------------|-------------|
+| Development | Can be enabled | For local development and testing. Developers can freely enable terminal access for debugging. |
+| Staging | Restricted | Requires review before enabling. Use for integration testing with limited scope. |
+| Production | Strictly controlled | Only enable for specific, audited use cases. Requires explicit authorization and logging. |
+
+### Environment-Specific Configuration
+
+**Development:**
+- Terminal access can be enabled by default for developer convenience
+- No additional authorization checks required
+- Useful for debugging and rapid iteration
+
+**Staging:**
+- Terminal access should be disabled by default
+- Enable only for specific test scenarios
+- Log all terminal access grants for review
+
+**Production:**
+- Terminal access must be disabled by default
+- Require explicit user authorization before granting
+- Implement audit logging for all terminal commands
+- Consider time-limited access grants
+
 ## Security Considerations
 
 ### Who Can Grant Terminal Access
@@ -128,6 +156,7 @@ result = await service.execute_terminal_command(unprivileged_session, "npm insta
 ## Related Issues
 
 - Issue #2023: Capability gate for terminal access
+- Issue #2044: Document terminal capability authorization flow and environment settings
 - Issue #1822: VS Code IDE integration
 
 ## Related Files

--- a/handoff/20250928/40_App/orchestrator/meta_agent/vm_provisioner.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/vm_provisioner.py
@@ -505,6 +505,12 @@ class VMProvisioner:
         """
         Provision a new VM for a task.
 
+        Note:
+            At most one active VM per task is enforced within a single process.
+            Cross-process uniqueness is NOT guaranteed. If your deployment runs
+            multiple VMProvisioner instances across processes or nodes, consider
+            using a Redis/DB-backed lock for cluster-wide uniqueness.
+
         Args:
             task_id: ID of the task
             plan_id: ID of the execution plan
@@ -520,7 +526,7 @@ class VMProvisioner:
             TaskVM instance
 
         Raises:
-            RuntimeError: If max concurrent VMs reached
+            RuntimeError: If max concurrent VMs reached or duplicate VM for task
         """
         async with self._lock:
             # Issue #2004: Prevent duplicate VM creation for the same task


### PR DESCRIPTION
## 描述 (Description)

此 PR 完成 VSCode/MCP 軌道 Phase 4 的文件更新任務：

**Issue #2043**: 在 `provision_vm()` docstring 中加註 cross-process 限制
- 說明 duplicate VM 防護機制僅限於單一 process 內的 in-memory `_vms` dict
- 建議多 process/node 部署時使用 Redis/DB-backed lock

**Issue #2044**: 在 `TERMINAL_ACCESS.md` 中新增環境設定指南
- 新增 dev/staging/prod 環境設定建議表格
- 新增各環境的詳細配置說明

Closes #2043
Closes #2044

**Link to Devin run**: https://app.devin.ai/sessions/dd753b8a5a30407f82d99b45db89de38
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- 實作 Redis/DB-backed lock（僅文件說明）
- 其他 VSCode/MCP 軌道的 issues

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [x] 手動測試 (Manual Testing) - 文件審閱
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 檢視 `vm_provisioner.py` 中 `provision_vm()` 的 docstring 是否清楚說明 cross-process 限制
2. 檢視 `TERMINAL_ACCESS.md` 中的環境設定表格是否符合安全最佳實踐

### 預期結果 (Expected Results)

- Docstring 清楚說明 in-memory dict 的限制
- 環境設定指南提供可操作的建議

## Human Review Checklist

- [ ] 確認 `_vms` dict 確實是 process-local（in-memory），docstring 描述準確
- [ ] 確認環境設定建議符合組織的安全政策
- [ ] 確認文件用語清晰、可操作

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] 此為純文件 PR，無程式碼邏輯變更
- [x] Flake8 lint 通過

## 文檔更新檢查清單 (Documentation Updates)

- [x] 此 PR 本身即為文件更新
- [x] `TERMINAL_ACCESS.md` 已更新環境設定指南
- [x] `vm_provisioner.py` docstring 已更新 cross-process 限制說明

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR，僅含文件更新