### PR TITLE
feat(api): add quick command ID validation for session command endpoint (#2179)

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/routes/sessions.py
+++ b/handoff/20250928/40_App/api-backend/src/routes/sessions.py
@@ -486,7 +486,14 @@ def cancel_session(session_id):
         return jsonify({'error': 'Failed to cancel session'}), 500
 
 
+# Valid command types for session commands
+VALID_COMMAND_TYPES = {'user_command', 'quick_command'}
+
 # Valid quick command IDs - must match frontend SessionCommandInput.jsx QUICK_COMMANDS
+# MAINTENANCE NOTE: When adding new quick commands, update these 3 locations:
+#   1. Backend: VALID_QUICK_COMMAND_IDS (this file)
+#   2. Frontend: QUICK_COMMANDS in SessionCommandInput.jsx
+#   3. Tests: test_sessions_routes.py parametrized test cases
 # Issue #2179 - API endpoint for SessionCommandInput
 VALID_QUICK_COMMAND_IDS = {'continue', 'explain', 'skip', 'retry'}
 
@@ -516,8 +523,6 @@ def send_command(session_id):
 
     Issue: #2179 - API endpoint for SessionCommandInput
     """
-    VALID_COMMAND_TYPES = {'user_command', 'quick_command'}
-
     try:
         session_data, user_info, key = _get_session_and_user(session_id)
         user_email = user_info['user_email']

--- a/handoff/20250928/40_App/api-backend/tests/test_sessions_routes.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_sessions_routes.py
@@ -891,8 +891,11 @@ class TestSendCommandEndpoint:
                 assert 'skip' in data['message']
                 assert 'retry' in data['message']
 
-    def test_send_command_valid_quick_command_continue(self, client, auth_headers_admin, mock_redis_client, sample_session_data):
-        """Test POST /api/sessions/:id/command succeeds with valid quick command 'continue' - Issue #2179"""
+    # MAINTENANCE NOTE: When adding new quick commands, update these test cases
+    # to match VALID_QUICK_COMMAND_IDS in sessions.py and QUICK_COMMANDS in SessionCommandInput.jsx
+    @pytest.mark.parametrize("quick_command_id", ['continue', 'explain', 'skip', 'retry'])
+    def test_send_command_valid_quick_command(self, client, auth_headers_admin, mock_redis_client, sample_session_data, quick_command_id):
+        """Test POST /api/sessions/:id/command succeeds with valid quick commands - Issue #2179"""
         with patch('src.routes.sessions.get_redis_client', return_value=mock_redis_client):
             with patch('src.routes.sessions.REDIS_AVAILABLE', True):
                 mock_redis_client.get.return_value = json.dumps(sample_session_data)
@@ -900,55 +903,7 @@ class TestSendCommandEndpoint:
                 response = client.post(
                     '/api/sessions/test-session-123/command',
                     headers=auth_headers_admin,
-                    json={'command': 'continue', 'type': 'quick_command'}
-                )
-
-                assert response.status_code == 200
-                data = response.get_json()
-                assert data['success'] is True
-
-    def test_send_command_valid_quick_command_explain(self, client, auth_headers_admin, mock_redis_client, sample_session_data):
-        """Test POST /api/sessions/:id/command succeeds with valid quick command 'explain' - Issue #2179"""
-        with patch('src.routes.sessions.get_redis_client', return_value=mock_redis_client):
-            with patch('src.routes.sessions.REDIS_AVAILABLE', True):
-                mock_redis_client.get.return_value = json.dumps(sample_session_data)
-
-                response = client.post(
-                    '/api/sessions/test-session-123/command',
-                    headers=auth_headers_admin,
-                    json={'command': 'explain', 'type': 'quick_command'}
-                )
-
-                assert response.status_code == 200
-                data = response.get_json()
-                assert data['success'] is True
-
-    def test_send_command_valid_quick_command_skip(self, client, auth_headers_admin, mock_redis_client, sample_session_data):
-        """Test POST /api/sessions/:id/command succeeds with valid quick command 'skip' - Issue #2179"""
-        with patch('src.routes.sessions.get_redis_client', return_value=mock_redis_client):
-            with patch('src.routes.sessions.REDIS_AVAILABLE', True):
-                mock_redis_client.get.return_value = json.dumps(sample_session_data)
-
-                response = client.post(
-                    '/api/sessions/test-session-123/command',
-                    headers=auth_headers_admin,
-                    json={'command': 'skip', 'type': 'quick_command'}
-                )
-
-                assert response.status_code == 200
-                data = response.get_json()
-                assert data['success'] is True
-
-    def test_send_command_valid_quick_command_retry(self, client, auth_headers_admin, mock_redis_client, sample_session_data):
-        """Test POST /api/sessions/:id/command succeeds with valid quick command 'retry' - Issue #2179"""
-        with patch('src.routes.sessions.get_redis_client', return_value=mock_redis_client):
-            with patch('src.routes.sessions.REDIS_AVAILABLE', True):
-                mock_redis_client.get.return_value = json.dumps(sample_session_data)
-
-                response = client.post(
-                    '/api/sessions/test-session-123/command',
-                    headers=auth_headers_admin,
-                    json={'command': 'retry', 'type': 'quick_command'}
+                    json={'command': quick_command_id, 'type': 'quick_command'}
                 )
 
                 assert response.status_code == 200


### PR DESCRIPTION
## 描述 (Description)

為 `/api/sessions/{id}/command` 端點添加 Quick Command ID 驗證。當 `type='quick_command'` 時，驗證 `command` 必須是有效的 quick command ID（`continue`, `explain`, `skip`, `retry`），與前端 `SessionCommandInput.jsx` 的 `QUICK_COMMANDS` 保持一致。

**變更內容：**
- 新增 `VALID_COMMAND_TYPES` 和 `VALID_QUICK_COMMAND_IDS` 常數（模組層級）
- 當 `type='quick_command'` 時驗證 command 是否為有效 ID
- 無效的 quick command 返回 400 錯誤
- 更新 docstring 文檔
- 新增測試案例（使用 `pytest.mark.parametrize` 合併）

**維護提醒：** 新增 quick command 時需同步更新 3 處：
1. Backend: `VALID_QUICK_COMMAND_IDS` (sessions.py)
2. Frontend: `QUICK_COMMANDS` (SessionCommandInput.jsx)
3. Tests: parametrized test cases (test_sessions_routes.py)

### Updates since last revision

- 將 `VALID_COMMAND_TYPES` 移到模組層級（函數外）
- 使用 `pytest.mark.parametrize` 合併 4 個 quick command 測試為 1 個
- 在程式碼中加入維護提醒註解

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - Issue #2179 API 完善
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- #2242 - Wire session commands from Redis into AutonomousExecutor loop
- #2253 - Rate Limiting 實作與驗證

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [ ] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 發送 `POST /api/sessions/{id}/command` with `{"command": "invalid_cmd", "type": "quick_command"}`
2. 預期返回 400 錯誤：`{"error": "Invalid quick command", "message": "quick command must be one of: continue, explain, retry, skip"}`
3. 發送 `POST /api/sessions/{id}/command` with `{"command": "continue", "type": "quick_command"}`
4. 預期返回 200 成功

### 受影響的區域 (Affected Areas)

- `POST /api/sessions/{id}/command` 端點

### 新增的自動化測試 (New Automated Tests)

- `test_send_command_invalid_quick_command_id` - 測試無效 quick command ID
- `test_send_command_valid_quick_command` - 使用 `@pytest.mark.parametrize` 測試所有有效 quick commands (continue, explain, skip, retry)

## Human Review Checklist

- [ ] 驗證 `VALID_QUICK_COMMAND_IDS` 與前端 `SessionCommandInput.jsx` 的 `QUICK_COMMANDS` 一致
- [ ] 驗證 `user_command` 類型不受此驗證影響（可以是任意文字）
- [ ] 驗證錯誤回應格式與現有 API 一致
- [ ] 驗證維護提醒註解正確指向 3 個需同步的位置

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`pnpm lint`
- [x] 所有測試通過：`pnpm test`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新（docstring 已更新）

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 工程 PR 僅含 API/邏輯

---

**Link to Devin run**: https://app.devin.ai/sessions/58f14d5c88f14fbfb716d279cce70a86
**Requested by**: Ryan Chen (@RC918)