### PR TITLE
feat(orchestrator): complete Wave 1 Phase 7 prerequisites (#2154, #1959)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/meta_agent/autonomous_executor.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/autonomous_executor.py
@@ -36,6 +36,12 @@ except ImportError:
     get_deepwiki_service = None  # type: ignore[assignment,misc]
     QueryType = None  # type: ignore[assignment,misc]
 
+try:
+    from webhooks.outbound_notifier import OutboundNotifier, WebhookSource
+except ImportError:
+    OutboundNotifier = None  # type: ignore[assignment,misc]
+    WebhookSource = None  # type: ignore[assignment,misc]
+
 logger = logging.getLogger(__name__)
 
 
@@ -121,6 +127,7 @@ class AutonomousExecutor:
         vm_provisioner: Optional[VMProvisioner] = None,
         ide_service: Optional[VSCodeIDEService] = None,
         vm_provider: VMProvider = VMProvider.LOCAL,
+        outbound_notifier: Optional[Any] = None,
     ):
         """
         Initialize the AutonomousExecutor.
@@ -137,6 +144,7 @@ class AutonomousExecutor:
             vm_provisioner: VMProvisioner for task VM management (Issue #2018)
             ide_service: VSCodeIDEService for IDE integration (Issue #2018)
             vm_provider: Default VM provider to use (Issue #2018)
+            outbound_notifier: OutboundNotifier for closed-loop notifications (Issue #2154)
         """
         self.goal_parser = goal_parser or GoalParser()
         self.task_planner = task_planner or TaskPlanner()
@@ -153,6 +161,10 @@ class AutonomousExecutor:
         self.vm_provisioner = vm_provisioner or VMProvisioner(default_provider=vm_provider)
         self.ide_service = ide_service or VSCodeIDEService()
         self.vm_provider = vm_provider
+
+        # OutboundNotifier for closed-loop notifications (Issue #2154)
+        self.outbound_notifier = outbound_notifier
+        self._notification_source: Optional[Any] = None  # WebhookSource for notifications
 
         # Current VM and IDE session for the execution
         self._current_vm: Optional[TaskVM] = None
@@ -194,9 +206,9 @@ class AutonomousExecutor:
 
         logger.info(
             "[AutonomousExecutor] Initialized with max_retries=%d, timeout=%ds, "
-            "max_loop_iterations=%d, vm_provider=%s",
+            "max_loop_iterations=%d, vm_provider=%s, outbound_notifier=%s",
             max_retries, task_timeout_seconds, self.policy.max_loop_iterations,
-            vm_provider.value)
+            vm_provider.value, "enabled" if outbound_notifier else "disabled")
 
     async def execute_goal(
         self,
@@ -314,6 +326,14 @@ class AutonomousExecutor:
             goal_text=plan.goal.original_text if hasattr(plan, 'goal') and plan.goal else "N/A",
             plan_id=plan.plan_id,
             task_count=len(plan.subtasks),
+        )
+
+        # Issue #2154: Send task started notification (closed-loop)
+        goal_text = plan.goal.original_text if hasattr(plan, 'goal') and plan.goal else "N/A"
+        await self._notify_task_started(
+            execution_id=self.current_execution.execution_id,
+            goal_text=goal_text,
+            metadata={"plan_id": plan.plan_id, "task_count": len(plan.subtasks)},
         )
 
         try:
@@ -447,6 +467,24 @@ class AutonomousExecutor:
                 duration_seconds=self.current_execution.total_duration_seconds,
             )
 
+            # Issue #2154: Send completion/failure notification (closed-loop)
+            if self.current_execution.status == ExecutionStatus.COMPLETED:
+                await self._notify_task_completed(
+                    execution_id=self.current_execution.execution_id,
+                    goal_text=goal_text,
+                    result=self.current_execution.outputs,
+                    pr_url=self.current_execution.pr_url,
+                    metadata={"plan_id": plan.plan_id},
+                )
+            elif self.current_execution.status == ExecutionStatus.FAILED:
+                error_summary = "; ".join(self.current_execution.errors[:3])
+                await self._notify_task_failed(
+                    execution_id=self.current_execution.execution_id,
+                    goal_text=goal_text,
+                    error=error_summary,
+                    metadata={"plan_id": plan.plan_id},
+                )
+
         except Exception as e:
             logger.error("[AutonomousExecutor] Plan execution failed: %s", e, exc_info=True)
             self.current_execution.status = ExecutionStatus.FAILED
