### PR TITLE
fix(audit): distinguish raw vs fallback hex colors in regression guard

### DIFF
--- a/.design-system-baseline.json
+++ b/.design-system-baseline.json
@@ -1,7 +1,10 @@
 {
-  "updated": "2025-12-13T06:43:46Z",
-  "hex_colors": 494,
+  "updated": "2025-12-14T09:08:28Z",
+  "hex_colors": 395,
+  "hex_colors_raw": 395,
+  "hex_colors_fallback": 144,
+  "hex_colors_total": 539,
   "inline_styles": 49,
   "shared_ui_components": 54,
-  "story_files": 21
+  "story_files": 34
 }

--- a/DESIGN_SYSTEM_GUIDELINES.md
+++ b/DESIGN_SYSTEM_GUIDELINES.md
@@ -1520,9 +1520,72 @@ input, select, textarea {
 #### 當前健康指標
 
 ```
-✓ PASSED:   22 / 24 檢查項目
-⚠ WARNINGS:  1 / 24 (可訪問性測試文件不足)
-✗ FAILED:    1 / 24 (硬編碼顏色過多: 494 處)
+✓ PASSED:   23 / 24 檢查項目
+⚠ WARNINGS:  0 / 24
+✗ FAILED:    1 / 24 (Raw hex colors: 395，目標 <50)
+```
+
+#### Raw Hex vs Fallback Hex 計算規則
+
+設計系統審計腳本區分兩種類型的 hex color 使用：
+
+**Raw Hex Colors（直接使用）**：
+- 定義：直接在 CSS/TSX 中使用的硬編碼顏色，如 `color: #005A9C`
+- 問題：繞過 design token 系統，難以維護主題一致性
+- 目標：減少至 50 處以下
+- Regression Guard：**會阻擋** raw hex 數量增加
+
+**Fallback Hex Colors（CSS 變數 fallback）**：
+- 定義：在 CSS 變數 fallback 中使用的顏色，如 `color: var(--color-primary, #005A9C)`
+- 用途：提供韌性，當 CSS 變數未定義時仍能正常顯示
+- 目標：允許存在，但應追蹤趨勢
+- Regression Guard：**不會阻擋** fallback hex 數量增加
+
+**計算方式**：
+```bash
+# Total hex colors（所有 hex 色碼）
+grep -rE "#[0-9A-Fa-f]{6}\b|#[0-9A-Fa-f]{3}\b" src/ --include="*.css" --include="*.tsx"
+
+# Fallback hex colors（在 var() 內的 hex）
+grep -rE "#[0-9A-Fa-f]{6}\b|#[0-9A-Fa-f]{3}\b" src/ --include="*.css" --include="*.tsx" | grep "var("
+
+# Raw hex colors = Total - Fallback
+```
+
+**Baseline 格式**（`.design-system-baseline.json`）：
+```json
+{
+  "hex_colors": 395,        // Raw hex（用於 regression guard）
+  "hex_colors_raw": 395,    // 同上，明確標示
+  "hex_colors_fallback": 144, // Fallback hex（追蹤用）
+  "hex_colors_total": 539   // 總計
+}
+```
+
+**已知限制**：
+- 多行 `var()` 語法可能導致誤判
+- 同一行同時有 raw hex 和 var() fallback 時，整行被計為 fallback
+- 審計針對 source code，不檢查 build 產物
+
+#### Build Pipeline 一致性要求
+
+為確保 fallback hex 在 production 環境正常運作，build pipeline **不得**將 `var(--token, #fallback)` 展開為單純的 `#fallback`。
+
+**當前配置**（已驗證安全）：
+- Vite + @vitejs/plugin-react：不轉換 CSS 變數
+- @tailwindcss/vite：不轉換 CSS 變數
+- 無 postcss-custom-properties、postcss-preset-env、cssnano 等變數展開插件
+
+**禁止使用的插件**：
+- `postcss-custom-properties`（會展開 CSS 變數）
+- `postcss-preset-env` 的 custom properties 功能
+- 任何會將 `var()` fallback 提取為獨立值的 CSS optimizer
+
+**驗證方式**：
+```bash
+# 檢查 build 產物是否保留 var() fallback
+pnpm build
+grep -r "var(--" dist/assets/*.css | head -5
 ```
 
 #### CI/CD 整合
@@ -1547,9 +1610,9 @@ input, select, textarea {
 
 > **注意**: 以下項目為設計系統健康度改進目標，與 Epic #2304 的 Phase 結構無關。
 
-1. **減少硬編碼顏色**: 目標從 494 處降至 50 處以下
-2. **增加可訪問性測試**: 目標 3+ 個專用測試文件
-3. **Storybook 覆蓋率**: 目標從 40% 提升至 80%
+1. **減少 Raw Hex Colors**: 目標從 395 處降至 50 處以下（已從 488 改善至 395）
+2. **增加可訪問性測試**: ✅ 已達成 3+ 個專用測試文件
+3. **Storybook 覆蓋率**: 目標從 40% 提升至 80%（目前 34 個 story files）
 4. **視覺回歸測試 (VRT)**: 建立自動化視覺測試
 
 ---

--- a/DESIGN_SYSTEM_GUIDELINES.md
+++ b/DESIGN_SYSTEM_GUIDELINES.md
@@ -1546,8 +1546,9 @@ input, select, textarea {
 # Total hex colors（所有 hex 色碼）
 grep -rE "#[0-9A-Fa-f]{6}\b|#[0-9A-Fa-f]{3}\b" src/ --include="*.css" --include="*.tsx"
 
-# Fallback hex colors（在 var() 內的 hex）
-grep -rE "#[0-9A-Fa-f]{6}\b|#[0-9A-Fa-f]{3}\b" src/ --include="*.css" --include="*.tsx" | grep "var("
+# Fallback hex colors（在 var() fallback 位置，逗號後的 hex）
+# Pattern: var(--token, #hex) - 精確匹配 CSS 變數 fallback
+grep -rE "var\([^)]*,[[:space:]]*#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?" src/ --include="*.css" --include="*.tsx"
 
 # Raw hex colors = Total - Fallback
 ```

--- a/audit-design-system.sh
+++ b/audit-design-system.sh
@@ -196,19 +196,36 @@ fi
 log_section "3. Design Tokens Enforcement"
 
 # Check for hard-coded hex colors in frontend apps (excluding node_modules, dist, .stories files)
-HEX_COLORS=$(grep -rE "#[0-9A-Fa-f]{6}\b|#[0-9A-Fa-f]{3}\b" \
+# We distinguish between:
+# - RAW hex colors: Direct usage like "color: #005A9C" - these are the real problem
+# - FALLBACK hex colors: Inside var() like "var(--token, #005A9C)" - acceptable for resilience
+HEX_COLORS_TOTAL=$(grep -rE "#[0-9A-Fa-f]{6}\b|#[0-9A-Fa-f]{3}\b" \
   "$FRONTEND_DASHBOARD_SRC" \
   "$OWNER_CONSOLE_SRC" \
   --include="*.tsx" --include="*.ts" --include="*.css" \
   --exclude-dir=node_modules --exclude="*.stories.*" \
   2>/dev/null | wc -l || echo "0")
 
-if [ "$HEX_COLORS" -le 50 ]; then
-  log_pass "Hard-coded hex colors: $HEX_COLORS (target: <50)"
-elif [ "$HEX_COLORS" -le 150 ]; then
-  log_warn "Hard-coded hex colors: $HEX_COLORS (target: <50, acceptable: <150)"
+# Count fallback hex colors (inside var() functions)
+HEX_COLORS_FALLBACK=$(grep -rE "#[0-9A-Fa-f]{6}\b|#[0-9A-Fa-f]{3}\b" \
+  "$FRONTEND_DASHBOARD_SRC" \
+  "$OWNER_CONSOLE_SRC" \
+  --include="*.tsx" --include="*.ts" --include="*.css" \
+  --exclude-dir=node_modules --exclude="*.stories.*" \
+  2>/dev/null | grep "var(" | wc -l || echo "0")
+
+# Raw hex colors = Total - Fallback (these are the ones we want to reduce)
+HEX_COLORS_RAW=$((HEX_COLORS_TOTAL - HEX_COLORS_FALLBACK))
+
+# For backward compatibility, HEX_COLORS now refers to raw hex colors
+HEX_COLORS=$HEX_COLORS_RAW
+
+if [ "$HEX_COLORS_RAW" -le 50 ]; then
+  log_pass "Raw hex colors: $HEX_COLORS_RAW (target: <50) [fallback: $HEX_COLORS_FALLBACK, total: $HEX_COLORS_TOTAL]"
+elif [ "$HEX_COLORS_RAW" -le 150 ]; then
+  log_warn "Raw hex colors: $HEX_COLORS_RAW (target: <50, acceptable: <150) [fallback: $HEX_COLORS_FALLBACK]"
 else
-  log_fail "Too many hard-coded hex colors: $HEX_COLORS (target: <50)"
+  log_fail "Too many raw hex colors: $HEX_COLORS_RAW (target: <50) [fallback: $HEX_COLORS_FALLBACK]"
 fi
 
 # Check for inline styles
@@ -427,8 +444,11 @@ TODO=$TODO_COUNT
 TOTAL=$TOTAL_CHECKS
 MODE=$MODE_LABEL
 HEX_COLORS=$HEX_COLORS
+HEX_COLORS_RAW=$HEX_COLORS_RAW
+HEX_COLORS_FALLBACK=$HEX_COLORS_FALLBACK
+HEX_COLORS_TOTAL=$HEX_COLORS_TOTAL
 INLINE_STYLES=$INLINE_STYLES
-NOTES=Full audit with all 8 sections implemented. Epic #2304 Phase 0-1 complete.
+NOTES=Full audit with all 8 sections implemented. Epic #2304 Phase 0-1 complete. Raw/fallback hex color tracking added.
 EOF
 
 log_info "Summary written to $SUMMARY_FILE"
@@ -444,14 +464,19 @@ log_info "Summary written to $SUMMARY_FILE"
 REGRESSION_DETECTED=false
 
 if [ -f "$BASELINE_FILE" ]; then
-  # Note: JSON format has space after colon, e.g. "hex_colors": 494
-  BASELINE_HEX=$(grep -o '"hex_colors": *[0-9]*' "$BASELINE_FILE" 2>/dev/null | grep -o '[0-9]*' || echo "0")
+  # Check for new format first (hex_colors_raw), fall back to old format (hex_colors)
+  BASELINE_HEX_RAW=$(grep -o '"hex_colors_raw": *[0-9]*' "$BASELINE_FILE" 2>/dev/null | grep -o '[0-9]*' || echo "")
+  if [ -z "$BASELINE_HEX_RAW" ]; then
+    # Fall back to old format for backward compatibility
+    BASELINE_HEX_RAW=$(grep -o '"hex_colors": *[0-9]*' "$BASELINE_FILE" 2>/dev/null | grep -o '[0-9]*' || echo "0")
+  fi
   
-  if [ -n "$BASELINE_HEX" ] && [ "$HEX_COLORS" -gt "$BASELINE_HEX" ] && [ "$BASELINE_HEX" -gt 0 ]; then
-    echo -e "${RED}❌ REGRESSION DETECTED: Hard-coded hex colors increased from $BASELINE_HEX to $HEX_COLORS${NC}"
+  # Regression guard now uses RAW hex colors (excluding var() fallbacks)
+  if [ -n "$BASELINE_HEX_RAW" ] && [ "$HEX_COLORS_RAW" -gt "$BASELINE_HEX_RAW" ] && [ "$BASELINE_HEX_RAW" -gt 0 ]; then
+    echo -e "${RED}❌ REGRESSION DETECTED: Raw hex colors increased from $BASELINE_HEX_RAW to $HEX_COLORS_RAW${NC}"
     REGRESSION_DETECTED=true
-  elif [ -n "$BASELINE_HEX" ] && [ "$HEX_COLORS" -lt "$BASELINE_HEX" ]; then
-    echo -e "${GREEN}✓ IMPROVEMENT: Hard-coded hex colors decreased from $BASELINE_HEX to $HEX_COLORS${NC}"
+  elif [ -n "$BASELINE_HEX_RAW" ] && [ "$HEX_COLORS_RAW" -lt "$BASELINE_HEX_RAW" ]; then
+    echo -e "${GREEN}✓ IMPROVEMENT: Raw hex colors decreased from $BASELINE_HEX_RAW to $HEX_COLORS_RAW${NC}"
   fi
 fi
 
@@ -462,6 +487,9 @@ for arg in "$@"; do
 {
   "updated": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "hex_colors": $HEX_COLORS,
+  "hex_colors_raw": $HEX_COLORS_RAW,
+  "hex_colors_fallback": $HEX_COLORS_FALLBACK,
+  "hex_colors_total": $HEX_COLORS_TOTAL,
   "inline_styles": $INLINE_STYLES,
   "shared_ui_components": $SHARED_UI_COMPONENTS,
   "story_files": $STORY_FILES

--- a/audit-design-system.sh
+++ b/audit-design-system.sh
@@ -206,13 +206,15 @@ HEX_COLORS_TOTAL=$(grep -rE "#[0-9A-Fa-f]{6}\b|#[0-9A-Fa-f]{3}\b" \
   --exclude-dir=node_modules --exclude="*.stories.*" \
   2>/dev/null | wc -l || echo "0")
 
-# Count fallback hex colors (inside var() functions)
-HEX_COLORS_FALLBACK=$(grep -rE "#[0-9A-Fa-f]{6}\b|#[0-9A-Fa-f]{3}\b" \
+# Count fallback hex colors (specifically in var() fallback position, after comma)
+# Pattern: var(--token, #hex) - matches hex colors that are CSS variable fallbacks
+# Using [[:space:]]* for POSIX compatibility instead of \s
+HEX_COLORS_FALLBACK=$(grep -rE "var\([^)]*,[[:space:]]*#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?" \
   "$FRONTEND_DASHBOARD_SRC" \
   "$OWNER_CONSOLE_SRC" \
   --include="*.tsx" --include="*.ts" --include="*.css" \
   --exclude-dir=node_modules --exclude="*.stories.*" \
-  2>/dev/null | grep "var(" | wc -l || echo "0")
+  2>/dev/null | wc -l || echo "0")
 
 # Raw hex colors = Total - Fallback (these are the ones we want to reduce)
 HEX_COLORS_RAW=$((HEX_COLORS_TOTAL - HEX_COLORS_FALLBACK))

--- a/audit-summary.txt
+++ b/audit-summary.txt
@@ -1,9 +1,12 @@
-PASS=22
-WARN=1
+PASS=23
+WARN=0
 FAIL=1
 TODO=0
 TOTAL=24
 MODE=relaxed
-HEX_COLORS=494
+HEX_COLORS=395
+HEX_COLORS_RAW=395
+HEX_COLORS_FALLBACK=144
+HEX_COLORS_TOTAL=539
 INLINE_STYLES=49
-NOTES=Full audit with all 8 sections implemented. Epic #2304 Phase 0-1 complete.
+NOTES=Full audit with all 8 sections implemented. Epic #2304 Phase 0-1 complete. Raw/fallback hex color tracking added.


### PR DESCRIPTION
## 描述 (Description)

修復設計系統審計腳本的 hex colors 回退誤判問題。

CSS 變數重構工作（Epic #2304）將硬編碼顏色改為 `var(--token, #fallback)` 格式，導致總 hex color 數量從 494 增加到 539，觸發了 CI regression guard。然而這實際上是改善：
- **Raw hex colors**（直接使用）：從 488 降至 395（改善 93 個）
- **Fallback hex colors**（在 var() 內）：從 6 增至 144（預期行為）

此 PR 修改審計腳本，區分 raw 和 fallback hex colors，regression guard 現在只阻擋 raw hex colors 的增加。

### Updates since last revision

**Regex 精確度改進**：
- 將 fallback hex 偵測從簡單的 `grep "var("` 改為精確的 regex pattern：
  ```
  var\([^)]*,[[:space:]]*#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?
  ```
- 此 pattern 專門匹配 var() fallback 位置（逗號後）的 hex colors
- 使用 POSIX `[[:space:]]*` 確保跨平台相容性
- 同步更新 `DESIGN_SYSTEM_GUIDELINES.md` 中的計算方式範例

**文檔更新**：
- 在 `DESIGN_SYSTEM_GUIDELINES.md` 新增「Raw Hex vs Fallback Hex 計算規則」章節
- 說明 baseline JSON 格式變更（新增 `hex_colors_raw`、`hex_colors_fallback`、`hex_colors_total`）
- 記錄 build pipeline 一致性要求（禁止使用會展開 CSS 變數的插件）
- 更新健康指標和改進目標

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)** - 必須立即處理，阻擋主線進度
- [x] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)** - 重要但不阻擋主線
- [ ] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)** - 可排期處理

## 本 PR 不處理 (Out of Scope)

- 實際減少 raw hex colors 數量（目前 395，目標 <50）
- Phase 2 應用層收斂工作
- 改用 occurrence count（目前仍使用 line count）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [x] 手動測試 (Manual Testing)

### 測試步驟 (Test Steps)

1. 執行 `./audit-design-system.sh --relaxed`
2. 確認輸出顯示 raw/fallback/total 分開計算
3. 確認 regression guard 顯示 "IMPROVEMENT" 而非 "REGRESSION DETECTED"

### 預期結果 (Expected Results)

```
✗ FAIL: Too many raw hex colors: 395 (target: <50) [fallback: 144, total: 539]
✓ IMPROVEMENT: Raw hex colors decreased from 494 to 395
✓ Audit completed in relaxed mode (exit 0).
```

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline

### 受影響的區域 (Affected Areas)

- `audit-design-system.sh` - 審計腳本邏輯
- `.design-system-baseline.json` - 基線格式
- `DESIGN_SYSTEM_GUIDELINES.md` - 文檔更新
- CI regression guard 行為

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] 無 TypeScript 變更
- [x] 程式碼遵循現有模式和慣例

