### PR TITLE
fix(deepwiki): add retry logic and rate limiting (#2152, #2153)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/deepwiki/service.py
+++ b/handoff/20250928/40_App/orchestrator/deepwiki/service.py
@@ -23,8 +23,10 @@ from typing import Dict, Any, Optional, List, Tuple, Type
 
 try:
     from utils.retry import retry_with_backoff, API_RETRY_CONFIG
+    from utils.rate_limit import check_deepwiki_rate_limit
 except ImportError:
     from orchestrator.utils.retry import retry_with_backoff, API_RETRY_CONFIG
+    from orchestrator.utils.rate_limit import check_deepwiki_rate_limit
 
 logger = logging.getLogger(__name__)
 
@@ -150,6 +152,9 @@ class DeepWikiService:
         language: Optional[str] = None,
         repo: Optional[str] = None,
         limit: int = 5,
+        enable_rate_limit: bool = True,
+        max_queries_per_minute: int = 60,
+        redis_url: Optional[str] = None,
     ) -> QueryResult:
         """
         Query the DeepWiki knowledge base.
@@ -160,12 +165,45 @@ class DeepWikiService:
             language: Optional language filter (e.g., 'python', 'javascript')
             repo: Optional repository filter
             limit: Maximum number of sources to return
+            enable_rate_limit: Enable rate limiting (default: True)
+            max_queries_per_minute: Maximum queries per minute (default: 60)
+            redis_url: Redis URL for rate limiting (optional)
             
         Returns:
             QueryResult with answer, sources, and confidence score
         """
         start_time = time.time()
         query_id = self._generate_query_id()
