### PR TITLE
[Phase 1] Add main.py refactoring plan document

### DIFF
--- a/docs/PHASE1_MAIN_PY_REFACTORING_PLAN.md
+++ b/docs/PHASE1_MAIN_PY_REFACTORING_PLAN.md
@@ -264,9 +264,9 @@ def validate_rate_limit_redis(): ...
 
 **main.py 變更**：
 ```python
-from src.extensions.database import configure_database, init_database
+from src.extensions.database import configure_database, init_database_with_retry
 configure_database(app)
-init_database(app)
+init_database_with_retry(app)
 ```
 
 **驗收條件**：
@@ -453,7 +453,7 @@ from src.extensions.sentry import before_send
 | `_as_bool` | `src.utils.helpers` | `src.main._as_bool` | 透過 re-export，測試仍 patch `src.main` |
 | `is_vercel_preview` | `src.middleware.cors` | `src.main.is_vercel_preview` | 透過 re-export |
 | `add_cors_headers` | `src.middleware.cors` | `src.main.add_cors_headers` | 透過 re-export |
-| `before_send` | `src.extensions.sentry` | `src.main.before_send` | 透過 re-export |
+| `before_send` | `src.extensions.sentry` | `src.extensions.sentry.before_send` | **不可 re-export**，Sentry SDK 持有原模組參考 |
 | `get_health_payload` | `src.main`（暫不搬移） | `src.main.get_health_payload` | 保留原位 |
 | `handle_exception` | `src.middleware.error_handlers` | `src.main.handle_exception` | 透過 re-export |
 | `BACKEND_SERVICES_AVAILABLE` | `src.main`（保留） | `src.main.BACKEND_SERVICES_AVAILABLE` | 不搬移 |
@@ -468,7 +468,9 @@ from src.extensions.sentry import before_send
    # These symbols are patched by tests via 'src.main.{symbol}'
    from src.utils.helpers import _as_bool  # noqa: F401
    from src.middleware.cors import is_vercel_preview, add_cors_headers  # noqa: F401
-   from src.extensions.sentry import before_send  # noqa: F401
+   from src.middleware.error_handlers import handle_exception  # noqa: F401
+   # NOTE: before_send 不可 re-export，因為 Sentry SDK 持有原模組參考
+   # 測試需 patch 'src.extensions.sentry.before_send'
    ```
 
 2. **測試不需修改 patch target**：
@@ -516,13 +518,20 @@ sentry_sdk.init(
 )
 ```
 
-**風險**：如果 `before_send` 被搬移到 `src.extensions.sentry`，但 Sentry init 時傳入的是搬移後的函式參考，則 re-export 不影響 Sentry 行為。
+**重要**：`before_send` **不可使用 re-export 策略**。原因：
+1. Sentry SDK 在 `init()` 時持有 `before_send` 函式的直接參考
+2. 當 `init_sentry()` 在 `src/extensions/sentry.py` 內呼叫時，SDK 持有的是該模組內的函式參考
+3. 即使在 `src.main` re-export `before_send`，patch `src.main.before_send` 也無法影響 Sentry 行為
+
+**正確做法**：
+- 測試需 patch `src.extensions.sentry.before_send`（定義位置）
+- 不要在 `src.main` re-export `before_send`
 
 **驗證方式**：
 ```python
 def test_sentry_before_send_hook_works():
     """Verify Sentry before_send hook is correctly configured."""
-    from src.main import before_send
+    from src.extensions.sentry import before_send
     # 模擬 Sentry event
     event = {'exception': {'values': [{'type': 'TestError'}]}}
     hint = {}
@@ -593,4 +602,4 @@ def test_sentry_before_send_hook_works():
 
 ---
 
-最後更新：2025-12-14（含 CTO 審閱補充）
+最後更新：2025-12-14（含 CTO 審閱補充 + Gemini Review 修正）


### PR DESCRIPTION
## 描述 (Description)

新增 Phase 1 main.py 拆分計劃文件，詳細說明如何將 1677 行的 `src/main.py` 重構為可維護的模組結構。

此計劃已通過 CTO 審閱，包含三項 blocking 條件的補充：
- Import Contract Test 規範
- Blueprint Contract Test + lazy import 要求
- Patch Canonical Target 規範

### Updates since last revision

**Blocking fixes from CTO/Gemini review:**

1. **Sentry `before_send` canonical target** - 修正為 `src.extensions.sentry.before_send`
   - Re-export 策略對 Sentry SDK callbacks 無效
   - SDK 在 `init()` 時持有原模組的函式參考
   - 更新 re-export section 排除 `before_send`
   - 新增 PR1f 詳細說明

2. **PR1e 函式名稱一致性** - 統一為 `init_database_with_retry`

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

**對應 GitHub Labels**: `P2`

## 本 PR 不處理 (Out of Scope)

- 實際的程式碼重構（將在後續 PR1a-PR1f 中實作）
- Smoke tests 和 Import Contract Test 的實作（將在前置工作 PR 中實作）
- Gunicorn --check-config CI 步驟（建議項目，可在 Phase 1 實作過程中加入）

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [x] 手動測試 (Manual Testing) - 文件審閱
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. 閱讀 `docs/PHASE1_MAIN_PY_REFACTORING_PLAN.md`
2. 驗證計劃的技術可行性
3. 確認風險評估和緩解策略是否完整

### 預期結果 (Expected Results)

- 計劃文件清晰說明 6 個 PR 的拆分順序和驗收條件
- Import Contract Test、Blueprint Contract Test、Patch Canonical Target 規範完整

### 測試環境 (Test Environment)

- [x] 本地開發環境 (Local Development) - 文件審閱

### 受影響的區域 (Affected Areas)

- 無（僅文件變更）

### Human Review Checklist

- [ ] 驗證 `PUBLIC_SYMBOLS` 列表是否涵蓋所有被外部 import 的 symbols
- [ ] 驗證 Patch Canonical Target 對照表是否涵蓋所有被測試 patch 的 symbols
- [x] ~~驗證 PR1f Sentry before_send hook 的風險評估是否準確~~ ✅ 已修正為不可 re-export
- [x] ~~驗證 PR1e 函式名稱一致性~~ ✅ 已統一為 `init_database_with_retry`
- [ ] 驗證 PR1c lazy import 要求是否技術上正確
- [ ] 確認 6 個 PR 的順序是否從低風險到高風險排列

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更

## 設計系統檢查 (Design System Checklist)

- [x] 不適用 - 此 PR 不包含 UI 元件變更

### Shared-UI Import 合規性（強制 - Stage 3: 完全強制執行）

- [x] 不適用 - 此 PR 不包含 UI import 變更

## 程式碼品質檢查

- [x] 無程式碼變更（僅文件）

## 文檔更新檢查清單 (Documentation Updates)

- [x] **架構變更** → 新增 `docs/PHASE1_MAIN_PY_REFACTORING_PLAN.md` 作為重構計劃文件


## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 此為文件 PR，不含 API/邏輯變更

---

**Link to Devin run**: https://app.devin.ai/sessions/85493849f575414191769d63346c1872
**Requested by**: Ryan Chen (@RC918)