### PR TITLE
feat(owner-console): add SessionCommandInput for interactive session commands (#1823)

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/components/sessions/SessionCommandInput.jsx
+++ b/handoff/20250928/40_App/owner-console/src/components/sessions/SessionCommandInput.jsx
@@ -1,0 +1,222 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { AppleButton } from '@morningai/shared-ui'
+import { 
+  Send,
+  Loader2,
+  MessageSquare,
+  Sparkles,
+  ChevronUp,
+  ChevronDown
+} from 'lucide-react'
+
+/**
+ * SessionCommandInput - Quick command input for sending instructions to running sessions
+ * 
+ * Features:
+ * - Send quick commands/instructions to running sessions
+ * - Expandable input area for longer messages
+ * - Command history navigation
+ * - Loading state while command is being processed
+ * - Keyboard shortcuts (Enter to send, Shift+Enter for newline)
+ * 
+ * Issue: #1823 - Interactive UI/UX - Session Features
+ * Requirement: "產生指令或快速回答" (Quick command/response)
+ */
+
+const QUICK_COMMANDS = [
+  { id: 'continue', label: 'Continue', icon: Sparkles },
+  { id: 'explain', label: 'Explain current step', icon: MessageSquare },
+  { id: 'skip', label: 'Skip this task', icon: ChevronDown },
+  { id: 'retry', label: 'Retry last action', icon: ChevronUp }
+]
+
+const SessionCommandInput = ({
+  sessionId,
+  sessionStatus,
+  onSendCommand,
+  disabled = false,
+  className = ''
+}) => {
+  const { t } = useTranslation()
+  const [command, setCommand] = useState('')
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [isSending, setIsSending] = useState(false)
+  const [commandHistory, setCommandHistory] = useState([])
+  const [historyIndex, setHistoryIndex] = useState(-1)
+  const textareaRef = useRef(null)
+
+  const isDisabled = disabled || sessionStatus === 'completed' || sessionStatus === 'failed' || sessionStatus === 'cancelled'
+
+  useEffect(() => {
+    if (textareaRef.current && isExpanded) {
+      textareaRef.current.focus()
+    }
+  }, [isExpanded])
+
+  const handleSendCommand = useCallback(async () => {
+    if (!command.trim() || isSending || isDisabled) return
+
+    const trimmedCommand = command.trim()
+    setIsSending(true)
+
+    try {
+      await onSendCommand({
+        sessionId,
+        command: trimmedCommand,
+        timestamp: new Date().toISOString()
+      })
+
+      setCommandHistory(prev => [trimmedCommand, ...prev.slice(0, 49)])
+      setCommand('')
+      setHistoryIndex(-1)
+      setIsExpanded(false)
+    } catch (error) {
+      console.error('Failed to send command:', error)
+    } finally {
+      setIsSending(false)
+    }
+  }, [command, isSending, isDisabled, sessionId, onSendCommand])
+
+  const handleQuickCommand = useCallback(async (quickCommand) => {
+    if (isSending || isDisabled) return
+
+    setIsSending(true)
+
+    try {
+      await onSendCommand({
+        sessionId,
+        command: quickCommand.id,
+        type: 'quick_command',
+        timestamp: new Date().toISOString()
+      })
+    } catch (error) {
+      console.error('Failed to send quick command:', error)
+    } finally {
+      setIsSending(false)
+    }
+  }, [isSending, isDisabled, sessionId, onSendCommand])
+
+  const handleKeyDown = useCallback((e) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSendCommand()
+    } else if (e.key === 'ArrowUp' && !command && commandHistory.length > 0) {
+      e.preventDefault()
+      const newIndex = Math.min(historyIndex + 1, commandHistory.length - 1)
+      setHistoryIndex(newIndex)
+      setCommand(commandHistory[newIndex])
+    } else if (e.key === 'ArrowDown' && historyIndex >= 0) {
+      e.preventDefault()
+      const newIndex = historyIndex - 1
+      setHistoryIndex(newIndex)
+      setCommand(newIndex >= 0 ? commandHistory[newIndex] : '')
+    } else if (e.key === 'Escape') {
+      setIsExpanded(false)
+      setCommand('')
+      setHistoryIndex(-1)
+    }
+  }, [command, commandHistory, historyIndex, handleSendCommand])
+
+  const handleInputChange = useCallback((e) => {
+    setCommand(e.target.value)
+    setHistoryIndex(-1)
+  }, [])
+
+  const toggleExpanded = useCallback(() => {
+    setIsExpanded(prev => !prev)
+  }, [])
+
+  if (isDisabled) {
+    return null
+  }
+
+  return (
+    <div className={`border-t border-[var(--border)] bg-[var(--surface)] ${className}`}>
+      {/* Quick Commands */}
+      <div className="px-4 py-2 flex items-center gap-2 overflow-x-auto">
+        <span className="text-xs text-[var(--text-secondary)] whitespace-nowrap">
+          {t('sessions.command.quickActions', 'Quick actions:')}
+        </span>
+        {QUICK_COMMANDS.map((qc) => {
+          const Icon = qc.icon
+          return (
+            <button
+              key={qc.id}
+              onClick={() => handleQuickCommand(qc)}
+              disabled={isSending}
+              className="flex items-center gap-1 px-2 py-1 text-xs rounded-full border border-[var(--border)] bg-[var(--surface-muted)] text-[var(--text-secondary)] hover:border-primary-300 hover:text-primary-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+              aria-label={t(`sessions.command.quick.${qc.id}`, qc.label)}
+            >
+              <Icon className="w-3 h-3" />
+              <span>{t(`sessions.command.quick.${qc.id}`, qc.label)}</span>
+            </button>
+          )
+        })}
+      </div>
+
+      {/* Command Input */}
+      <div className="px-4 pb-3">
+        <div className="flex items-end gap-2">
+          <div className="flex-1 relative">
+            {isExpanded ? (
+              <textarea
+                ref={textareaRef}
+                value={command}
+                onChange={handleInputChange}
+                onKeyDown={handleKeyDown}
+                placeholder={t('sessions.command.placeholder', 'Type a command or instruction...')}
+                rows={3}
+                disabled={isSending}
+                className="w-full px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500 resize-none disabled:opacity-50"
+                aria-label={t('sessions.command.inputLabel', 'Command input')}
+              />
+            ) : (
+              <input
+                type="text"
+                value={command}
+                onChange={handleInputChange}
+                onKeyDown={handleKeyDown}
+                onFocus={() => setIsExpanded(true)}
+                placeholder={t('sessions.command.placeholder', 'Type a command or instruction...')}
+                disabled={isSending}
+                className="w-full px-3 py-2 rounded-lg border border-[var(--border)] bg-[var(--surface)] text-[var(--text-primary)] placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50"
+                aria-label={t('sessions.command.inputLabel', 'Command input')}
+              />
+            )}
+            {isExpanded && (
+              <button
+                onClick={toggleExpanded}
+                className="absolute top-2 right-2 p-1 text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                aria-label={t('sessions.command.collapse', 'Collapse input')}
+              >
+                <ChevronDown className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+          <AppleButton
+            variant="default"
+            size="sm"
+            haptic="medium"
+            onClick={handleSendCommand}
+            disabled={!command.trim() || isSending}
+            aria-label={t('sessions.command.send', 'Send command')}
+          >
+            {isSending ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Send className="w-4 h-4" />
+            )}
+          </AppleButton>
+        </div>
+        {isExpanded && (
+          <p className="mt-1 text-xs text-[var(--text-secondary)]">
+            {t('sessions.command.hint', 'Press Enter to send, Shift+Enter for new line, Esc to cancel')}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default SessionCommandInput

--- a/handoff/20250928/40_App/owner-console/src/components/sessions/index.js
+++ b/handoff/20250928/40_App/owner-console/src/components/sessions/index.js
@@ -6,6 +6,7 @@ export { default as TestResultsPanel } from './TestResultsPanel'
 export { default as ConfidenceApproval } from './ConfidenceApproval'
 export { default as FileDiffViewer } from './FileDiffViewer'
 export { default as SessionInsights } from './SessionInsights'
+export { default as SessionCommandInput } from './SessionCommandInput'
 
 // Constants for confidence scoring
 export {

--- a/handoff/20250928/40_App/owner-console/src/locales/en-US.json
+++ b/handoff/20250928/40_App/owner-console/src/locales/en-US.json
@@ -636,6 +636,23 @@
               "label": "Auto",
               "enabled": "Auto-refresh enabled (10s)",
               "disabled": "Auto-refresh disabled"
+            },
+            "command": {
+              "quickActions": "Quick actions:",
+              "placeholder": "Type a command or instruction...",
+              "inputLabel": "Command input",
+              "send": "Send command",
+              "collapse": "Collapse input",
+              "hint": "Press Enter to send, Shift+Enter for new line, Esc to cancel",
+              "quick": {
+                "continue": "Continue",
+                "explain": "Explain current step",
+                "skip": "Skip this task",
+                "retry": "Retry last action"
+              },
+              "error": {
+                "sendFailed": "Failed to send command"
+              }
             }
           },
           "approvalQueue": {

--- a/handoff/20250928/40_App/owner-console/src/locales/zh-TW.json
+++ b/handoff/20250928/40_App/owner-console/src/locales/zh-TW.json
@@ -635,6 +635,23 @@
             "label": "自動",
             "enabled": "自動刷新已啟用 (10秒)",
             "disabled": "自動刷新已停用"
+          },
+          "command": {
+            "quickActions": "快速操作：",
+            "placeholder": "輸入指令或說明...",
+            "inputLabel": "指令輸入",
+            "send": "發送指令",
+            "collapse": "收合輸入",
+            "hint": "按 Enter 發送，Shift+Enter 換行，Esc 取消",
+            "quick": {
+              "continue": "繼續",
+              "explain": "說明目前步驟",
+              "skip": "跳過此任務",
+              "retry": "重試上一個操作"
+            },
+            "error": {
+              "sendFailed": "發送指令失敗"
+            }
           }
         },
         "approvalQueue": {

--- a/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/Sessions.jsx
@@ -44,6 +44,7 @@ import {
   ConfidenceApproval,
   FileDiffViewer,
   SessionInsights,
+  SessionCommandInput,
   CONFIDENCE_THRESHOLD,
   MEDIUM_CONFIDENCE_THRESHOLD,
   validateConfidence
@@ -907,6 +908,26 @@ const Sessions = () => {
     }
   }, [selectedSession, refreshSessionsSilently, handleCloseConfidenceApproval, t])
 
+  const handleSendCommand = useCallback(async ({ sessionId, command, type, timestamp }) => {
+    if (!sessionId || !command) {
+      return
+    }
+    try {
+      await apiClientWithMeta(`/api/sessions/${sessionId}/command`, {
+        method: 'POST',
+        body: JSON.stringify({ command, type: type || 'user_command', timestamp })
+      })
+      refreshSessionsSilently()
+    } catch (err) {
+      const errorMessage = handleApiError(err, {
+        defaultMessage: t('sessions.command.error.sendFailed', 'Failed to send command'),
+        logContext: 'Sessions.handleSendCommand'
+      })
+      setError(errorMessage)
+      throw err
+    }
+  }, [refreshSessionsSilently, t])
+
   if (loading) {
     return (
       <div className="space-y-8" role="status" aria-live="polite" aria-busy="true" aria-label={t('common.loading')}>
@@ -1373,6 +1394,14 @@ const Sessions = () => {
                   />
                 </TabsContent>
               </Tabs>
+
+              {/* Session Command Input (#1823) - Quick command/response feature */}
+              <SessionCommandInput
+                sessionId={selectedSession.id}
+                sessionStatus={selectedSession.status}
+                onSendCommand={handleSendCommand}
+                disabled={selectedSession.status === 'completed' || selectedSession.status === 'failed'}
+              />
 
               {/* Session Footer */}
               <div className="px-5 py-3 border-t border-[var(--border)] text-xs text-[var(--text-secondary)]">


### PR DESCRIPTION
## 描述 (Description)

實作 Issue #1823 的「產生指令或快速回答」功能，新增 `SessionCommandInput` 元件，讓使用者可以在會話執行期間發送指令給 AI Agent。

**主要功能：**
- 快速操作按鈕：繼續、說明目前步驟、跳過任務、重試
- 可展開的文字輸入區域
- 指令歷史記錄導航（上下箭頭鍵）
- 鍵盤快捷鍵：Enter 發送、Shift+Enter 換行、Esc 取消

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - Issue #1823 互動式 UI/UX 會話功能
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- 後端 API 端點 `/api/sessions/{id}/command` 實作（需另開 PR）
- 指令歷史記錄持久化（目前僅存於元件狀態）
- 單元測試（建議後續補上）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [x] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 進入 Sessions 頁面
2. 選擇一個 `running` 或 `paused` 狀態的會話
3. 在會話詳情底部應看到指令輸入區域
4. 測試快速操作按鈕點擊
5. 測試文字輸入和鍵盤快捷鍵
6. 驗證 `completed` 或 `failed` 狀態的會話不顯示輸入區域

### 預期結果 (Expected Results)

- 指令輸入區域正確顯示在會話詳情底部
- 快速操作按鈕可點擊並顯示載入狀態
- 鍵盤快捷鍵正常運作
- 已完成/失敗的會話不顯示輸入區域

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [ ] CI/CD Pipeline
- [ ] Staging 環境

### 受影響的區域 (Affected Areas)

- Sessions 頁面會話詳情區域

### ⚠️ 人工審查重點 (Human Review Checklist)

1. **API 端點設計**：`/api/sessions/{id}/command` 尚未實作，請確認此設計符合後端預期
2. **Quick Command IDs**：`continue`, `explain`, `skip`, `retry` 需與後端對應
3. **元件狀態管理**：指令歷史僅存於元件狀態，頁面刷新會遺失

## i18n 檢查清單（強制）


- [x] 所有用戶可見字串使用 `t()` 或 `<Trans>`（無硬編碼字串）
- [x] 新 translation keys 已加入 `en-US.json` 和 `zh-TW.json`
- [x] Translation keys 使用適當的命名空間（`sessions.command.*`）
- [x] 無障礙屬性（`aria-label`）已翻譯
- [x] ESLint i18n 規則通過
- [ ] 已測試語言切換（如有 UI 變更）

## 設計系統檢查 (Design System Checklist)

- [x] 我已檢查 `@morningai/shared-ui` 是否有可用的元件
- [x] 使用 `AppleButton` 來自 shared-ui
- [x] 使用設計 tokens（`var(--border)`, `var(--surface)`, `var(--text-primary)` 等）
- [ ] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制）

- [x] 使用 `@morningai/shared-ui` 元件
- [x] 僅使用允許的例外：`lucide-react`（圖示）
- [x] ESLint `no-restricted-imports` 規則通過

## 程式碼品質檢查

- [x] ESLint 通過（0 errors, 48 pre-existing warnings）
- [ ] TypeScript 類型檢查通過
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式
- [x] 避免使用已廢棄的目錄

---

**Link to Devin run**: https://app.devin.ai/sessions/e02a758862714adf819b635d74769074
**Requested by**: Ryan Chen (ryan2939z@gmail.com) (@RC918)