+        
+        # Issue #2153: Rate limiting for DeepWiki API calls
+        if enable_rate_limit:
+            allowed, count = check_deepwiki_rate_limit(
+                query_type=query_type.value,
+                max_per_minute=max_queries_per_minute,
+                redis_url=redis_url,
+            )
+            if not allowed:
+                logger.warning("[DeepWiki] Rate limited", extra={
+                    "operation": "query",
+                    "query_id": query_id,
+                    "query_type": query_type.value,
+                    "rate_limit_count": count,
+                    "max_per_minute": max_queries_per_minute,
+                })
+                return QueryResult(
+                    query_id=query_id,
+                    query_type=query_type,
+                    question=question,
+                    answer="Rate limit exceeded. Please try again later.",
+                    sources=[],
+                    confidence=0.0,
+                    latency_ms=(time.time() - start_time) * 1000,
+                    metadata={
+                        "rate_limited": True,
+                        "rate_limit_count": count,
+                        "max_per_minute": max_queries_per_minute,
+                    }
+                )
         
         logger.info("[DeepWiki] Processing query", extra={
             "operation": "query",

--- a/handoff/20250928/40_App/orchestrator/deepwiki/tests/test_service.py
+++ b/handoff/20250928/40_App/orchestrator/deepwiki/tests/test_service.py
@@ -878,3 +878,109 @@ class TestDeepWikiRetryLogic:
         # Should succeed on first attempt
         assert call_count == 1
         assert len(result) == 1
+
+
+class TestDeepWikiRateLimiting:
+    """Tests for rate limiting functionality (#2153)."""
+
+    def test_query_with_rate_limit_disabled(self):
+        """Test query works when rate limiting is disabled."""
+        service = DeepWikiService(enable_kg=False, enable_error_pairs=False)
+        
+        result = service.query(
+            question="test query",
+            query_type=QueryType.CODE_QUESTION,
+            enable_rate_limit=False,
+        )
+        
+        assert isinstance(result, QueryResult)
+        assert result.metadata.get("rate_limited") is None
+
+    @patch("deepwiki.service.check_deepwiki_rate_limit")
+    def test_query_rate_limited(self, mock_rate_limit):
+        """Test query returns rate limit response when limit exceeded."""
+        mock_rate_limit.return_value = (False, 61)
+        
+        service = DeepWikiService(enable_kg=False, enable_error_pairs=False)
+        
+        result = service.query(
+            question="test query",
+            query_type=QueryType.CODE_QUESTION,
+            enable_rate_limit=True,
+            max_queries_per_minute=60,
+        )
+        
+        assert result.metadata.get("rate_limited") is True
+        assert result.metadata.get("rate_limit_count") == 61
+        assert result.metadata.get("max_per_minute") == 60
+        assert "Rate limit exceeded" in result.answer
+        assert result.confidence == 0.0
+        assert result.sources == []
+
+    @patch("deepwiki.service.check_deepwiki_rate_limit")
+    def test_query_allowed_by_rate_limit(self, mock_rate_limit):
+        """Test query proceeds when under rate limit."""
+        mock_rate_limit.return_value = (True, 5)
+        
+        service = DeepWikiService(enable_kg=False, enable_error_pairs=False)
+        
+        result = service.query(
+            question="test query",
+            query_type=QueryType.CODE_QUESTION,
+            enable_rate_limit=True,
+        )
+        
+        assert result.metadata.get("rate_limited") is None
+        mock_rate_limit.assert_called_once()
+
+    @patch("deepwiki.service.check_deepwiki_rate_limit")
+    def test_query_rate_limit_called_with_correct_params(self, mock_rate_limit):
+        """Test rate limit check is called with correct parameters."""
+        mock_rate_limit.return_value = (True, 1)
+        
+        service = DeepWikiService(enable_kg=False, enable_error_pairs=False)
+        
+        service.query(
+            question="test query",
+            query_type=QueryType.ERROR_LOOKUP,
+            enable_rate_limit=True,
+            max_queries_per_minute=30,
+            redis_url="redis://localhost:6379",
+        )
+        
+        mock_rate_limit.assert_called_once_with(
+            query_type="error_lookup",
+            max_per_minute=30,
+            redis_url="redis://localhost:6379",
+        )
+
+    def test_query_rate_limit_default_enabled(self):
+        """Test rate limiting is enabled by default."""
+        service = DeepWikiService(enable_kg=False, enable_error_pairs=False)
+        
+        with patch("deepwiki.service.check_deepwiki_rate_limit") as mock_rate_limit:
+            mock_rate_limit.return_value = (True, 1)
+            
+            service.query(
+                question="test query",
+                query_type=QueryType.CODE_QUESTION,
+            )
+            
+            mock_rate_limit.assert_called_once()
+
+    @patch("deepwiki.service.check_deepwiki_rate_limit")
+    def test_query_rate_limit_graceful_degradation(self, mock_rate_limit):
+        """Test query proceeds when rate limit check fails gracefully."""
+        # Simulate graceful degradation (Redis unavailable)
+        mock_rate_limit.return_value = (True, 0)
+        
+        service = DeepWikiService(enable_kg=False, enable_error_pairs=False)
+        
+        result = service.query(
+            question="test query",
+            query_type=QueryType.CODE_QUESTION,
+            enable_rate_limit=True,
+        )
+        
+        # Should proceed normally
+        assert result.metadata.get("rate_limited") is None

--- a/handoff/20250928/40_App/orchestrator/utils/rate_limit.py
+++ b/handoff/20250928/40_App/orchestrator/utils/rate_limit.py
@@ -73,3 +73,78 @@ def get_pr_count_last_hour(redis_url: Optional[str] = None) -> int:
         
     except Exception:
         return 0
+
+
+def check_deepwiki_rate_limit(
+    query_type: str,
+    max_per_minute: int = 60,
+    redis_url: Optional[str] = None
+) -> tuple[bool, int]:
+    """
+    Check if DeepWiki queries are rate limited.
+    
+    Issue #2153: Rate limiting for DeepWiki API calls.
+    
+    Args:
+        query_type: Type of query (e.g., 'code_question', 'error_lookup')
+        max_per_minute: Maximum queries allowed per minute (default: 60)
+        redis_url: Redis connection URL (optional, uses localhost if None)
+    
+    Returns:
+        Tuple of (allowed: bool, current_count: int)
+        - allowed: True if query should proceed, False if rate limited
+        - current_count: Current number of queries this minute
+    """
+    try:
+        if redis_url:
+            r = redis.Redis.from_url(redis_url, decode_responses=True)
+        else:
+            r = redis.Redis(host='localhost', port=6379, db=0, decode_responses=True)
+        
+        current_minute = int(time.time() / 60)
+        key = f"deepwiki:query_count:{query_type}:{current_minute}"
+        
+        count = r.incr(key)
+        r.expire(key, 120)  # Keep for 2 minutes to handle edge cases
+        
+        if count > max_per_minute:
+            return False, count
+        
+        return True, count
+        
+    except redis.ConnectionError:
+        # Redis unavailable, allow query (graceful degradation)
+        return True, 0
+    except Exception:
+        # Unexpected error, allow query (graceful degradation)
+        return True, 0
+
+
+def get_deepwiki_query_count(
+    query_type: str,
+    redis_url: Optional[str] = None
+) -> int:
+    """
+    Get the current DeepWiki query count for this minute.
+    
+    Args:
+        query_type: Type of query (e.g., 'code_question', 'error_lookup')
+        redis_url: Redis connection URL (optional)
+    
+    Returns:
+        Number of queries in the current minute, or 0 if unavailable
+    """
+    try:
+        if redis_url:
+            r = redis.Redis.from_url(redis_url, decode_responses=True)
+        else:
+            r = redis.Redis(host='localhost', port=6379, db=0, decode_responses=True)
+        
+        current_minute = int(time.time() / 60)
+        key = f"deepwiki:query_count:{query_type}:{current_minute}"
+        
+        count = r.get(key)
+        return int(count) if count else 0
+        
+    except Exception:
+        return 0


### PR DESCRIPTION
## 描述 (Description)

為 DeepWiki 服務新增兩項 P2 改進：

### #2152 - 指數退避重試邏輯
- 新增 `DeepWikiQueryError`、`DeepWikiTransientError`、`DeepWikiPermanentError` 例外類別
- 定義 `DEEPWIKI_RETRYABLE_EXCEPTIONS` 包含可重試的例外類型
- 新增 `_query_error_pairs_with_retry()` 和 `_query_knowledge_graph_with_retry()` 內部方法
- 使用現有的 `API_RETRY_CONFIG`（max_retries=3, initial_delay=2.0s, backoff_factor=2.0）

### #2153 - API 呼叫速率限制
- 新增 `check_deepwiki_rate_limit()` 和 `get_deepwiki_query_count()` 函數到 `utils/rate_limit.py`
- 在 `DeepWikiService.query()` 方法中整合速率限制檢查
- 新增 `enable_rate_limit`、`max_queries_per_minute`、`redis_url` 參數
- 使用 Redis 追蹤每分鐘查詢次數（per query type）
- Redis 不可用時優雅降級（允許查詢繼續）

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- Feature flag for enabling/disabling retry behavior at service level
- Feature flag for enabling/disabling rate limiting at service level (only per-query parameter)

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pnpm test`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [ ] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

```bash
cd handoff/20250928/40_App/orchestrator
python -m pytest deepwiki/tests/test_service.py -v
```

### 預期結果 (Expected Results)

58 個測試全部通過，包含 7 個重試邏輯測試 + 6 個速率限制測試

### 實際結果 (Actual Results)

58 passed in 0.60s

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- DeepWiki service error-fix pair queries
- DeepWiki service Knowledge Graph queries
- DeepWiki service query() method (new rate limiting)

### 新增的自動化測試 (New Automated Tests)

**重試邏輯測試 (#2152):**
- `test_retry_exceptions_defined` - 驗證例外類別定義正確
- `test_query_error_pairs_retries_on_transient_error` - 驗證暫時性錯誤會重試
- `test_query_error_pairs_fails_after_max_retries` - 驗證超過最大重試次數後失敗
- `test_query_kg_retries_on_transient_error` - 驗證 KG 查詢暫時性錯誤會重試
- `test_query_kg_fails_after_max_retries` - 驗證 KG 查詢超過最大重試次數後失敗
- `test_query_error_pairs_no_retry_on_import_error` - 驗證 ImportError 不會重試
- `test_query_succeeds_without_retry_when_no_error` - 驗證無錯誤時不會重試

**速率限制測試 (#2153):**
- `test_query_with_rate_limit_disabled` - 驗證停用速率限制時正常運作
- `test_query_rate_limited` - 驗證超過限制時返回速率限制回應
- `test_query_allowed_by_rate_limit` - 驗證未超過限制時正常處理
- `test_query_rate_limit_called_with_correct_params` - 驗證參數正確傳遞
- `test_query_rate_limit_default_enabled` - 驗證速率限制預設啟用
- `test_query_rate_limit_graceful_degradation` - 驗證 Redis 不可用時優雅降級

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] 所有測試通過：`pnpm test`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義（無新增環境變數）

## Human Review Checklist

請特別審查以下項目：

1. **速率限制預設啟用**: `enable_rate_limit=True` 是預設值，現有呼叫者會自動啟用速率限制。確認這是預期行為。
2. **Redis 依賴**: 速率限制依賴 Redis，但 Redis 不可用時會優雅降級（允許查詢）。確認這是正確的 fallback 行為。
3. **速率限制在重試之前**: 速率限制檢查在進入重試迴圈之前執行，避免重複計數。
4. **例外類別設計**: `DeepWikiPermanentError` 已定義但目前未使用，是否需要移除或保留供未來使用？
5. **重試例外範圍**: `DEEPWIKI_RETRYABLE_EXCEPTIONS` 包含 `ConnectionError`, `TimeoutError`, `OSError` - 這些是否足夠涵蓋所有暫時性錯誤？
6. **Import fallback**: 使用 try/except 處理 import 路徑，確認在所有執行環境中都能正常運作

---

Link to Devin run: https://app.devin.ai/sessions/e02a758862714adf819b635d74769074
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918