### PR TITLE
fix(owner-console): unify icon styling across stat cards to match StatCard design

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/components/sessions/SessionStatusCard.jsx
+++ b/handoff/20250928/40_App/owner-console/src/components/sessions/SessionStatusCard.jsx
@@ -4,13 +4,13 @@ import { cn } from '@morningai/shared-ui'
 /**
  * SessionStatusCard - Standardized status filter card for Agent Sessions page
  * 
- * Design Specification (Unified Status Card Standard):
+ * Design Specification (Unified Status Card Standard - aligned with StatCard):
  * - Fixed dimensions: min-w-[140px] h-24 (96px) for consistent visual alignment
- * - Internal padding: px-4 py-3 (16px horizontal, 12px vertical)
- * - Icon container: 28x28px (h-7 w-7) with rounded-lg, positioned top-right
- * - Typography: label text-xs font-medium (top-left), value text-2xl font-semibold (bottom-left)
- * - Vertical spacing: justify-between for consistent label-to-value distance
- * - Active state: light tinted background + subtle shadow + 2px left highlight (internal, no external ring)
+ * - Internal padding: p-4 (16px) matching StatCard
+ * - Icon container: 40x40px (h-10 w-10) circular (rounded-full), positioned right-center
+ * - Typography: label text-xs font-medium (top-left), value text-2xl font-semibold (below label)
+ * - Layout: flex row with content on left, icon on right (matching StatCard)
+ * - Active state: light tinted background + subtle shadow + colored border
  * - Focus state: 2px ring with accessibility color (var(--accessibility-focus-outline-color)), only on keyboard focus
  * 
  * @param {Object} props
@@ -80,14 +80,13 @@ function SessionStatusCard({
       className={cn(
         // Fixed dimensions for all cards - ensures visual consistency
         'relative min-w-[140px] h-24 w-full',
-        'text-left rounded-xl border px-4 py-3',
-        'flex flex-col justify-between',
+        'text-left rounded-xl border p-4',
         'transition-all duration-150',
         // Default state
         'border-[var(--border)] bg-[var(--surface)] shadow-sm',
         // Hover state (only when not active)
         !isActive && 'hover:shadow-md hover:border-[var(--neutral-300)]',
-        // Active state - light tinted background + subtle shadow (no external ring)
+        // Active state - light tinted background + subtle shadow
         isActive && [
           styles.activeBg,
           styles.activeBorder,
@@ -98,46 +97,40 @@ function SessionStatusCard({
         className
       )}
     >
-      {/* Subtle left highlight for active state */}
-      {isActive && (
-        <div 
-          className={cn(
-            'pointer-events-none absolute inset-y-3 left-1.5 w-0.5 rounded-full',
-            variant === 'default' ? 'bg-[var(--neutral-400)]' : styles.iconText
-          )}
-          aria-hidden="true"
-        />
-      )}
-      
-      {/* Top row: Label + Icon */}
+      {/* Layout matching StatCard: content left, icon right */}
       <div className="flex items-center justify-between">
-        <span className="text-xs font-medium text-[var(--text-secondary)]">
-          {label}
-        </span>
-        <div
-          className={cn(
-            'flex h-7 w-7 items-center justify-center rounded-lg shrink-0',
-            styles.iconBg,
-            styles.iconText
-          )}
-        >
-          {icon && cloneElement(icon, { 
-            className: 'w-4 h-4',
-            'aria-hidden': 'true'
-          })}
+        <div className="flex-1">
+          {/* Label */}
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs font-medium text-[var(--text-secondary)]">
+              {label}
+            </span>
+          </div>
+          {/* Value */}
+          <div
+            className={cn(
+              'text-2xl font-semibold transition-colors duration-150',
+              isActive ? styles.activeValue : 'text-[var(--text-primary)]'
+            )}
+          >
+            {value}
+          </div>
         </div>
-      </div>
-        
-      {/* Bottom row: Value */}
-      <div className="flex items-baseline">
-        <span
-          className={cn(
-            'text-2xl font-semibold transition-colors duration-150',
-            isActive ? styles.activeValue : 'text-[var(--text-primary)]'
-          )}
-        >
-          {value}
-        </span>
+        {/* Icon container - matching StatCard: h-10 w-10 rounded-full */}
+        {icon && (
+          <div
+            className={cn(
+              'flex h-10 w-10 items-center justify-center rounded-full ml-3 shrink-0',
+              styles.iconBg,
+              styles.iconText
+            )}
+          >
+            {cloneElement(icon, { 
+              className: 'w-5 h-5',
+              'aria-hidden': 'true'
+            })}
+          </div>
+        )}
       </div>
     </button>
   )

