### PR TITLE
refactor(design-tokens): unify KPI icon style to FailureExperiment standard

### DIFF
--- a/DESIGN_SYSTEM_GUIDELINES.md
+++ b/DESIGN_SYSTEM_GUIDELINES.md
@@ -732,14 +732,15 @@ Dashboard 卡片組件的 icon 規格分為兩種 archetype，定義於 `tokens.
 **用途**: 數據指標展示卡片，強調數值視覺化
 
 **規格**:
-- Icon 大小: `40px` (CSS: `var(--card-icon-kpi-size)`)
-- 容器大小: `40px` (CSS: `var(--card-icon-kpi-containerSize)`)
+- Icon 大小: `16px` (CSS: `var(--card-icon-kpi-size)`)
+- 容器大小: `32px` (CSS: `var(--card-icon-kpi-containerSize)`)
 - 形狀: `circle` (圓形)
 
 **使用場景**:
 - 總覽頁面的 KPI 指標
 - 數據儀表板的統計數字
 - 需要強調數值的卡片
+- 故障實驗頁面的統計卡片
 
 **範例**:
 ```jsx

--- a/handoff/20250928/40_App/frontend-dashboard/public/tokens.json
+++ b/handoff/20250928/40_App/frontend-dashboard/public/tokens.json
@@ -215,10 +215,10 @@
   "card": {
     "icon": {
       "kpi": {
-        "size": "40px",
-        "containerSize": "40px",
+        "size": "16px",
+        "containerSize": "32px",
         "shape": "9999px",
-        "description": "KPI/metric cards - large circular icon for data visualization emphasis"
+        "description": "KPI/metric cards - compact circular icon matching FailureExperiment style"
       },
       "status": {
         "size": "16px",

--- a/handoff/20250928/40_App/frontend-dashboard/src/tokens.json
+++ b/handoff/20250928/40_App/frontend-dashboard/src/tokens.json
@@ -215,10 +215,10 @@
   "card": {
     "icon": {
       "kpi": {
-        "size": "40px",
-        "containerSize": "40px",
+        "size": "16px",
+        "containerSize": "32px",
         "shape": "9999px",
-        "description": "KPI/metric cards - large circular icon for data visualization emphasis"
+        "description": "KPI/metric cards - compact circular icon matching FailureExperiment style"
       },
       "status": {
         "size": "16px",

--- a/handoff/20250928/40_App/owner-console/public/tokens.json
+++ b/handoff/20250928/40_App/owner-console/public/tokens.json
@@ -215,10 +215,10 @@
   "card": {
     "icon": {
       "kpi": {
-        "size": "40px",
-        "containerSize": "40px",
+        "size": "16px",
+        "containerSize": "32px",
         "shape": "9999px",
-        "description": "KPI/metric cards - large circular icon for data visualization emphasis"
+        "description": "KPI/metric cards - compact circular icon matching FailureExperiment style"
       },
       "status": {
         "size": "16px",

--- a/handoff/20250928/40_App/owner-console/src/tokens.json
+++ b/handoff/20250928/40_App/owner-console/src/tokens.json
@@ -215,10 +215,10 @@
   "card": {
     "icon": {
       "kpi": {
-        "size": "40px",
-        "containerSize": "40px",
+        "size": "16px",
+        "containerSize": "32px",
         "shape": "9999px",
-        "description": "KPI/metric cards - large circular icon for data visualization emphasis"
+        "description": "KPI/metric cards - compact circular icon matching FailureExperiment style"
       },
       "status": {
         "size": "16px",

--- a/packages/shared-ui/src/components/dashboard/stat-card.tsx
+++ b/packages/shared-ui/src/components/dashboard/stat-card.tsx
@@ -82,14 +82,14 @@ function StatCard({
           <div
             className={cn(
               "flex items-center justify-center ml-3 shrink-0",
-              "h-[var(--card-icon-kpi-containerSize,40px)] w-[var(--card-icon-kpi-containerSize,40px)]",
+              "h-[var(--card-icon-kpi-containerSize,32px)] w-[var(--card-icon-kpi-containerSize,32px)]",
               "rounded-[var(--card-icon-kpi-shape,9999px)]",
               variantStyles[variant]
             )}
           >
             {React.isValidElement(icon)
               ? React.cloneElement(icon as React.ReactElement<{ className?: string }>, {
-                  className: "w-[var(--card-icon-kpi-size,40px)] h-[var(--card-icon-kpi-size,40px)]",
+                  className: "w-[var(--card-icon-kpi-size,16px)] h-[var(--card-icon-kpi-size,16px)]",
                 })
               : icon}
           </div>

--- a/packages/shared-ui/src/tokens.json
+++ b/packages/shared-ui/src/tokens.json
@@ -215,10 +215,10 @@
   "card": {
     "icon": {
       "kpi": {
-        "size": "40px",
-        "containerSize": "40px",
+        "size": "16px",
+        "containerSize": "32px",
         "shape": "9999px",
-        "description": "KPI/metric cards - large circular icon for data visualization emphasis"
+        "description": "KPI/metric cards - compact circular icon matching FailureExperiment style"
       },
       "status": {
         "size": "16px",


### PR DESCRIPTION
## 描述 (Description)

統一 KPI 卡片 icon 規格，將所有使用 StatCard 的頁面 icon 樣式改為「故障實驗」頁面的標準：
- 容器大小：40px → 32px
- Icon 大小：40px → 16px

此變更解決了專案中存在的三種不同 icon 實作風格問題，統一採用用戶偏好的緊湊圓形樣式。

### Updates since last revision

- Fixed Design Tokens Drift Check CI failure by syncing `public/tokens.json` files with canonical source

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 統一設計系統 icon 規格
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- 遷移 FailureExperimentDashboard 頁面使用 StatCard 組件
- 遷移 ApprovalQueue 頁面使用 StatCard 組件
- 視覺回歸測試 (VRT) 建立

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [x] 單元測試 (Unit Tests) - 現有測試應通過
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [x] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 開啟 Agent 治理頁面，確認 StatCard icon 變為 32×32 容器 + 16×16 icon
2. 比較與故障實驗頁面的 icon 樣式是否一致
3. 確認 Storybook 中 StatCard 組件顯示正確

### 預期結果 (Expected Results)

所有使用 StatCard 的頁面 icon 應顯示為 32×32px 圓形容器內的 16×16px icon

### 受影響的區域 (Affected Areas)

- Agent 治理頁面 (AgentGovernance) - 使用 StatCard 的 KPI 卡片
- 任何其他使用 StatCard 組件的頁面

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更（僅 token 數值變更）

## 設計系統檢查 (Design System Checklist)

- [x] 如使用設計 tokens，我已從 `@morningai/shared-ui` 匯入而非硬編碼
- [x] 新元件已加入 Storybook story（StatCard 已有 story）

### Shared-UI Import 合規性（強制）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] ESLint 通過（僅 warnings，無 errors）
- [x] TypeScript 類型檢查通過
- [x] 無 `any` 類型
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] 已更新 `DESIGN_SYSTEM_GUIDELINES.md` 中的 KPI Archetype 規格

## 人工審查重點 (Human Review Checklist)


- [ ] **視覺確認（重要）**：Icon 從 40×40px 縮小到 16×16px 是顯著變化，請確認視覺效果符合預期
- [ ] **Token 同步**：確認 6 個 tokens.json 檔案內容一致（shared-ui, owner-console, frontend-dashboard 的 src 和 public 目錄）
- [ ] **Fallback 值**：StatCard 組件的 fallback 值 (32px, 16px) 與 tokens.json 一致

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式
- [x] 避免使用已廢棄的目錄

---

**Link to Devin run**: https://app.devin.ai/sessions/02796fc310e24aac8ece2b37c1a2b2cd
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918

Relates to Epic #2304 Phase 1