### PR TITLE
feat(orchestrator): implement concurrency-safe session command processing (P1)

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/routes/sessions.py
+++ b/handoff/20250928/40_App/api-backend/src/routes/sessions.py
@@ -583,8 +583,10 @@ def send_command(session_id):
         redis_client = get_redis_client()
 
         commands_key = f"{key}{SESSION_COMMANDS_KEY_SUFFIX}"
-        redis_client.rpush(commands_key, json.dumps(command_entry))
-        redis_client.expire(commands_key, SESSION_TTL_SECONDS)
+        with redis_client.pipeline() as pipe:
+            pipe.rpush(commands_key, json.dumps(command_entry))
+            pipe.expire(commands_key, SESSION_TTL_SECONDS)
+            pipe.execute()
 
         logger.info(
             "Command queued to session %s by %s: type=%s, length=%d, command_id=%s",

--- a/handoff/20250928/40_App/api-backend/tests/test_sessions_routes.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_sessions_routes.py
@@ -985,6 +985,9 @@ class TestSendCommandEndpoint:
         with patch('src.routes.sessions.get_redis_client', return_value=mock_redis_client):
             with patch('src.routes.sessions.REDIS_AVAILABLE', True):
                 mock_redis_client.get.return_value = json.dumps(sample_session_data)
+                mock_pipe = MagicMock()
+                mock_redis_client.pipeline.return_value.__enter__ = MagicMock(return_value=mock_pipe)
+                mock_redis_client.pipeline.return_value.__exit__ = MagicMock(return_value=False)
 
                 response = client.post(
                     '/api/sessions/test-session-123/command',
@@ -1004,8 +1007,9 @@ class TestSendCommandEndpoint:
                 assert 'command_id' in data
                 assert 'timestamp' in data
 
-                mock_redis_client.rpush.assert_called_once()
-                mock_redis_client.expire.assert_called_once()
+                mock_pipe.rpush.assert_called_once()
+                mock_pipe.expire.assert_called_once()
+                mock_pipe.execute.assert_called_once()
 
     def test_send_command_success_paused_session(self, client, auth_headers_admin, mock_redis_client, sample_session_data):
         """Test POST /api/sessions/:id/command succeeds for paused session"""
@@ -1030,6 +1034,9 @@ class TestSendCommandEndpoint:
         with patch('src.routes.sessions.get_redis_client', return_value=mock_redis_client):
             with patch('src.routes.sessions.REDIS_AVAILABLE', True):
                 mock_redis_client.get.return_value = json.dumps(sample_session_data)
+                mock_pipe = MagicMock()
+                mock_redis_client.pipeline.return_value.__enter__ = MagicMock(return_value=mock_pipe)
+                mock_redis_client.pipeline.return_value.__exit__ = MagicMock(return_value=False)
 
                 response = client.post(
                     '/api/sessions/test-session-123/command',
@@ -1039,15 +1046,18 @@ class TestSendCommandEndpoint:
 
                 assert response.status_code == 200
 
-                call_args = mock_redis_client.rpush.call_args
+                call_args = mock_pipe.rpush.call_args
                 command_data = json.loads(call_args[0][1])
                 assert command_data['type'] == 'user_command'
 
-    def test_send_command_uses_rpush_for_concurrency_safety(self, client, auth_headers_admin, mock_redis_client, sample_session_data):
-        """Test POST /api/sessions/:id/command uses RPUSH for concurrency-safe command queuing"""
+    def test_send_command_uses_pipeline_for_concurrency_safety(self, client, auth_headers_admin, mock_redis_client, sample_session_data):
+        """Test POST /api/sessions/:id/command uses Redis pipeline for atomic RPUSH+EXPIRE"""
         with patch('src.routes.sessions.get_redis_client', return_value=mock_redis_client):
             with patch('src.routes.sessions.REDIS_AVAILABLE', True):
                 mock_redis_client.get.return_value = json.dumps(sample_session_data)
+                mock_pipe = MagicMock()
+                mock_redis_client.pipeline.return_value.__enter__ = MagicMock(return_value=mock_pipe)
+                mock_redis_client.pipeline.return_value.__exit__ = MagicMock(return_value=False)
 
                 response = client.post(
                     '/api/sessions/test-session-123/command',
@@ -1057,8 +1067,8 @@ class TestSendCommandEndpoint:
 
                 assert response.status_code == 200
 
-                mock_redis_client.rpush.assert_called_once()
-                call_args = mock_redis_client.rpush.call_args
+                mock_pipe.rpush.assert_called_once()
+                call_args = mock_pipe.rpush.call_args
                 commands_key = call_args[0][0]
                 assert commands_key == 'dev_agent:session:test-session-123:commands'
 
@@ -1067,11 +1077,16 @@ class TestSendCommandEndpoint:
                 assert 'command_id' in command_data
                 assert 'server_timestamp' in command_data
 
+                mock_pipe.execute.assert_called_once()
+
     def test_send_command_sets_ttl_on_commands_key(self, client, auth_headers_admin, mock_redis_client, sample_session_data):
-        """Test POST /api/sessions/:id/command sets TTL on commands key"""
+        """Test POST /api/sessions/:id/command sets TTL on commands key via pipeline"""
         with patch('src.routes.sessions.get_redis_client', return_value=mock_redis_client):
             with patch('src.routes.sessions.REDIS_AVAILABLE', True):
                 mock_redis_client.get.return_value = json.dumps(sample_session_data)
+                mock_pipe = MagicMock()
+                mock_redis_client.pipeline.return_value.__enter__ = MagicMock(return_value=mock_pipe)
+                mock_redis_client.pipeline.return_value.__exit__ = MagicMock(return_value=False)
 
                 response = client.post(
                     '/api/sessions/test-session-123/command',
@@ -1081,7 +1096,7 @@ class TestSendCommandEndpoint:
 
                 assert response.status_code == 200
 
-                mock_redis_client.expire.assert_called_once()
-                call_args = mock_redis_client.expire.call_args
+                mock_pipe.expire.assert_called_once()
+                call_args = mock_pipe.expire.call_args
                 assert call_args[0][0] == 'dev_agent:session:test-session-123:commands'
                 assert call_args[0][1] == 86400

--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -1350,12 +1350,12 @@ def run_meta_agent_task(task_id: str, goal_text: str, repo: str, tenant_id: str,
         )
 
         # Issue #2322: Persist session_data back to Redis after command processing
-        # Clear processed commands from the separate Redis List for concurrency safety
-        commands_processed_count = 0
-        if pending_commands:
+        # Use LTRIM to remove only processed commands, preserving any new commands
+        # that arrived between LRANGE and now (fixes race condition vs DELETE)
+        commands_processed_count = len(pending_commands)
+        if commands_processed_count > 0:
             try:
-                redis.delete(commands_key)
-                commands_processed_count = len(pending_commands)
+                redis.ltrim(commands_key, commands_processed_count, -1)
                 logger.info(
                     "[MetaAgent] Processed commands cleared from queue",
                     extra={


### PR DESCRIPTION
## 描述 (Description)

實現 P1 並發安全改進：將 session commands 從 session_data 分離到獨立的 Redis List，消除 API 端（添加命令）和 Worker 端（處理命令）之間的 race condition。

**變更摘要**：
- API 端使用 Redis pipeline 原子性執行 `RPUSH` + `EXPIRE`，將命令添加到獨立的 Redis List (`dev_agent:session:{id}:commands`)
- Worker 端使用 `LRANGE` 讀取待處理命令，處理後使用 `LTRIM` 只移除已處理的命令（保留新進來的命令）
- 移除 session_data 中的 commands 欄位（改為獨立存儲）

### Updates since last revision

基於 review feedback 修復：
1. **Redis Pipeline 優化**：API 端將 `RPUSH` + `EXPIRE` 包裝在 pipeline 中，確保原子性執行
2. **LRANGE/DELETE race condition 修復**：Worker 端改用 `LTRIM(key, N, -1)` 只移除已處理的 N 個命令，保留在 LRANGE 和 LTRIM 之間新進來的命令

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)** - 必須立即處理，阻擋主線進度
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 重要但不阻擋主線
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)** - 可排期處理

**對應 GitHub Labels**: `P1`

## 本 PR 不處理 (Out of Scope)

- P2: 統一 UTC 時間戳格式（將在後續 PR 處理）
- P2: 改進日誌記錄 pending commands count（將在後續 PR 處理）
- 使用 WATCH/MULTI/EXEC 的替代方案（key 分離方案更簡單且效能更好）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest`
- [ ] 整合測試 (Integration Tests)
- [ ] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. `cd ~/repos/morningai && source .venv/bin/activate`
2. `pytest handoff/20250928/40_App/orchestrator/meta_agent/tests/test_session_command_processor.py -v`
3. 驗證所有 22 個測試通過

### 預期結果 (Expected Results)

- 所有測試通過
- API 端使用 pipeline 原子性執行 RPUSH + EXPIRE
- Worker 端使用 LTRIM 只移除已處理的命令

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- `api-backend/src/routes/sessions.py` - send_command endpoint
- `orchestrator/redis_queue/worker.py` - run_meta_agent_task function
- Session command 處理流程

### 新增的自動化測試 (New Automated Tests)

- `test_send_command_uses_pipeline_for_concurrency_safety` - 驗證 pipeline 原子性行為
- `test_send_command_sets_ttl_on_commands_key` - 驗證 TTL 設置

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更


## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`pnpm lint`
- [x] 所有測試通過：`pytest`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 避免使用已廢棄的目錄

## Human Review Checklist

請特別審查以下項目：

1. ~~**潛在的命令丟失風險**~~ ✓ 已修復：改用 `LTRIM(key, N, -1)` 只移除已處理的 N 個命令，保留新進來的命令

2. **向後兼容性**: 現有 session_data 中的 commands 欄位將不再被處理。確認這是否可接受（sessions 有 24h TTL）。

3. ~~**錯誤處理策略**~~ ✓ 已改善：使用 LTRIM 失敗時，命令可能會被重複處理（at-least-once 語義），這比丟失命令更安全。

4. **LTRIM index 邏輯**: 確認 `LTRIM(key, processed_count, -1)` 的 index 計算正確（0-based，保留 index >= processed_count 的元素）。

---

**Link to Devin run**: https://app.devin.ai/sessions/58f14d5c88f14fbfb716d279cce70a86
**Requested by**: Ryan Chen (@RC918)