### PR TITLE
test(orchestrator): add security rules tests for project_engineer/agent.py (#1916)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_agent_security_rules.py
+++ b/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_agent_security_rules.py
@@ -520,16 +520,20 @@ class TestSecurityEdgeCases:
     """Test edge cases for security validation"""
 
     def test_validate_repo_with_special_characters(self):
-        """Should handle repo names with special characters"""
+        """Should reject repos with special characters that are not allowlisted"""
         agent = ProjectEngineerAgent()
         is_allowed, error = agent._validate_repo_allowed("user/repo-with-dashes")
-        assert isinstance(is_allowed, bool)
+        assert is_allowed is False
+        assert error != ""
+        assert "not allowed" in error.lower() or "not in" in error.lower()
 
     def test_validate_repo_with_numbers(self):
-        """Should handle repo names with numbers"""
+        """Should reject repos with numbers that are not allowlisted"""
         agent = ProjectEngineerAgent()
         is_allowed, error = agent._validate_repo_allowed("user123/repo456")
-        assert isinstance(is_allowed, bool)
+        assert is_allowed is False
+        assert error != ""
+        assert "not allowed" in error.lower() or "not in" in error.lower()
 
     @pytest.mark.asyncio
     async def test_process_step_exception_handling(self):


### PR DESCRIPTION
## 描述 (Description)

為 `project_engineer/agent.py` 的安全規則驗證方法新增 41 個單元測試。

測試覆蓋範圍：
- `_validate_repo_allowed`: 5 個測試 - 倉庫驗證
- `_validate_directories_allowed`: 6 個測試 - 目錄驗證
- `_validate_task_type_allowed`: 6 個測試 - 任務類型驗證
- `_validate_task_semantic_rules`: 8 個測試 - 綜合語義規則驗證
- `_get_task_timeout`: 3 個測試 - 超時配置
- `run_task` 安全驗證: 3 個測試
- `_process_step` 安全驗證: 4 個測試
- 安全功能標誌: 2 個測試
- 邊界情況: 4 個測試

### Updates since last revision

根據 gemini-code-assist 建議進行以下修正：
- 移除冗餘測試 `test_validate_repo_allowed_with_semantic_rules`（該測試 mock 了被測試的方法本身，屬於反模式）
- 修正 `test_validate_directories_allowed_import_error_fallback` 使用 `patch.dict('sys.modules', ...)` 模擬 ImportError
- 修正 `test_validate_task_semantic_rules_import_error_fallback` 使用 `patch.dict('sys.modules', ...)` 模擬 ImportError
- 修正 `test_get_task_timeout_import_error` 使用 `patch.dict('sys.modules', ...)` 並明確斷言 `timeout == 300`

強化邊界情況測試斷言：
- `test_validate_repo_with_special_characters` 和 `test_validate_repo_with_numbers` 現在斷言 `is_allowed is False`、`error != ""`，並檢查錯誤訊息包含 "not allowed" 或 "not in"
- 遵循 `test_validate_repo_allowed_disallowed_repo` 的相同模式以保持一致性

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- 不修改 `agent.py` 的實作邏輯
- 不新增整合測試（僅單元測試）
- 不測試 `semantic_rules.py` 本身（已有獨立測試）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [ ] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. `cd handoff/20250928/40_App/orchestrator`
2. `pytest project_engineer/tests/test_agent_security_rules.py -v`

### 預期結果 (Expected Results)

41 個測試全部通過

### 實際結果 (Actual Results)

```
======================== 41 passed, 1 warning in 24.38s ========================
```

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline

### 新增的自動化測試 (New Automated Tests)

- `handoff/20250928/40_App/orchestrator/project_engineer/tests/test_agent_security_rules.py` (41 個測試)


## Human Review Checklist

- [ ] 驗證 `patch.dict('sys.modules', ...)` 是否能正確模擬 ImportError fallback 行為（模組可能已在測試前被導入）
- [ ] 確認 mock 模式是否準確反映實際 `semantic_rules` API
- [ ] 確認 `_validate_task_semantic_rules` 測試涵蓋 hard-blocking 和 approval-required 兩種違規類型
- [x] ~~確認邊界情況測試（空字串、None、特殊字符）是否充分~~ - 已強化斷言

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`flake8` 通過
- [x] 所有測試通過：41 passed
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 API/邏輯

---

**Link to Devin run**: https://app.devin.ai/sessions/e925e2072a7b452e8c76e6870732e3f0
**Requested by**: Ryan Chen (ryan2939z@gmail.com) (@RC918)