### PR TITLE
refactor(tests): use pytest.mark.parametrize for metrics Redis unavailable tests

### DIFF
--- a/handoff/20250928/40_App/api-backend/tests/test_metrics_routes.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_metrics_routes.py
@@ -228,36 +228,25 @@ class TestMetricsHealthEndpoint:
 class TestMetricsRedisUnavailable:
     """Tests for metrics collection when Redis is unavailable"""
 
-    def test_api_metrics_redis_unavailable(self, client):
-        """Test API metrics returns unavailable when Redis fails"""
+    @pytest.mark.parametrize(
+        "section,expect_error_key",
+        [
+            ("api", True),
+            ("rate_limit", False),
+            ("session_commands", False),
+        ],
+    )
+    def test_section_unavailable_when_redis_missing(self, client, section, expect_error_key):
+        """Test metrics sections return unavailable when Redis fails"""
         with patch('src.routes.metrics._get_redis_client', return_value=None):
             with patch('src.routes.metrics._get_orchestrator_metrics', return_value=None):
                 response = client.get('/api/metrics')
 
                 assert response.status_code == 200
                 data = response.get_json()
-                assert data['api']['available'] is False
-                assert 'error' in data['api']
-
-    def test_rate_limit_metrics_redis_unavailable(self, client):
-        """Test rate limit metrics returns unavailable when Redis fails"""
-        with patch('src.routes.metrics._get_redis_client', return_value=None):
-            with patch('src.routes.metrics._get_orchestrator_metrics', return_value=None):
-                response = client.get('/api/metrics')
-
-                assert response.status_code == 200
-                data = response.get_json()
-                assert data['rate_limit']['available'] is False
-
-    def test_session_metrics_redis_unavailable(self, client):
-        """Test session metrics returns unavailable when Redis fails"""
-        with patch('src.routes.metrics._get_redis_client', return_value=None):
-            with patch('src.routes.metrics._get_orchestrator_metrics', return_value=None):
-                response = client.get('/api/metrics')
-
-                assert response.status_code == 200
-                data = response.get_json()
-                assert data['session_commands']['available'] is False
+                assert data[section]['available'] is False
+                if expect_error_key:
+                    assert 'error' in data[section]
 
 
 class TestWindowParameterValidation:


### PR DESCRIPTION
## 描述 (Description)

將 `TestMetricsRedisUnavailable` 類別中 3 個重複的測試方法合併為 1 個參數化測試，減少程式碼重複並提高可維護性。

**變更內容：**
- 合併 `test_api_metrics_redis_unavailable`、`test_rate_limit_metrics_redis_unavailable`、`test_session_metrics_redis_unavailable` 為單一參數化測試
- 使用 `expect_error_key` 參數保留 API section 特有的 `'error'` key 檢查

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)** - 測試程式碼重構

## 本 PR 不處理 (Out of Scope)

- 其他測試檔案的類似重構
- 移除未使用的 `mock_redis` fixture（該 fixture 實際上有被其他測試使用）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests)

### 測試步驟 (Test Steps)

1. 執行 `pytest handoff/20250928/40_App/api-backend/tests/test_metrics_routes.py -v`
2. 確認 `TestMetricsRedisUnavailable` 類別產生 3 個測試案例

### 預期結果 (Expected Results)

- 參數化測試產生 3 個測試案例（api、rate_limit、session_commands）
- 所有測試通過
- 測試覆蓋率與重構前相同

### 測試環境 (Test Environment)

- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- `test_metrics_routes.py` 測試檔案

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`pnpm lint`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義（無新增）

## Human Review Checklist

請特別審查以下項目：

1. **參數化測試覆蓋率** - 確認 3 個參數組合（api/rate_limit/session_commands）正確對應原本的 3 個測試
2. **expect_error_key 邏輯** - 確認只有 `api` section 會檢查 `'error'` key，與原本行為一致

---

**Link to Devin run**: https://app.devin.ai/sessions/58f14d5c88f14fbfb716d279cce70a86
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918