## 文檔更新檢查清單 (Documentation Updates)

- [x] **架構變更** → 更新 `DESIGN_SYSTEM_GUIDELINES.md`：新增 Raw Hex vs Fallback Hex 計算規則、Build Pipeline 一致性要求

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 所有環境變數已在 `config/env.schema.yaml` 中定義（無新增）

---

## Human Review Checklist

請特別檢查以下項目：

1. **Regex 模式準確性**：新的 fallback 偵測 pattern `var\([^)]*,[[:space:]]*#[0-9A-Fa-f]{3}([0-9A-Fa-f]{3})?` 是否正確匹配所有 CSS 變數 fallback 格式？
2. **向後相容性**：確認 `hex_colors_raw` 不存在時回退到 `hex_colors` 的邏輯正確
3. **Baseline 數值**：確認 `.design-system-baseline.json` 中的數值正確（story_files 從 21 變為 34 是其他 PR 的結果）
4. **文檔準確性**：確認 `DESIGN_SYSTEM_GUIDELINES.md` 中的計算規則說明與實際腳本邏輯一致
5. **Line count 限制**：目前使用 line count 而非 occurrence count，若同一行有多個 hex colors 或同時有 raw + fallback，可能導致計數不精確。這是已知限制，是否可接受？

---

**Link to Devin run**: https://app.devin.ai/sessions/f3b2c00b49214e85bd57a8592d185bbc
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918