@@ -455,6 +493,14 @@ class AutonomousExecutor:
                 self.audit_logger.log_execution_failed(error=str(e))
             # Clean up resources on unexpected failure (Issue #2018)
             await self.cleanup_resources()
+
+            # Issue #2154: Send failure notification (closed-loop)
+            await self._notify_task_failed(
+                execution_id=self.current_execution.execution_id,
+                goal_text=goal_text,
+                error=str(e),
+                metadata={"plan_id": plan.plan_id},
+            )
 
         self.current_execution.completed_at = datetime.now()
         self.current_execution.total_duration_seconds = (
@@ -789,8 +835,33 @@ class AutonomousExecutor:
         Issue #2018: Provisions a VM and creates an IDE session for task execution.
         The VM and IDE session are stored in instance variables for use by other
         task handlers and cleaned up in _handle_cleanup.
+
+        Issue #1959: Supports dry_run mode where VM provisioning is simulated.
         """
         logger.info("[AutonomousExecutor] Setting up environment for task %s", task.task_id)
+
+        # dry_run mode: Log planned action but don't execute (#1959)
+        if self.policy.dry_run:
+            logger.info(
+                "[AutonomousExecutor] DRY_RUN: Would provision VM for task %s",
+                task.task_id)
+            if self.audit_logger:
+                self.audit_logger.log_high_risk_operation(
+                    task_id=task.task_id,
+                    operation="setup_environment",
+                    resource=task.description[:100],
+                    risk_level="low",
+                    dry_run=True,
+                    planned_action="Provision VM and create IDE session",
+                )
+            return {
+                "environment_ready": False,
+                "dry_run": True,
+                "planned_action": "Would provision VM and create IDE session",
+                "vm_id": None,
+                "ide_session_id": None,
+                "setup_steps": ["DRY_RUN: VM provisioning skipped"],
+            }
 
         setup_steps = []
         plan_id = self.current_plan.plan_id if self.current_plan else "unknown"
@@ -920,8 +991,33 @@ class AutonomousExecutor:
         }
 
     async def _handle_write_test(self, task: SubTask) -> Dict[str, Any]:
-        """Handle test writing tasks"""
+        """
+        Handle test writing tasks.
+
+        Issue #1959: Supports dry_run mode where test writing is simulated.
+        """
         logger.info("[AutonomousExecutor] Writing tests for task %s", task.task_id)
+
+        # dry_run mode: Log planned action but don't execute (#1959)
+        if self.policy.dry_run:
+            logger.info(
+                "[AutonomousExecutor] DRY_RUN: Would write tests for task %s",
+                task.task_id)
+            if self.audit_logger:
+                self.audit_logger.log_high_risk_operation(
+                    task_id=task.task_id,
+                    operation="write_test",
+                    resource=task.description[:100],
+                    risk_level="medium",
+                    dry_run=True,
+                    planned_action="Write test files",
+                )
+            return {
+                "tests_written": False,
+                "dry_run": True,
+                "planned_action": "Would write test files",
+                "test_files": [],
+            }
 
         if self.dev_agent:
             try:
@@ -938,8 +1034,34 @@ class AutonomousExecutor:
         }
 
     async def _handle_run_test(self, task: SubTask) -> Dict[str, Any]:
-        """Handle test execution tasks"""
+        """
+        Handle test execution tasks.
+
+        Issue #1959: Supports dry_run mode where test execution is simulated.
+        """
         logger.info("[AutonomousExecutor] Running tests for task %s", task.task_id)
+
+        # dry_run mode: Log planned action but don't execute (#1959)
+        if self.policy.dry_run:
+            logger.info(
+                "[AutonomousExecutor] DRY_RUN: Would run tests for task %s",
+                task.task_id)
+            if self.audit_logger:
+                self.audit_logger.log_high_risk_operation(
+                    task_id=task.task_id,
+                    operation="run_test",
+                    resource=task.description[:100],
+                    risk_level="low",
+                    dry_run=True,
+                    planned_action="Execute test suite",
+                )
+            return {
+                "tests_passed": False,
+                "dry_run": True,
+                "planned_action": "Would execute test suite",
+                "test_count": 0,
+                "coverage": 0,
+            }
 
         if self.dev_agent:
             try:
@@ -969,8 +1091,33 @@ class AutonomousExecutor:
         }
 
     async def _handle_documentation(self, task: SubTask) -> Dict[str, Any]:
-        """Handle documentation tasks"""
+        """
+        Handle documentation tasks.
+
+        Issue #1959: Supports dry_run mode where documentation writing is simulated.
+        """
         logger.info("[AutonomousExecutor] Writing documentation for task %s", task.task_id)
+
+        # dry_run mode: Log planned action but don't execute (#1959)
+        if self.policy.dry_run:
+            logger.info(
+                "[AutonomousExecutor] DRY_RUN: Would write documentation for task %s",
+                task.task_id)
+            if self.audit_logger:
+                self.audit_logger.log_high_risk_operation(
+                    task_id=task.task_id,
+                    operation="documentation",
+                    resource=task.description[:100],
+                    risk_level="low",
+                    dry_run=True,
+                    planned_action="Update documentation files",
+                )
+            return {
+                "documentation_updated": False,
+                "dry_run": True,
+                "planned_action": "Would update documentation files",
+                "files_updated": [],
+            }
 
         await asyncio.sleep(1)
 
@@ -1132,8 +1279,32 @@ class AutonomousExecutor:
 
         Issue #2018: Closes IDE session and destroys VM to release resources.
         This ensures proper cleanup of resources created in _handle_setup_environment.
+
+        Issue #1959: Supports dry_run mode where cleanup is simulated.
         """
         logger.info("[AutonomousExecutor] Cleaning up for task %s", task.task_id)
+
+        # dry_run mode: Log planned action but don't execute (#1959)
+        if self.policy.dry_run:
+            logger.info(
+                "[AutonomousExecutor] DRY_RUN: Would cleanup resources for task %s",
+                task.task_id)
+            if self.audit_logger:
+                self.audit_logger.log_high_risk_operation(
+                    task_id=task.task_id,
+                    operation="cleanup",
+                    resource=task.description[:100],
+                    risk_level="low",
+                    dry_run=True,
+                    planned_action="Close IDE session and destroy VM",
+                )
+            return {
+                "cleanup_complete": False,
+                "dry_run": True,
+                "planned_action": "Would close IDE session and destroy VM",
+                "cleanup_steps": ["DRY_RUN: Cleanup skipped"],
+                "cleanup_failures": [],
+            }
 
         cleanup_steps = []
         cleanup_failures = []
@@ -1416,3 +1587,182 @@ class AutonomousExecutor:
                 "[AutonomousExecutor] DeepWiki error lookup failed: %s", e
             )
             return None
