### PR TITLE
feat(observer): extract truncation magic numbers as named constants (#1839)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/observer_node.py
+++ b/handoff/20250928/40_App/orchestrator/observer_node.py
@@ -28,6 +28,14 @@ DEFAULT_SIMILARITY_THRESHOLD = 0.6
 # Default limit for past failure queries
 DEFAULT_QUERY_LIMIT = 3
 
+# Truncation limits for failure summaries and learning context
+# Maximum characters for goal text in failure summaries
+MAX_GOAL_CHARS = 200
+# Maximum characters for error text in failure summaries
+MAX_ERROR_CHARS = 500
+# Maximum characters for text snippets in learning context
+MAX_CONTEXT_SNIPPET_CHARS = 200
+
 
 def _generate_failure_summary(state: Dict[str, Any]) -> str:
     """
@@ -43,14 +51,14 @@ def _generate_failure_summary(state: Dict[str, Any]) -> str:
 
     goal = state.get("goal", "")
     if goal:
-        parts.append(f"Goal: {goal[:200]}")
+        parts.append(f"Goal: {goal[:MAX_GOAL_CHARS]}")
 
     task_type = state.get("task_type", "unknown")
     parts.append(f"Task Type: {task_type}")
 
     error = state.get("error", "")
     if error:
-        parts.append(f"Error: {error[:500]}")
+        parts.append(f"Error: {error[:MAX_ERROR_CHARS]}")
 
     ci_state = state.get("ci_state", "")
     if ci_state:
@@ -331,11 +339,11 @@ def get_learning_context(
         for i, failure in enumerate(past_failures, 1):
             context_parts.append(f"### Case {i} (Similarity: {failure.get('similarity', 0):.2f})")
             context_parts.append(f"Error Type: {failure.get('error_type', 'unknown')}")
-            context_parts.append(f"Error: {failure.get('error_text', '')[:200]}")
+            context_parts.append(f"Error: {failure.get('error_text', '')[:MAX_CONTEXT_SNIPPET_CHARS]}")
 
             fix_text = failure.get("fix_text", "")
             if fix_text and not fix_text.startswith("[PENDING]"):
-                context_parts.append(f"Fix: {fix_text[:200]}")
+                context_parts.append(f"Fix: {fix_text[:MAX_CONTEXT_SNIPPET_CHARS]}")
                 context_parts.append(f"Confidence: {failure.get('confidence_score', 0):.2f}")
 
             context_parts.append("")

--- a/handoff/20250928/40_App/orchestrator/tests/test_observer_node.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_observer_node.py
@@ -7,6 +7,41 @@ Tests the failure observation and learning context functionality.
 import sys
 from unittest.mock import patch, MagicMock
 
+
+class TestObserverNodeConstants:
+    """Tests for Observer Node named constants (#1839)."""
+
+    def test_constants_are_exported(self):
+        """Test that all named constants are exported and have expected values."""
+        from observer_node import (
+            MAX_FIXER_RETRIES,
+            DEFAULT_SIMILARITY_THRESHOLD,
+            DEFAULT_QUERY_LIMIT,
+            MAX_GOAL_CHARS,
+            MAX_ERROR_CHARS,
+            MAX_CONTEXT_SNIPPET_CHARS,
+        )
+
+        assert MAX_FIXER_RETRIES == 3
+        assert DEFAULT_SIMILARITY_THRESHOLD == 0.6
+        assert DEFAULT_QUERY_LIMIT == 3
+        assert MAX_GOAL_CHARS == 200
+        assert MAX_ERROR_CHARS == 500
+        assert MAX_CONTEXT_SNIPPET_CHARS == 200
+
+    def test_truncation_constants_are_positive(self):
+        """Test that truncation constants are positive integers."""
+        from observer_node import (
+            MAX_GOAL_CHARS,
+            MAX_ERROR_CHARS,
+            MAX_CONTEXT_SNIPPET_CHARS,
+        )
+
+        assert MAX_GOAL_CHARS > 0
+        assert MAX_ERROR_CHARS > 0
+        assert MAX_CONTEXT_SNIPPET_CHARS > 0
+
+
 mock_supabase = MagicMock()
 mock_openai = MagicMock()
 sys.modules['supabase'] = mock_supabase


### PR DESCRIPTION
## 描述 (Description)

提取 Observer Node 中的 truncation magic numbers 為命名常數，提升程式碼可讀性和可維護性。

新增常數：
- `MAX_GOAL_CHARS = 200` - goal 文字截斷長度
- `MAX_ERROR_CHARS = 500` - error 文字截斷長度
- `MAX_CONTEXT_SNIPPET_CHARS = 200` - learning context 片段截斷長度

這些常數取代了 `_generate_failure_summary()` 和 `get_learning_context()` 中的硬編碼數值。

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- 不修改截斷長度的實際數值（保持原有行為）
- 不處理其他模組的 magic numbers

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [ ] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

```bash
cd ~/repos/morningai
source .venv/bin/activate
PYTHONPATH="$PWD/handoff/20250928/40_App/orchestrator:$PWD/handoff/20250928/40_App/api-backend/src:$PYTHONPATH" \
  pytest handoff/20250928/40_App/orchestrator/tests/test_observer_node.py -v
```

### 預期結果 (Expected Results)

所有 23 個測試通過，包含新增的 2 個常數測試。

### 實際結果 (Actual Results)

✅ 23 passed in 0.32s

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [ ] CI/CD Pipeline
- [ ] Staging 環境

### 受影響的區域 (Affected Areas)

- `observer_node.py` - failure summary 生成
- `get_learning_context()` - planner 的 learning context 格式化

### 新增的自動化測試 (New Automated Tests)

- `TestObserverNodeConstants::test_constants_are_exported` - 驗證所有常數已匯出且值正確
- `TestObserverNodeConstants::test_truncation_constants_are_positive` - 驗證截斷常數為正數

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`flake8`
- [x] 所有測試通過：`pytest`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR，僅含邏輯重構

## Human Review Checklist


- [ ] 確認常數值與原本硬編碼值一致 (200, 500, 200)
- [ ] 確認所有 magic numbers 都已被替換（共 4 處）
- [ ] 確認新測試覆蓋所有新增常數

---

**Link to Devin run**: https://app.devin.ai/sessions/302563fc784948be95deb3e0c358dd68
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918