### PR TITLE
refactor(orchestrator): improve _determine_cost_action and add reload_policies (#2345, #2346)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/governance/runtime_policy_enforcer.py
+++ b/handoff/20250928/40_App/orchestrator/governance/runtime_policy_enforcer.py
@@ -160,17 +160,28 @@ class RuntimePolicyEnforcer:
         """
         Reload runtime policies from settings / configuration source.
 
-        This method resets the lazy-loaded policy components so they will
-        be re-initialized with fresh settings on next access. Thread-safe
-        when used with the global enforcer via _enforcer_lock.
+        This method:
+        1. Reloads global settings via reload_settings()
+        2. Resets PolicyGuard and CostTracker global singletons
+        3. Resets this instance's lazy-loaded references
+
+        Thread-safe when used with the global enforcer via _enforcer_lock.
+        Note: Does NOT overwrite self.settings to preserve custom settings
+        passed during initialization (e.g., in tests).
 
         Use cases:
         - Dynamic configuration updates without restart
         - Testing with different policy configurations
         - Hot-reloading after Owner Console policy changes
         """
-        from common.config.settings import settings as global_settings
-        self.settings = global_settings
+        from common.config.settings import reload_settings
+        import governance.policy_guard as policy_guard_module
+        import governance.cost_tracker as cost_tracker_module
+
+        reload_settings()
+
+        policy_guard_module._policy_guard = None
+        cost_tracker_module._cost_tracker = None
 
         self._policy_guard = None
         self._cost_tracker = None


### PR DESCRIPTION
## 描述 (Description)

此 PR 修復 RuntimePolicyEnforcer 的兩個問題：

**#2345 - `_determine_cost_action` 未使用參數**：
- `budget_type`、`current`、`limit` 參數原本完全未使用
- 現在使用這些參數進行增強日誌記錄（計算 `overage_ratio` 並記錄決策上下文）
- 行為不變，但參數現在被積極使用於可觀測性

**#2346 - 新增 `reload_policies()` 方法**：
- 實例方法 `reload_policies()` 重置 lazy-loaded 組件
- 模組層級輔助函數 `reload_runtime_policies()` 用於全域 singleton
- 支援動態配置更新、測試和 Owner Console policy 變更後的熱重載

### Updates since last revision

**修復 `reload_policies()` 實作**：
- 現在調用 `reload_settings()` 重載全域設定
- 重置 `PolicyGuard` 和 `CostTracker` 模組層級 singletons（`policy_guard_module._policy_guard = None`）
- **不再覆寫 `self.settings`**，保留自訂設定（如測試中傳入的設定）
- 更新 docstring 說明重載行為

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)** - 必須立即處理，阻擋主線進度
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 重要但不阻擋主線
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)** - 可排期處理

**對應 GitHub Labels**: `P1`, `enhancement`

## 本 PR 不處理 (Out of Scope)

- 根據 `budget_type` 或 `overage_ratio` 實作不同的 action 策略（保留給未來擴展）
- 新增 `reload_policies()` 的單元測試（現有測試通過，可在 follow-up 中補充）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest`
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. 執行 `pytest handoff/20250928/40_App/orchestrator/governance/tests/test_runtime_policy_enforcer.py -v`
2. 確認所有 23 個測試案例通過

### 預期結果 (Expected Results)

所有現有測試通過，無回歸（23 passed）

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)


- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] 所有測試通過：23 passed
- [x] 程式碼遵循現有模式和慣例
- [ ] ESLint 通過 - N/A (Python)
- [ ] TypeScript 類型檢查通過 - N/A (Python)

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 避免使用已廢棄的目錄

## Human Review Checklist

請特別審查以下項目：

1. **直接存取私有變數**：`reload_policies()` 直接設置 `policy_guard_module._policy_guard = None` 和 `cost_tracker_module._cost_tracker = None`。這是重置 singletons 的唯一方式，但存取私有變數可能在未來重構時出問題。

2. **線程安全**：`reload_policies()` 實例方法本身不獲取 `_enforcer_lock`。只有透過 `reload_runtime_policies()` 調用時才是線程安全的。直接調用 `enforcer.reload_policies()` 可能有競爭條件。

3. **日誌級別**：`_determine_cost_action` 使用 `logger.debug()`，只有在啟用 debug 日誌時才可見。

4. **測試覆蓋**：新增的 `reload_policies()` 和 `reload_runtime_policies()` 沒有專門的測試。

---

**Link to Devin run**: https://app.devin.ai/sessions/58f14d5c88f14fbfb716d279cce70a86
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918
**Closes**: #2345, #2346