### PR TITLE
feat(owner-console): Phase 2-1d - Cleanup unused Card imports and migrate AgentEvaluationDashboard

### DIFF
--- a/handoff/20250928/40_App/owner-console/src/pages/AIPolicies.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/AIPolicies.jsx
@@ -1,11 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { 
-  Card, 
-  CardContent, 
-  CardDescription, 
-  CardHeader, 
-  CardTitle, 
   Badge, 
   Button, 
   Alert, 

--- a/handoff/20250928/40_App/owner-console/src/pages/AgentEvaluationDashboard.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/AgentEvaluationDashboard.jsx
@@ -1,17 +1,14 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import { 
-  Card, 
-  CardContent, 
-  CardDescription, 
-  CardHeader, 
-  CardTitle, 
   Badge, 
   Button, 
   Alert, 
   AlertDescription, 
   AlertTitle, 
-  Skeleton 
+  Skeleton,
+  StatCard,
+  SectionCard
 } from '@morningai/shared-ui'
 import { 
   Activity, 
@@ -60,20 +57,6 @@ const AgentEvaluationDashboard = () => {
     }
   }
 
-  const getMetricColor = (value, target) => {
-    const percentage = (value / target) * 100
-    if (percentage >= 90) return 'text-success-600'
-    if (percentage >= 70) return 'text-warning-600'
-    return 'text-error-600'
-  }
-
-  const getMetricBadgeColor = (value, target) => {
-    const percentage = (value / target) * 100
-    if (percentage >= 90) return 'bg-success-100 text-success-800 border-success-300'
-    if (percentage >= 70) return 'bg-warning-100 text-warning-800 border-warning-300'
-    return 'bg-error-100 text-error-800 border-error-300'
-  }
-
   const formatDate = (dateString) => {
     if (!dateString) return t('common.na', 'N/A')
     const date = new Date(dateString)
@@ -107,34 +90,28 @@ const AgentEvaluationDashboard = () => {
         {/* Metrics Cards Skeleton */}
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {[1, 2, 3, 4].map((i) => (
-            <Card key={i} className="material-card">
-              <CardHeader>
-                <Skeleton className="h-6 w-32" />
-              </CardHeader>
-              <CardContent>
-                <Skeleton className="h-8 w-20 mb-2" />
-                <Skeleton className="h-4 w-24" />
-              </CardContent>
-            </Card>
+            <div key={i} className="rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-card p-5">
+              <Skeleton className="h-6 w-32 mb-4" />
+              <Skeleton className="h-8 w-20 mb-2" />
+              <Skeleton className="h-4 w-24" />
+            </div>
           ))}
         </div>
 
         {/* Evaluation History Skeleton */}
-        <Card className="material-card">
-          <CardHeader>
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-card">
+          <div className="px-5 py-4 border-b border-[var(--border)]">
             <Skeleton className="h-6 w-48" />
-          </CardHeader>
-          <CardContent>
-            <div className="space-y-4">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="flex justify-between">
-                  <Skeleton className="h-4 w-32" />
-                  <Skeleton className="h-4 w-24" />
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+          </div>
+          <div className="p-5 space-y-4">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex justify-between">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-24" />
+              </div>
+            ))}
+          </div>
+        </div>
       </div>
     )
   }