+
+    def set_notification_source(self, source: Any) -> None:
+        """
+        Set the webhook source for outbound notifications.
+
+        Issue #2154: Configures which external service to notify (GitHub, Jira, Slack).
+
+        Args:
+            source: WebhookSource enum value (GITHUB, JIRA, SLACK)
+        """
+        self._notification_source = source
+        logger.info(
+            "[AutonomousExecutor] Notification source set to: %s",
+            source.value if hasattr(source, 'value') else source
+        )
+
+    async def _notify_task_started(
+        self,
+        execution_id: str,
+        goal_text: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Send notification that execution has started.
+
+        Issue #2154: Closed-loop notification for task start.
+
+        Args:
+            execution_id: Execution ID
+            goal_text: Goal text
+            metadata: Additional metadata (repo, issue_number, etc.)
+        """
+        if not self.outbound_notifier or not self._notification_source:
+            return
+
+        if OutboundNotifier is None or WebhookSource is None:
+            return
+
+        try:
+            await self.outbound_notifier.notify_task_started(
+                source=self._notification_source,
+                task_id=execution_id,
+                goal_text=goal_text,
+                metadata=metadata,
+            )
+            logger.info(
+                "[AutonomousExecutor] Sent task started notification for %s",
+                execution_id
+            )
+        except Exception as e:
+            logger.warning(
+                "[AutonomousExecutor] Failed to send task started notification: %s", e
+            )
+
+    async def _notify_task_completed(
+        self,
+        execution_id: str,
+        goal_text: str,
+        result: Optional[Dict[str, Any]] = None,
+        pr_url: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Send notification that execution has completed.
+
+        Issue #2154: Closed-loop notification for task completion.
+
+        Args:
+            execution_id: Execution ID
+            goal_text: Goal text
+            result: Execution result
+            pr_url: URL of created PR (if any)
+            metadata: Additional metadata
+        """
+        if not self.outbound_notifier or not self._notification_source:
+            return
+
+        if OutboundNotifier is None or WebhookSource is None:
+            return
+
+        try:
+            await self.outbound_notifier.notify_task_completed(
+                source=self._notification_source,
+                task_id=execution_id,
+                goal_text=goal_text,
+                result=result,
+                pr_url=pr_url,
+                metadata=metadata,
+            )
+            logger.info(
+                "[AutonomousExecutor] Sent task completed notification for %s",
+                execution_id
+            )
+        except Exception as e:
+            logger.warning(
+                "[AutonomousExecutor] Failed to send task completed notification: %s", e
+            )
+
+    async def _notify_task_failed(
+        self,
+        execution_id: str,
+        goal_text: str,
+        error: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Send notification that execution has failed.
+
+        Issue #2154: Closed-loop notification for task failure.
+
+        Args:
+            execution_id: Execution ID
+            goal_text: Goal text
+            error: Error message
+            metadata: Additional metadata
+        """
+        if not self.outbound_notifier or not self._notification_source:
+            return
+
+        if OutboundNotifier is None or WebhookSource is None:
+            return
+
+        try:
+            await self.outbound_notifier.notify_task_failed(
+                source=self._notification_source,
+                task_id=execution_id,
+                goal_text=goal_text,
+                error=error,
+                metadata=metadata,
+            )
+            logger.info(
+                "[AutonomousExecutor] Sent task failed notification for %s",
+                execution_id
+            )
+        except Exception as e:
+            logger.warning(
+                "[AutonomousExecutor] Failed to send task failed notification: %s", e
+            )
+
+    async def _notify_approval_required(
+        self,
+        execution_id: str,
+        task_id: str,
+        operation: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Send notification that approval is required.
+
+        Issue #2154: Closed-loop notification for approval requests.
+
+        Args:
+            execution_id: Execution ID
+            task_id: Task ID requiring approval
+            operation: Operation requiring approval
+            metadata: Additional metadata
+        """
+        if not self.outbound_notifier or not self._notification_source:
+            return
+
+        if OutboundNotifier is None or WebhookSource is None:
+            return
+
+        try:
+            await self.outbound_notifier.notify_approval_required(
+                source=self._notification_source,
+                task_id=execution_id,
+                operation=operation,
+                resource=task_id,
+                metadata=metadata,
+            )
+            logger.info(
+                "[AutonomousExecutor] Sent approval required notification for %s",
+                task_id
+            )
+        except Exception as e:
+            logger.warning(
+                "[AutonomousExecutor] Failed to send approval required notification: %s", e
+            )

--- a/handoff/20250928/40_App/orchestrator/meta_agent/tests/test_autonomous_executor.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/tests/test_autonomous_executor.py
@@ -701,6 +701,314 @@ class TestDryRunBehavior:
         assert result["code_written"] is True
 
 
+class TestDryRunAllHandlers:
+    """Tests for dry_run behavior in all handlers (#1959)"""
+
+    @pytest.fixture
+    def setup_executor_state(self):
+        """Helper to initialize executor state for direct handler calls"""
+        from datetime import datetime
+        from ..audit_log import AuditLogger
+
+        def _setup(executor):
+            executor.audit_logger = AuditLogger(
+                execution_id="test-exec-dry-all-001",
+                actor="test-user",
+            )
+            executor.current_execution = ExecutionResult(
+                execution_id="test-exec-dry-all-001",
+                plan_id="test-plan-dry-all-001",
+                status=ExecutionStatus.RUNNING,
+                started_at=datetime.now(),
+            )
+            return executor
+        return _setup
+
+    @pytest.mark.asyncio
+    async def test_dry_run_setup_environment_does_not_provision_vm(self):
+        """Test that dry_run mode prevents actual VM provisioning"""
+        executor = AutonomousExecutor(
+            max_retries=1,
+            task_timeout_seconds=5,
+            policy=DRY_RUN_POLICY,
+        )
+
+        task = SubTask(
+            task_id="test-dry-setup-001",
+            task_type=SubTaskType.SETUP_ENVIRONMENT,
+            description="Setup environment",
+        )
+
+        result = await executor._handle_setup_environment(task)
+
+        assert result["dry_run"] is True
+        assert result["environment_ready"] is False
+        assert result["vm_id"] is None
+        assert "planned_action" in result
+
+    @pytest.mark.asyncio
+    async def test_dry_run_write_test_does_not_execute(self):
+        """Test that dry_run mode prevents actual test writing"""
+        executor = AutonomousExecutor(
+            max_retries=1,
+            task_timeout_seconds=5,
+            policy=DRY_RUN_POLICY,
+        )
+
+        task = SubTask(
+            task_id="test-dry-write-test-001",
+            task_type=SubTaskType.WRITE_TEST,
+            description="Write tests",
+        )
+
+        result = await executor._handle_write_test(task)
+
+        assert result["dry_run"] is True
+        assert result["tests_written"] is False
+        assert "planned_action" in result
+
+    @pytest.mark.asyncio
+    async def test_dry_run_run_test_does_not_execute(self):
+        """Test that dry_run mode prevents actual test execution"""
+        executor = AutonomousExecutor(
+            max_retries=1,
+            task_timeout_seconds=5,
+            policy=DRY_RUN_POLICY,
+        )
+
+        task = SubTask(
+            task_id="test-dry-run-test-001",
+            task_type=SubTaskType.RUN_TEST,
+            description="Run tests",
+        )
+
+        result = await executor._handle_run_test(task)
+
+        assert result["dry_run"] is True
+        assert result["tests_passed"] is False
+        assert "planned_action" in result
+
+    @pytest.mark.asyncio
+    async def test_dry_run_documentation_does_not_execute(self):
+        """Test that dry_run mode prevents actual documentation writing"""
+        executor = AutonomousExecutor(
+            max_retries=1,
+            task_timeout_seconds=5,
+            policy=DRY_RUN_POLICY,
+        )
+
+        task = SubTask(
+            task_id="test-dry-doc-001",
+            task_type=SubTaskType.DOCUMENTATION,
+            description="Write documentation",
+        )
+
+        result = await executor._handle_documentation(task)
+
+        assert result["dry_run"] is True
+        assert result["documentation_updated"] is False
+        assert "planned_action" in result
+
+    @pytest.mark.asyncio
+    async def test_dry_run_cleanup_does_not_execute(self):
+        """Test that dry_run mode prevents actual cleanup"""
+        executor = AutonomousExecutor(
+            max_retries=1,
+            task_timeout_seconds=5,
+            policy=DRY_RUN_POLICY,
+        )
+
+        task = SubTask(
+            task_id="test-dry-cleanup-001",
+            task_type=SubTaskType.CLEANUP,
+            description="Cleanup resources",
+        )
+
+        result = await executor._handle_cleanup(task)
+
+        assert result["dry_run"] is True
+        assert result["cleanup_complete"] is False
+        assert "planned_action" in result
+
+
+class TestOutboundNotifierIntegration:
+    """Tests for OutboundNotifier integration in AutonomousExecutor (#2154)"""
+
+    @pytest.fixture
+    def setup_executor_state(self):
+        """Helper to initialize executor state for direct method calls"""
+        from datetime import datetime
+        from ..audit_log import AuditLogger
+
+        def _setup(executor):
+            executor.audit_logger = AuditLogger(
+                execution_id="test-exec-notifier-001",
+                actor="test-user",
+            )
+            executor.current_execution = ExecutionResult(
+                execution_id="test-exec-notifier-001",
+                plan_id="test-plan-notifier-001",
+                status=ExecutionStatus.RUNNING,
+                started_at=datetime.now(),
+            )
+            return executor
+        return _setup
+
+    def test_executor_initializes_with_outbound_notifier(self):
+        """Test that executor can be initialized with OutboundNotifier"""
+        from unittest.mock import MagicMock
+
+        mock_notifier = MagicMock()
+        executor = AutonomousExecutor(outbound_notifier=mock_notifier)
+
+        assert executor.outbound_notifier is mock_notifier
+
+    def test_executor_initializes_without_outbound_notifier(self):
+        """Test that executor can be initialized without OutboundNotifier"""
+        executor = AutonomousExecutor()
+
+        assert executor.outbound_notifier is None
+
+    def test_set_notification_source(self):
+        """Test that notification source can be set"""
+        from unittest.mock import MagicMock
+
+        mock_notifier = MagicMock()
+        mock_source = MagicMock()
+        mock_source.value = "github"
+
+        executor = AutonomousExecutor(outbound_notifier=mock_notifier)
+        executor.set_notification_source(mock_source)
+
+        assert executor._notification_source is mock_source
+
+    @pytest.mark.asyncio
+    async def test_notify_task_started_does_nothing_without_notifier(self):
+        """Test that _notify_task_started does nothing without notifier"""
+        executor = AutonomousExecutor()
+
+        # Should not raise
+        await executor._notify_task_started(
+            execution_id="test-001",
+            goal_text="Test goal",
+        )
+
+    @pytest.mark.asyncio
+    async def test_notify_task_started_does_nothing_without_source(self):
+        """Test that _notify_task_started does nothing without source"""
+        from unittest.mock import MagicMock
+
+        mock_notifier = MagicMock()
+        executor = AutonomousExecutor(outbound_notifier=mock_notifier)
+
+        # Should not raise
+        await executor._notify_task_started(
+            execution_id="test-001",
+            goal_text="Test goal",
+        )
+
+        mock_notifier.notify_task_started.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_notify_task_started_calls_notifier(self):
+        """Test that _notify_task_started calls notifier when configured"""
+        from unittest.mock import MagicMock, AsyncMock
+
+        mock_notifier = MagicMock()
+        mock_notifier.notify_task_started = AsyncMock()
+        mock_source = MagicMock()
+
+        executor = AutonomousExecutor(outbound_notifier=mock_notifier)
+        executor._notification_source = mock_source
+
+        await executor._notify_task_started(
+            execution_id="test-001",
+            goal_text="Test goal",
+            metadata={"key": "value"},
+        )
+
+        mock_notifier.notify_task_started.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_notify_task_completed_calls_notifier(self):
+        """Test that _notify_task_completed calls notifier when configured"""
+        from unittest.mock import MagicMock, AsyncMock
+
+        mock_notifier = MagicMock()
+        mock_notifier.notify_task_completed = AsyncMock()
+        mock_source = MagicMock()
+
+        executor = AutonomousExecutor(outbound_notifier=mock_notifier)
+        executor._notification_source = mock_source
+
+        await executor._notify_task_completed(
+            execution_id="test-001",
+            goal_text="Test goal",
+            result={"status": "success"},
+            pr_url="https://github.com/test/pr/1",
+        )
+
+        mock_notifier.notify_task_completed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_notify_task_failed_calls_notifier(self):
+        """Test that _notify_task_failed calls notifier when configured"""
+        from unittest.mock import MagicMock, AsyncMock
+
+        mock_notifier = MagicMock()
+        mock_notifier.notify_task_failed = AsyncMock()
+        mock_source = MagicMock()
+
+        executor = AutonomousExecutor(outbound_notifier=mock_notifier)
+        executor._notification_source = mock_source
+
+        await executor._notify_task_failed(
+            execution_id="test-001",
+            goal_text="Test goal",
+            error="Test error",
+        )
+
+        mock_notifier.notify_task_failed.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_notify_approval_required_calls_notifier(self):
+        """Test that _notify_approval_required calls notifier when configured"""
+        from unittest.mock import MagicMock, AsyncMock
+
+        mock_notifier = MagicMock()
+        mock_notifier.notify_approval_required = AsyncMock()
+        mock_source = MagicMock()
+
+        executor = AutonomousExecutor(outbound_notifier=mock_notifier)
+        executor._notification_source = mock_source
+
+        await executor._notify_approval_required(
+            execution_id="test-001",
+            task_id="task-001",
+            operation="deployment",
+        )
+
+        mock_notifier.notify_approval_required.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_notification_error_does_not_fail_execution(self):
+        """Test that notification errors don't fail execution"""
+        from unittest.mock import MagicMock, AsyncMock
+
+        mock_notifier = MagicMock()
+        mock_notifier.notify_task_started = AsyncMock(side_effect=RuntimeError("Network error"))
+        mock_source = MagicMock()
+
+        executor = AutonomousExecutor(outbound_notifier=mock_notifier)
+        executor._notification_source = mock_source
+
+        # Should not raise
+        await executor._notify_task_started(
+            execution_id="test-001",
+            goal_text="Test goal",
+        )
+
+
 class TestVMAndIDEIntegration:
     """Tests for VM and IDE integration in AutonomousExecutor (#2018)"""
 
@@ -883,7 +1191,7 @@ class TestVMAndIDEIntegration:
     @pytest.mark.asyncio
     async def test_setup_environment_raises_on_vm_failure(self, mock_plan):
         """Test that setup_environment raises ExecutionError when VM provisioning fails"""
-        from unittest.mock import AsyncMock, patch
+        from unittest.mock import AsyncMock
         from ..autonomous_executor import ExecutionError
 
         executor = AutonomousExecutor()
@@ -1154,7 +1462,7 @@ class TestDeepWikiIntegration:
     @pytest.mark.asyncio
     async def test_task_failure_queries_deepwiki_for_suggestions(self, setup_executor_state):
         """Test that task failure triggers DeepWiki error lookup"""
-        from unittest.mock import patch, AsyncMock, MagicMock
+        from unittest.mock import patch, AsyncMock
 
         executor = AutonomousExecutor(max_retries=1, task_timeout_seconds=1)
         setup_executor_state(executor)


### PR DESCRIPTION
## 描述 (Description)

完成 Wave 1 Phase 7 前置工作，實作兩個關鍵功能：

**#2154 OutboundNotifier 整合（閉環通知）**：
- 在 `AutonomousExecutor.__init__` 新增 `outbound_notifier` 參數
- 新增通知輔助方法：`_notify_task_started`, `_notify_task_completed`, `_notify_task_failed`, `_notify_approval_required`
- 在 `execute_plan` 中於任務生命週期事件時發送通知
- 新增 `set_notification_source` 方法配置 webhook 來源

**#1959 ExecutionPolicy dry_run 完整實作**：
- 為以下 handlers 新增 dry_run 支援：
  - `_handle_setup_environment`
  - `_handle_write_test`
  - `_handle_run_test`
  - `_handle_documentation`
  - `_handle_cleanup`
- 每個 dry_run handler 會記錄計劃動作並返回模擬結果

## PR 類型與優先級 (PR Type & Priority)

- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 重要但不阻擋主線

## 本 PR 不處理 (Out of Scope)

- OutboundNotifier 本身的實作（已存在）
- ExecutionPolicy 的其他功能（已存在）
- 整合測試（僅新增單元測試）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

```bash
cd ~/repos/morningai/handoff/20250928/40_App/orchestrator
source ~/.venv/bin/activate
pytest meta_agent/tests/test_autonomous_executor.py -v -k "TestDryRunAllHandlers or TestOutboundNotifierIntegration"
```

### 預期結果 (Expected Results)

15 個新測試全部通過

### 新增的自動化測試 (New Automated Tests)

- `TestDryRunAllHandlers` (5 tests): 測試所有 handlers 的 dry_run 行為
- `TestOutboundNotifierIntegration` (10 tests): 測試 OutboundNotifier 整合

## Human Review Checklist

- [ ] 驗證 OutboundNotifier import fallback 行為正確（lines 39-43）
- [ ] 驗證通知錯誤處理不會遮蔽重要錯誤（notification helper methods 使用 try/except 並只記錄 warning）
- [ ] 驗證 dry_run 返回結構與呼叫者預期一致
- [ ] 驗證 `execute_plan` 中的通知呼叫時機正確

## i18n 檢查清單（強制）


- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（flake8 僅有預存在的 C901 複雜度警告）
- [x] 所有測試通過：1934 passed, 1 failed (pre-existing), 9 skipped
- [x] 覆蓋率達標：72.09% (threshold: 50%)

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 API/邏輯

---

**Link to Devin run**: https://app.devin.ai/sessions/e925e2072a7b452e8c76e6870732e3f0
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918