### PR TITLE
fix(migrations): wrap RAISE NOTICE in DO block for valid PL/pgSQL syntax

### DIFF
--- a/migrations/006_update_rls_policies_true_tenant_isolation.sql
+++ b/migrations/006_update_rls_policies_true_tenant_isolation.sql
@@ -310,6 +310,5 @@ BEGIN
 ║  2. Update backend: db_writer.py auto-fetch tenant_id      ║
 ║  3. Create tenant APIs: /api/tenant/*                      ║
 ║  4. Frontend: TenantContext + UI components                ║
-╚════════════════════════════════════════════════════════════╝
-    ';
+╚════════════════════════════════════════════════════════════╝';
 END $$;


### PR DESCRIPTION
## 描述 (Description)

修復 migration 006 中的 PostgreSQL 語法錯誤。原本的 `RAISE NOTICE` 語句放在 `DO $$` 區塊外面，這是無效的 PL/pgSQL 語法，導致在 Supabase SQL Editor 執行時出現 `ERROR: 42601: syntax error at or near "RAISE"` 錯誤。

**變更內容**：
- 將完成訊息的 `RAISE NOTICE` 包裝在 `DO $$ BEGIN ... END $$;` 區塊內
- 移除 emoji 字元（✅）以提高相容性
- 將 closing quote 移至 banner 最後一行，避免輸出多餘空白行（根據 Gemini Code Assist 建議）

**注意**：此修復主要是為了未來執行或文檔目的。Migration 006 的核心功能（policies、helper functions）已經成功部署到 staging 和 production 環境。

### Updates since last revision

- 根據 Gemini Code Assist 建議，將 closing quote (`';`) 移至 banner 最後一行，避免 log 輸出時產生多餘的空白行

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)** - 必須立即處理，阻擋主線進度
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 重要但不阻擋主線
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)** - 可排期處理

## 本 PR 不處理 (Out of Scope)

- Migration 006 的功能性變更
- 其他 migration 檔案的檢查或修復

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [x] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. 在 Supabase SQL Editor 中執行修復後的 migration 006
2. 確認不再出現 `ERROR: 42601` 語法錯誤
3. 確認完成訊息正確顯示，且無多餘空白行

### 預期結果 (Expected Results)

Migration 執行完成，顯示完成 banner 訊息，無語法錯誤，無多餘空白行。

### 測試環境 (Test Environment)

- [x] Staging 環境
- [x] Production 環境（已驗證核心功能正常）

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## Human Review Checklist

請特別檢查：

1. **PL/pgSQL 語法正確性**：確認 `DO $$ BEGIN RAISE NOTICE '...'; END $$;` 語法有效
2. **Banner 輸出格式**：確認 closing quote 位置不會導致格式問題

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此為工程 PR，僅含邏輯修復

---


**Link to Devin run**: https://app.devin.ai/sessions/58f14d5c88f14fbfb716d279cce70a86
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918