@@ -181,193 +158,136 @@ const AgentEvaluationDashboard = () => {
       {metrics && (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
           {/* Planner Accuracy */}
-          <Card className="material-card">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-callout font-medium">{t('agentEvaluation.metrics.plannerAccuracy', 'Planner Accuracy')}</CardTitle>
-              <Target className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className={`text-title-2 md:text-title-1 font-bold ${hasData ? getMetricColor(metrics.metrics.planner_accuracy, metrics.targets.planner_accuracy) : 'text-neutral-400'}`}>
-                {hasData ? formatPercentage(metrics.metrics.planner_accuracy) : t('common.na', 'N/A')}
-              </div>
-              <p className="text-caption-2 text-muted-foreground mt-1">
-                {hasData ? `${t('agentEvaluation.target', 'Target')}: ${formatPercentage(metrics.targets.planner_accuracy)}` : t('monitoring.noMetricsData', 'No metrics available yet')}
-              </p>
-              <div className="mt-2 min-h-[24px]">
-                {hasData && (
-                  <Badge className={getMetricBadgeColor(metrics.metrics.planner_accuracy, metrics.targets.planner_accuracy)}>
-                    {metrics.metrics.planner_accuracy >= metrics.targets.planner_accuracy ? t('agentEvaluation.onTarget', 'On Target') : t('agentEvaluation.belowTarget', 'Below Target')}
-                  </Badge>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          <StatCard
+            label={t('agentEvaluation.metrics.plannerAccuracy', 'Planner Accuracy')}
+            value={hasData ? formatPercentage(metrics.metrics.planner_accuracy) : t('common.na', 'N/A')}
+            icon={<Target />}
+            variant={hasData && metrics.metrics.planner_accuracy >= metrics.targets.planner_accuracy ? 'green' : hasData ? 'red' : 'default'}
+            deltaLabel={hasData ? `${t('agentEvaluation.target', 'Target')}: ${formatPercentage(metrics.targets.planner_accuracy)}` : t('monitoring.noMetricsData', 'No metrics available yet')}
+            deltaPositive="neutral"
+            badge={hasData ? (metrics.metrics.planner_accuracy >= metrics.targets.planner_accuracy ? t('agentEvaluation.onTarget', 'On Target') : t('agentEvaluation.belowTarget', 'Below Target')) : undefined}
+          />
 
           {/* Self-Healing Rate */}
-          <Card className="material-card">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-callout font-medium">{t('agentEvaluation.metrics.selfHealingRate', 'Self-Healing Rate')}</CardTitle>
-              <Activity className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className={`text-title-2 md:text-title-1 font-bold ${hasData ? getMetricColor(metrics.metrics.self_healing_rate, metrics.targets.self_healing_rate) : 'text-neutral-400'}`}>
-                {hasData ? formatPercentage(metrics.metrics.self_healing_rate) : t('common.na', 'N/A')}
-              </div>
-              <p className="text-caption-2 text-muted-foreground mt-1">
-                {hasData ? `${t('agentEvaluation.target', 'Target')}: ${formatPercentage(metrics.targets.self_healing_rate)}` : t('monitoring.noMetricsData', 'No metrics available yet')}
-              </p>
-              <div className="mt-2 min-h-[24px]">
-                {hasData && (
-                  <Badge className={getMetricBadgeColor(metrics.metrics.self_healing_rate, metrics.targets.self_healing_rate)}>
-                    {metrics.metrics.self_healing_rate >= metrics.targets.self_healing_rate ? t('agentEvaluation.onTarget', 'On Target') : t('agentEvaluation.belowTarget', 'Below Target')}
-                  </Badge>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          <StatCard
+            label={t('agentEvaluation.metrics.selfHealingRate', 'Self-Healing Rate')}
+            value={hasData ? formatPercentage(metrics.metrics.self_healing_rate) : t('common.na', 'N/A')}
+            icon={<Activity />}
+            variant={hasData && metrics.metrics.self_healing_rate >= metrics.targets.self_healing_rate ? 'green' : hasData ? 'red' : 'default'}
+            deltaLabel={hasData ? `${t('agentEvaluation.target', 'Target')}: ${formatPercentage(metrics.targets.self_healing_rate)}` : t('monitoring.noMetricsData', 'No metrics available yet')}
+            deltaPositive="neutral"
+            badge={hasData ? (metrics.metrics.self_healing_rate >= metrics.targets.self_healing_rate ? t('agentEvaluation.onTarget', 'On Target') : t('agentEvaluation.belowTarget', 'Below Target')) : undefined}
+          />
 
           {/* Completion Rate */}
-          <Card className="material-card">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-callout font-medium">{t('agentEvaluation.metrics.completionRate', 'Completion Rate')}</CardTitle>
-              <CheckCircle2 className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className={`text-title-2 md:text-title-1 font-bold ${hasData ? getMetricColor(metrics.metrics.completion_rate, metrics.targets.completion_rate) : 'text-neutral-400'}`}>
-                {hasData ? formatPercentage(metrics.metrics.completion_rate) : t('common.na', 'N/A')}
-              </div>
-              <p className="text-caption-2 text-muted-foreground mt-1">
-                {hasData ? `${t('agentEvaluation.target', 'Target')}: ${formatPercentage(metrics.targets.completion_rate)}` : t('monitoring.noMetricsData', 'No metrics available yet')}
-              </p>
-              <div className="mt-2 min-h-[24px]">
-                {hasData && (
-                  <Badge className={getMetricBadgeColor(metrics.metrics.completion_rate, metrics.targets.completion_rate)}>
-                    {metrics.metrics.completion_rate >= metrics.targets.completion_rate ? t('agentEvaluation.onTarget', 'On Target') : t('agentEvaluation.belowTarget', 'Below Target')}
-                  </Badge>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          <StatCard
+            label={t('agentEvaluation.metrics.completionRate', 'Completion Rate')}
+            value={hasData ? formatPercentage(metrics.metrics.completion_rate) : t('common.na', 'N/A')}
+            icon={<CheckCircle2 />}
+            variant={hasData && metrics.metrics.completion_rate >= metrics.targets.completion_rate ? 'green' : hasData ? 'red' : 'default'}
+            deltaLabel={hasData ? `${t('agentEvaluation.target', 'Target')}: ${formatPercentage(metrics.targets.completion_rate)}` : t('monitoring.noMetricsData', 'No metrics available yet')}
+            deltaPositive="neutral"
+            badge={hasData ? (metrics.metrics.completion_rate >= metrics.targets.completion_rate ? t('agentEvaluation.onTarget', 'On Target') : t('agentEvaluation.belowTarget', 'Below Target')) : undefined}
+          />
 
           {/* CI Pass Rate */}
-          <Card className="material-card">
-            <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-              <CardTitle className="text-callout font-medium">{t('agentEvaluation.metrics.ciPassRate', 'CI Pass Rate')}</CardTitle>
-              <TrendingUp className="h-4 w-4 text-muted-foreground" />
-            </CardHeader>
-            <CardContent>
-              <div className={`text-title-2 md:text-title-1 font-bold ${hasData ? getMetricColor(metrics.metrics.ci_pass_rate, metrics.targets.ci_pass_rate) : 'text-neutral-400'}`}>
-                {hasData ? formatPercentage(metrics.metrics.ci_pass_rate) : t('common.na', 'N/A')}
-              </div>
-              <p className="text-caption-2 text-muted-foreground mt-1">
-                {hasData ? `${t('agentEvaluation.target', 'Target')}: ${formatPercentage(metrics.targets.ci_pass_rate)}` : t('monitoring.noMetricsData', 'No metrics available yet')}
-              </p>
-              <div className="mt-2 min-h-[24px]">
-                {hasData && (
-                  <Badge className={getMetricBadgeColor(metrics.metrics.ci_pass_rate, metrics.targets.ci_pass_rate)}>
-                    {metrics.metrics.ci_pass_rate >= metrics.targets.ci_pass_rate ? t('agentEvaluation.onTarget', 'On Target') : t('agentEvaluation.belowTarget', 'Below Target')}
-                  </Badge>
-                )}
-              </div>
-            </CardContent>
-          </Card>
+          <StatCard
+            label={t('agentEvaluation.metrics.ciPassRate', 'CI Pass Rate')}
+            value={hasData ? formatPercentage(metrics.metrics.ci_pass_rate) : t('common.na', 'N/A')}
+            icon={<TrendingUp />}
+            variant={hasData && metrics.metrics.ci_pass_rate >= metrics.targets.ci_pass_rate ? 'green' : hasData ? 'red' : 'default'}
+            deltaLabel={hasData ? `${t('agentEvaluation.target', 'Target')}: ${formatPercentage(metrics.targets.ci_pass_rate)}` : t('monitoring.noMetricsData', 'No metrics available yet')}
+            deltaPositive="neutral"
+            badge={hasData ? (metrics.metrics.ci_pass_rate >= metrics.targets.ci_pass_rate ? t('agentEvaluation.onTarget', 'On Target') : t('agentEvaluation.belowTarget', 'Below Target')) : undefined}
+          />
         </div>
       )}
 
       {/* Evaluation History */}
-      <Card className="material-card">
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Calendar className="w-5 h-5" />
-            {t('agentEvaluation.history.title', 'Evaluation History')}
-          </CardTitle>
-          <CardDescription>
-            {t('agentEvaluation.history.subtitle', 'Recent agent evaluation runs from GitHub Actions')}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {evaluations.length === 0 ? (
-            <div className="py-8 text-center">
-              <Activity className="w-12 h-12 text-neutral-400 mx-auto mb-4" />
-              <p className="text-neutral-600 dark:text-neutral-400">
-                {t('agentEvaluation.history.noResults', 'No evaluation results available yet')}
-              </p>
-              <p className="text-callout text-neutral-500 dark:text-neutral-500 mt-2">
-                {t('agentEvaluation.history.weeklyRuns', 'Evaluations run weekly via GitHub Actions')}
-              </p>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              {evaluations.map((evaluation) => (
-                <div 
-                  key={evaluation.id} 
-                  className="flex items-center justify-between p-4 material-card transition-opacity hover:opacity-80"
-                >
-                  <div className="flex-1">
-                    <div className="flex items-center gap-3">
-                      <div className="flex items-center gap-2">
-                        {evaluation.status === 'success' ? (
-                          <CheckCircle2 className="w-5 h-5 text-success-600" />
-                        ) : (
-                          <XCircle className="w-5 h-5 text-error-600" />
-                        )}
-                        <span className="font-medium text-callout">
-                          {formatDate(evaluation.date)}
-                        </span>
-                      </div>
-                      <Badge variant="outline" className="text-caption-2">
-                        {t('agentEvaluation.history.runNumber', 'Run #{{id}}', { id: evaluation.run_id })}
-                      </Badge>
+      <SectionCard
+        title={t('agentEvaluation.history.title', 'Evaluation History')}
+        subtitle={t('agentEvaluation.history.subtitle', 'Recent agent evaluation runs from GitHub Actions')}
+        icon={<Calendar className="w-5 h-5" />}
+      >
+        {evaluations.length === 0 ? (
+          <div className="py-8 text-center">
+            <Activity className="w-12 h-12 text-neutral-400 mx-auto mb-4" />
+            <p className="text-neutral-600 dark:text-neutral-400">
+              {t('agentEvaluation.history.noResults', 'No evaluation results available yet')}
+            </p>
+            <p className="text-callout text-neutral-500 dark:text-neutral-500 mt-2">
+              {t('agentEvaluation.history.weeklyRuns', 'Evaluations run weekly via GitHub Actions')}
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {evaluations.map((evaluation) => (
+              <div 
+                key={evaluation.id} 
+                className="flex items-center justify-between p-4 rounded-lg border border-[var(--border)] bg-[var(--surface)] transition-opacity hover:opacity-80"
+              >
+                <div className="flex-1">
+                  <div className="flex items-center gap-3">
+                    <div className="flex items-center gap-2">
+                      {evaluation.status === 'success' ? (
+                        <CheckCircle2 className="w-5 h-5 text-success-600" />
+                      ) : (
+                        <XCircle className="w-5 h-5 text-error-600" />
+                      )}
+                      <span className="font-medium text-callout">
+                        {formatDate(evaluation.date)}
+                      </span>
                     </div>
-                    <div className="mt-2 grid grid-cols-4 gap-4 text-callout">
-                      <div>
-                        <span className="text-neutral-500">{t('agentEvaluation.history.tasks', 'Tasks')}:</span>
-                        <span className="ml-1 font-medium">{evaluation.total_tasks}</span>
-                      </div>
-                      <div>
-                        <span className="text-neutral-500">{t('agentEvaluation.history.completed', 'Completed')}:</span>
-                        <span className="ml-1 font-medium">{evaluation.completed}</span>
-                      </div>
-                      <div>
-                        <span className="text-neutral-500">{t('agentEvaluation.history.prs', 'PRs')}:</span>
-                        <span className="ml-1 font-medium">{evaluation.pr_created}</span>
-                      </div>
-                      <div>
-                        <span className="text-neutral-500">{t('agentEvaluation.history.ciPassed', 'CI Passed')}:</span>
-                        <span className="ml-1 font-medium">{evaluation.ci_passed}</span>
-                      </div>
-                    </div>
+                    <Badge variant="outline" className="text-caption-2">
+                      {t('agentEvaluation.history.runNumber', 'Run #{{id}}', { id: evaluation.run_id })}
+                    </Badge>
                   </div>
-                  <div className="ml-4">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => window.open(evaluation.run_url, '_blank')}
-                    >
-                      <ExternalLink className="w-4 h-4" />
-                    </Button>
+                  <div className="mt-2 grid grid-cols-4 gap-4 text-callout">
+                    <div>
+                      <span className="text-neutral-500">{t('agentEvaluation.history.tasks', 'Tasks')}:</span>
+                      <span className="ml-1 font-medium">{evaluation.total_tasks}</span>
+                    </div>
+                    <div>
+                      <span className="text-neutral-500">{t('agentEvaluation.history.completed', 'Completed')}:</span>
+                      <span className="ml-1 font-medium">{evaluation.completed}</span>
+                    </div>
+                    <div>
+                      <span className="text-neutral-500">{t('agentEvaluation.history.prs', 'PRs')}:</span>
+                      <span className="ml-1 font-medium">{evaluation.pr_created}</span>
+                    </div>
+                    <div>
+                      <span className="text-neutral-500">{t('agentEvaluation.history.ciPassed', 'CI Passed')}:</span>
+                      <span className="ml-1 font-medium">{evaluation.ci_passed}</span>
+                    </div>
                   </div>
                 </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                <div className="ml-4">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => window.open(evaluation.run_url, '_blank')}
+                  >
+                    <ExternalLink className="w-4 h-4" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </SectionCard>
 
       {/* Last Evaluation Info */}
       {metrics && metrics.last_evaluation && (
-        <Card className="material-card">
-          <CardContent className="py-4">
-            <div className="flex items-center justify-between text-callout">
-              <span className="text-neutral-600 dark:text-neutral-400">
-                {t('agentEvaluation.lastEvaluation', 'Last evaluation')}:
-              </span>
-              <span className="font-medium">
-                {formatDate(metrics.last_evaluation)}
-              </span>
-            </div>
-          </CardContent>
-        </Card>
+        <div className="rounded-xl border border-[var(--border)] bg-[var(--surface)] shadow-card px-5 py-4">
+          <div className="flex items-center justify-between text-callout">
+            <span className="text-neutral-600 dark:text-neutral-400">
+              {t('agentEvaluation.lastEvaluation', 'Last evaluation')}:
+            </span>
+            <span className="font-medium">
+              {formatDate(metrics.last_evaluation)}
+            </span>
+          </div>
+        </div>
       )}
     </div>
   )

--- a/handoff/20250928/40_App/owner-console/src/pages/AgentGovernance.jsx
+++ b/handoff/20250928/40_App/owner-console/src/pages/AgentGovernance.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle, Badge, Button, Tabs, TabsContent, TabsList, TabsTrigger, StatCard, SectionCard } from '@morningai/shared-ui'
+import { Badge, Button, Tabs, TabsContent, TabsList, TabsTrigger, StatCard, SectionCard } from '@morningai/shared-ui'
 import { 
   Shield, 
   TrendingUp,


### PR DESCRIPTION
## 描述 (Description)

Phase 2-1d of Epic #2304: Cleanup unused Card imports and migrate `AgentEvaluationDashboard.jsx` from legacy Card components to `StatCard` and `SectionCard` from `@morningai/shared-ui`.

**Changes:**
- **AgentGovernance.jsx**: Remove unused Card/CardHeader/CardTitle/CardDescription/CardContent imports
- **AIPolicies.jsx**: Remove unused Card/CardHeader/CardTitle/CardDescription/CardContent imports  
- **AgentEvaluationDashboard.jsx**: Full migration
  - 4 metric cards → `StatCard` with icon, variant, deltaLabel, badge props
  - Evaluation History card → `SectionCard` with icon prop
  - Last Evaluation Info card → div-based card
  - Loading skeleton → div-based skeleton
  - Removed unused `getMetricColor` and `getMetricBadgeColor` helper functions

## PR 類型與優先級 (PR Type & Priority)

- [ ] **P0 - 主線功能 / 緊急修復 (Blocking)**
- [ ] **P1 - 修正既有問題 / 改善體驗 (Non-blocking)**
- [x] **P2 - 優化 / 重構 / 技術債 (Nice-to-have)**

## 本 PR 不處理 (Out of Scope)

- frontend-dashboard legacy Card migrations (Phase 2-2)
- Other owner-console components with legacy Cards

## 如何測試 (How to Test)

### 測試類型 (Test Types)

- [ ] 單元測試 (Unit Tests)
- [ ] 整合測試 (Integration Tests)
- [ ] E2E 測試 (End-to-End Tests)
- [ ] 視覺回歸測試 (Visual Regression Tests)
- [x] 手動測試 (Manual Testing)
- [ ] 無障礙測試 (Accessibility Testing)

### 測試步驟 (Test Steps)

1. Navigate to Agent Evaluation Dashboard in owner-console
2. Verify loading skeleton displays correctly during data fetch
3. Verify all 4 metric cards (Planner Accuracy, Self-Healing Rate, Completion Rate, CI Pass Rate) render with correct values, icons, and badges
4. Verify Evaluation History section renders with Calendar icon
5. Verify Last Evaluation Info card displays correctly

### 測試環境 (Test Environment)

- [ ] 本地開發環境 (Local Development)
- [x] CI/CD Pipeline
- [x] Staging 環境 (Vercel Preview)

### 受影響的區域 (Affected Areas)

- AgentEvaluationDashboard page
- AgentGovernance page (import cleanup only)
- AIPolicies page (import cleanup only)

## i18n 檢查清單（強制）

- [x] 不適用 - 此 PR 無用戶可見變更 (no new strings, existing i18n preserved)

## 設計系統檢查 (Design System Checklist)

- [x] 我已檢查 `@morningai/shared-ui` 是否有可用的元件
- [x] 如果需要新元件，我已將其加入 `packages/shared-ui/` 而非應用層
- [ ] 新元件已加入 Storybook story
- [x] 我沒有在應用層重複實作已存在於 shared-ui 的元件

## Phase 2 Audit Checklist (Epic #2304)

### Audit Delta Report

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Shared-UI Cards | 53 | 58 | +5 |
| Legacy Cards | 3 | 3 | 0 |
| Adoption Rate | 84.1% | 85.2% | +1.1% |
| Raw Hex Colors | 58 | 58 | 0 |
| Inline Styles | 56 | 56 | 0 |

### Bundle Size Report

| App | JS (gzip) | CSS (gzip) | Largest Chunk | Status |
|-----|-----------|------------|---------------|--------|
| owner-console | 443.5 kB | 26.2 kB | 189.2 kB | unchanged |
| frontend-dashboard | 495.5 kB | 23.0 kB | 213.0 kB | unchanged |

### Phase 2 Verification Checklist

- [x] `./scripts/phase2_audit.sh` 已執行並記錄結果
- [x] `./scripts/measure-bundle-size.sh` 已執行並記錄結果
- [x] Shared-UI adoption rate 不低於 baseline
- [x] Raw hex colors 數量不增加
- [x] Inline styles 數量不增加
- [x] Bundle size 增量在閾值內（JS: +50KB, CSS: +10KB）
- [ ] 視覺回歸測試通過（Vercel Preview 截圖）

### Shared-UI Import 合規性

- [x] 我已使用 `@morningai/shared-ui` 元件
- [x] ESLint `no-restricted-imports` 規則通過

## Human Review Checklist

**⚠️ Please verify on Vercel Preview:**

1. **StatCard badge rendering**: The original used `<Badge className={getMetricBadgeColor(...)}>` inside CardContent. Now using StatCard's `badge` prop - verify it renders similarly.

2. **Warning state removed**: Original code had 3 states (green ≥90%, yellow 70-90%, red <70%). New code only has 2 states (green if ≥target, red otherwise). **Is this intentional?**

3. **Loading skeleton appearance**: Changed from Card/CardHeader/CardContent structure to div-based. Verify visual consistency.

4. **SectionCard with icon**: Evaluation History now uses SectionCard with `icon={<Calendar />}` - verify icon displays correctly.

## 程式碼品質檢查

- [x] ESLint 通過
- [x] Pre-commit hooks 通過

## 提醒

- [x] 不修改 OpenAPI/資料欄位
- [x] 設計 PR 僅含 UI/文案/樣式

---

**Link to Devin run**: https://app.devin.ai/sessions/f3b2c00b49214e85bd57a8592d185bbc
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918
**Part of**: Epic #2304 Phase 2-1