--- a/handoff/20250928/40_App/owner-console/src/components/sessions/__tests__/SessionStatusCard.test.jsx
+++ b/handoff/20250928/40_App/owner-console/src/components/sessions/__tests__/SessionStatusCard.test.jsx
@@ -106,21 +106,12 @@ describe('SessionStatusCard', () => {
   })
 
   describe('active state', () => {
-    it('shows left highlight bar when active', () => {
-      const { container } = render(<SessionStatusCard {...defaultProps} isActive={true} />)
+    it('applies active background and border when active', () => {
+      render(<SessionStatusCard {...defaultProps} variant="blue" isActive={true} />)
       
-      // The left highlight bar is a div with specific classes (w-0.5 rounded-full)
-      const highlightBar = container.querySelector('div.rounded-full')
-      expect(highlightBar).toBeInTheDocument()
-      expect(highlightBar.className).toContain('w-0.5')
-    })
-
-    it('does not show left highlight bar when inactive', () => {
-      const { container } = render(<SessionStatusCard {...defaultProps} isActive={false} />)
-      
-      // The left highlight bar should not be present when inactive
-      const highlightBar = container.querySelector('div.rounded-full.w-0\\.5')
-      expect(highlightBar).not.toBeInTheDocument()
+      const button = screen.getByRole('button')
+      expect(button.className).toContain('bg-primary-50')
+      expect(button.className).toContain('border-primary-500')
     })
 
     it('applies shadow-md when active', () => {
@@ -146,16 +137,22 @@ describe('SessionStatusCard', () => {
       expect(button.className).toContain('min-w-[140px]')
     })
 
-    it('has consistent padding px-4 py-3', () => {
+    it('has consistent padding p-4 (matching StatCard)', () => {
       render(<SessionStatusCard {...defaultProps} />)
       
       const button = screen.getByRole('button')
-      expect(button.className).toContain('px-4')
-      expect(button.className).toContain('py-3')
+      expect(button.className).toContain('p-4')
     })
   })
 
-  describe('icon variants', () => {
+  describe('icon container', () => {
+    it('has icon container matching StatCard dimensions (h-10 w-10 rounded-full)', () => {
+      const { container } = render(<SessionStatusCard {...defaultProps} />)
+      
+      const iconContainer = container.querySelector('.h-10.w-10.rounded-full')
+      expect(iconContainer).toBeInTheDocument()
+    })
+
     it('renders with Play icon for running status', () => {
       render(<SessionStatusCard {...defaultProps} icon={<Play data-testid="play-icon" />} variant="blue" />)
       

--- a/handoff/20250928/40_App/owner-console/src/pages/ApprovalQueue.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/ApprovalQueue.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Badge, Tabs, TabsContent, TabsList, TabsTrigger, Skeleton } from '@morningai/shared-ui'
+import { Badge, Tabs, TabsContent, TabsList, TabsTrigger, Skeleton, StatCard } from '@morningai/shared-ui'
 import { 
   Shield, 
   AlertTriangle,
@@ -370,54 +370,31 @@ const ApprovalQueue = () => {
       )}
 
       {statistics && (
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-          <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-card p-5">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-sm text-[var(--text-secondary)]">
-                {t('approvalQueue.stats.pending', 'Pending')}
-              </p>
-              <Clock className="w-5 h-5 text-joy" />
-            </div>
-            <p className="text-2xl font-bold text-[var(--text-primary)]">
-              {statistics.pending_count || 0}
-            </p>
-          </div>
-
-          <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-card p-5">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-sm text-[var(--text-secondary)]">
-                {t('approvalQueue.stats.critical', 'Critical')}
-              </p>
-              <AlertTriangle className="w-5 h-5 text-energy" />
-            </div>
-            <p className="text-2xl font-bold text-energy">
-              {statistics.by_risk_level?.critical || 0}
-            </p>
-          </div>
-
-          <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-card p-5">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-sm text-[var(--text-secondary)]">
-                {t('approvalQueue.stats.high', 'High Risk')}
-              </p>
-              <FileWarning className="w-5 h-5 text-joy" />
-            </div>
-            <p className="text-2xl font-bold text-joy">
-              {statistics.by_risk_level?.high || 0}
-            </p>
-          </div>
-
-          <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-card p-5">
-            <div className="flex items-center justify-between mb-2">
-              <p className="text-sm text-[var(--text-secondary)]">
-                {t('approvalQueue.stats.medium', 'Medium/Low')}
-              </p>
-              <Shield className="w-5 h-5 text-calm" />
-            </div>
-            <p className="text-2xl font-bold text-[var(--text-primary)]">
-              {(statistics.by_risk_level?.medium || 0) + (statistics.by_risk_level?.low || 0)}
-            </p>
-          </div>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
+          <StatCard
+            label={t('approvalQueue.stats.pending', 'Pending')}
+            value={String(statistics.pending_count || 0)}
+            icon={<Clock className="w-5 h-5" />}
+            variant="yellow"
+          />
+          <StatCard
+            label={t('approvalQueue.stats.critical', 'Critical')}
+            value={String(statistics.by_risk_level?.critical || 0)}
+            icon={<AlertTriangle className="w-5 h-5" />}
+            variant="red"
+          />
+          <StatCard
+            label={t('approvalQueue.stats.high', 'High Risk')}
+            value={String(statistics.by_risk_level?.high || 0)}
+            icon={<FileWarning className="w-5 h-5" />}
+            variant="yellow"
+          />
+          <StatCard
+            label={t('approvalQueue.stats.medium', 'Medium/Low')}
+            value={String((statistics.by_risk_level?.medium || 0) + (statistics.by_risk_level?.low || 0))}
+            icon={<Shield className="w-5 h-5" />}
+            variant="default"
+          />
         </div>
       )}
 


### PR DESCRIPTION
## 描述 (Description)

統一三個頁面（審核佇列、Agent 治理、Agent 會話）的統計卡片 icon 樣式，使其與 `@morningai/shared-ui` 的 `StatCard` 設計一致。

**變更內容：**
- `SessionStatusCard`: 將 icon 容器從 `h-7 w-7 rounded-lg` 改為 `h-10 w-10 rounded-full`，並調整布局為水平排列（內容左側、icon 右側）
- `ApprovalQueue`: 將 4 個 inline 自訂卡片重構為使用 `StatCard` 組件
- 更新單元測試以反映新的 icon 容器尺寸

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - UI 一致性修復
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- Agent Governance 頁面已使用 `StatCard`，無需修改
- 其他頁面的 StatCard 使用情況

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pnpm test`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [x] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 前往 `/approval-queue` 頁面，確認統計卡片 icon 為 40×40px 圓形
2. 前往 `/governance` 頁面，確認統計卡片 icon 樣式一致
3. 前往 `/sessions` 頁面，確認狀態卡片 icon 為 40×40px 圓形，位於右側垂直置中

### 預期結果 (Expected Results)

三個頁面的統計卡片 icon 應具有相同的尺寸（40×40px）、形狀（圓形）和位置（右側垂直置中）

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline
- [ ] Staging 環境

### 受影響的區域 (Affected Areas)

- `/approval-queue` - 統計卡片
- `/sessions` - 狀態篩選卡片

### 新增的自動化測試 (New Automated Tests)

- `SessionStatusCard.test.jsx`: 新增 icon 容器尺寸測試 (`h-10 w-10 rounded-full`)

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅樣式調整）

## 設計系統檢查 (Design System Checklist)


- [x] 我已檢查 `@morningai/shared-ui` 是否有可用的元件
- [x] 如使用設計 tokens，我已從 `@morningai/shared-ui` 匯入而非硬編碼
- [x] ApprovalQueue 現在使用 `StatCard` 組件而非自訂 inline 卡片

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 我已使用 `@morningai/shared-ui` 元件
- [x] ESLint `no-restricted-imports` 規則通過

## 程式碼品質檢查

- [x] ESLint 通過（僅 warnings，無 errors）：`pnpm lint`
- [x] 所有測試通過：`pnpm test` (22 tests passed)
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式

## ⚠️ 人工審查重點 (Human Review Checklist)

1. **視覺驗證**：請在 Preview URL 確認三個頁面的 icon 樣式是否一致
2. **ApprovalQueue 顏色變更**：原本使用 `text-joy`、`text-energy`、`text-calm` 的自訂顏色，現改為 StatCard 的 variant 顏色，請確認視覺效果是否可接受
3. **SessionStatusCard 布局變更**：從垂直布局改為水平布局，請確認在不同螢幕尺寸下的顯示效果

---

Link to Devin run: https://app.devin.ai/sessions/41aad67f450f4959b8238d130b520aa4
Requested by: Ryan Chen (ryan2939z@gmail.com) (@RC918)