### PR TITLE
feat(orchestrator): implement VSCodeIDEService._initialize_session (#2243)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py
@@ -1083,11 +1083,14 @@ class TestInitializeSession:
 
         assert mock_session.metadata.get("code_server_url") == "http://localhost:8443"
         assert "initialized_at" in mock_session.metadata
+        assert shell_call_count >= 3
+        assert mcp_call_count >= 1
 
     @pytest.mark.asyncio
     async def test_initialize_session_starts_code_server(self, service, mock_session):
         """Test initialization starts code-server when not running"""
         call_sequence = []
+        mcp_call_count = 0
 
         async def mock_shell(session, command, timeout_seconds=60):
             call_sequence.append(command)
@@ -1099,11 +1102,13 @@ class TestInitializeSession:
                 return {"success": True, "exit_code": 0, "stdout": "12345", "stderr": ""}
             if "mkdir -p" in command:
                 return {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
-            if "echo" in command:
+            if "base64" in command:
                 return {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
             return {"success": True, "exit_code": 0, "stdout": "", "stderr": ""}
 
         async def mock_mcp(session, endpoint, payload, timeout_seconds=30):
+            nonlocal mcp_call_count
+            mcp_call_count += 1
             return {"success": True}
 
         service._execute_shell_command = mock_shell
@@ -1113,6 +1118,8 @@ class TestInitializeSession:
 
         assert any("code-server --bind-addr" in cmd for cmd in call_sequence)
         assert mock_session.metadata.get("code_server_url") == "http://localhost:8443"
+        assert len(call_sequence) >= 5
+        assert mcp_call_count >= 1
 
     @pytest.mark.asyncio
     async def test_initialize_session_code_server_fails_to_start(
@@ -1177,4 +1184,4 @@ class TestInitializeSession:
 
         await service._initialize_session(mock_session)
 
-        assert any("echo" in cmd and "settings.json" in cmd for cmd in shell_commands)
+        assert any("base64" in cmd and "settings.json" in cmd for cmd in shell_commands)

--- a/handoff/20250928/40_App/orchestrator/meta_agent/vscode_ide.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/vscode_ide.py
@@ -26,6 +26,8 @@ Features:
 """
 
 import asyncio
+import base64
+import json
 import logging
 import shlex
 from dataclasses import dataclass, field
@@ -277,6 +279,12 @@ class VSCodeIDEService:
     DEFAULT_VSCODE_PORT = 8443
     DEFAULT_MCP_PORT = 8080
 
+    # Default VS Code workspace settings (#2243)
+    DEFAULT_VSCODE_SETTINGS: Dict[str, Any] = {
+        "editor.formatOnSave": True,
+        "editor.tabSize": 4,
+    }
+
     # Supported formatters by language
     FORMATTERS: Dict[Language, str] = {
         Language.PYTHON: "black",
@@ -433,9 +441,10 @@ class VSCodeIDEService:
             session_id, workspace_path
         )
 
+        port = self.DEFAULT_VSCODE_PORT
         health_check = await self._execute_shell_command(
             session,
-            "pgrep -f code-server || curl -s http://127.0.0.1:8443/healthz",
+            f"pgrep -f code-server || curl -s http://127.0.0.1:{port}/healthz",
             timeout_seconds=10,
         )
 
@@ -446,7 +455,7 @@ class VSCodeIDEService:
             )
             start_result = await self._execute_shell_command(
                 session,
-                f"code-server --bind-addr 0.0.0.0:8443 --auth none {shlex.quote(workspace_path)} &",
+                f"code-server --bind-addr 0.0.0.0:{port} --auth none {shlex.quote(workspace_path)} &",
                 timeout_seconds=10,
             )
 
@@ -487,7 +496,7 @@ class VSCodeIDEService:
 
         vscode_dir = f"{workspace_path}/.vscode"
         settings_path = f"{vscode_dir}/settings.json"
-        default_settings = '{"editor.formatOnSave": true, "editor.tabSize": 4}'
+        settings_json = json.dumps(self.DEFAULT_VSCODE_SETTINGS, separators=(",", ":"))
 
         await self._execute_shell_command(
             session,
@@ -500,15 +509,16 @@ class VSCodeIDEService:
             "file/write",
             {
                 "file_path": settings_path,
-                "content": default_settings,
+                "content": settings_json,
             },
             timeout_seconds=10,
         )
 
         if not settings_result.get("success"):
+            settings_b64 = base64.b64encode(settings_json.encode("utf-8")).decode("ascii")
             fallback_result = await self._execute_shell_command(
                 session,
-                f"echo '{default_settings}' > {shlex.quote(settings_path)}",
+                f"printf '%s' {shlex.quote(settings_b64)} | base64 -d > {shlex.quote(settings_path)}",
                 timeout_seconds=10,
             )
             if not fallback_result.get("success"):


### PR DESCRIPTION
## 描述 (Description)

實作 `VSCodeIDEService._initialize_session` 方法，將原本的空 stub 變成真正會啟動 VM 內 code-server 的初始化流程。

**主要變更**：
- 透過 `pgrep` 和 health check 檢查 code-server 是否已在運行
- 若未運行，啟動 code-server（`--bind-addr 0.0.0.0:8443 --auth none`）
- 確保 workspace 目錄存在
- 建立 `.vscode/settings.json` 預設設定（MCP file/write 優先，shell fallback）
- 在 session metadata 中記錄 `code_server_url` 和 `initialized_at`

## Updates since last revision

**Code review improvements (#6-#10)**:
- **#6/#7**: 將硬編碼 port 8443 改用 `self.DEFAULT_VSCODE_PORT` 常數
- **#8**: 將 `default_settings` 提升為 class constant `DEFAULT_VSCODE_SETTINGS`
- **#9**: Shell fallback 改用 base64 編碼避免特殊字元風險（`printf '%s' <base64> | base64 -d > settings.json`）
- **#10**: 測試補充 call count 斷言（`shell_call_count >= 3`, `mcp_call_count >= 1`）
- 更新 `test_initialize_session_settings_fallback` 檢查 `base64` 而非 `echo`

**Previous revision**:
- 修復現有測試：在 8 個現有測試中 mock `_initialize_session` 為 no-op

## PR 類型與優先級 (PR Type & Priority)

- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 重要但不阻擋主線

## 本 PR 不處理 (Out of Scope)

- code-server 認證強化（目前使用 `auth: none`）- 接受為 v1 限制
- `asyncio.sleep(2)` 競態條件改進 - 接受為 v1 限制
- CORS 設定（iframe 嵌入需要）
- Extension 自動安裝
- 資源限制監控

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - `pytest`

### 測試步驟 (Test Steps)

```bash
cd ~/repos/morningai
source .venv/bin/activate
pytest handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py::TestInitializeSession -v
```

### 預期結果 (Expected Results)

5 個測試全部通過：
- `test_initialize_session_code_server_already_running` - code-server 已運行時跳過啟動
- `test_initialize_session_starts_code_server` - code-server 未運行時啟動
- `test_initialize_session_code_server_fails_to_start` - 啟動失敗時拋出 RuntimeError
- `test_initialize_session_workspace_creation_fails` - workspace 建立失敗時拋出 RuntimeError
- `test_initialize_session_settings_fallback` - MCP 失敗時使用 shell fallback（base64 編碼）

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- `VSCodeIDEService.create_session()` - 呼叫 `_initialize_session`
- IDE session 初始化流程

### 新增的自動化測試 (New Automated Tests)

- `handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py::TestInitializeSession` (5 個測試案例)

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

## 程式碼品質檢查

- [x] ESLint 通過（0 warnings）：`flake8`
- [x] 所有測試通過：`pytest`
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 不適用 - 此 PR 不需要文檔更新

## Human Review Checklist

請特別審閱以下項目：

1. **Shell 命令正確性** - 確認 `pgrep -f code-server` 和 `code-server --bind-addr` 命令在 VM 環境中正確運作
2. **base64 命令可用性** - 確認 VM 環境中有 `base64` 命令（用於 settings.json fallback）
3. **路徑安全性** - 使用 `shlex.quote()` 防止 shell injection，請確認是否完整
4. **錯誤處理** - 確認 RuntimeError 的錯誤訊息是否足夠清晰
5. **測試隔離策略** - 現有測試 mock `_initialize_session` 為 no-op，確保測試專注於各自的職責
6. **v1 限制** - `asyncio.sleep(2)` 和 `auth: none` 已接受為 v1 限制，後續 issue 追蹤

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義（無新增）

---

**Link to Devin run**: https://app.devin.ai/sessions/58f14d5c88f14fbfb716d279cce70a86
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918