### PR TITLE
fix(ci): resolve Playwright version mismatch in computed-style-check job

### DIFF
--- a/.github/workflows/ux-pipeline.yml
+++ b/.github/workflows/ux-pipeline.yml
@@ -608,7 +608,9 @@ jobs:
         run: pnpm run build
       
       - name: Install Playwright browsers
-        working-directory: handoff/20250928/40_App/${{ matrix.app }}
+        # Install at root level to match script resolution context
+        # scripts/ux/check-computed-styles.mjs imports from root @playwright/test
+        # See: https://github.com/RC918/morningai/issues/2571
         run: pnpm exec playwright install --with-deps chromium
       
       - name: Start preview server


### PR DESCRIPTION
## Summary

Fixes the `Computed Style Verification (owner-console)` CI failure caused by Playwright browser version mismatch.

**Root cause:** The `computed-style-check` job was installing Playwright browsers in the app workspace context (v1200), but the script `scripts/ux/check-computed-styles.mjs` imports from root `@playwright/test` which expects v1194 browsers.

**Fix:** Remove `working-directory` from the Playwright install step so it runs at root level, matching the script's module resolution context.

## Manual Verification

### Version Analysis
```bash
$ pnpm list @playwright/test -r

morningai-monorepo@1.0.0 (root)
  @playwright/test 1.56.1

frontend-dashboard@0.0.1
  @playwright/test 1.56.1

owner-console@0.0.0
  @playwright/test 1.57.0
```

| Workspace | @playwright/test | Browser Build |
|-----------|------------------|---------------|
| **root** | 1.56.1 | v1194 |
| frontend-dashboard | 1.56.1 | v1194 |
| **owner-console** | 1.57.0 | v1200 |

Node.js module resolution uses the **importer file's location**, so `scripts/ux/check-computed-styles.mjs` always resolves to root `@playwright/test` (v1.56.1, expecting v1194 browsers). This explains why `frontend-dashboard` passed (same version as root) but `owner-console` failed.

## Review & Testing Checklist for Human

- [ ] **Post-merge validation required** - This PR's CI does not trigger `ux-pipeline` (workflow only runs on frontend path changes). After merging, create a small PR touching `owner-console` to verify `Computed Style Verification (owner-console)` passes.
- [ ] **Verify version analysis** - Confirm the browser build versions (v1194 for 1.56.1, v1200 for 1.57.0) match what CI logs show.
- [x] **Root package.json has @playwright/test** - Confirmed: root has `@playwright/test: ^1.56.1`

### Test Plan
1. Merge this PR
2. Create a test PR that touches `owner-console` files
3. Verify `Computed Style Verification (owner-console)` job passes
4. Close issue #2571

### Notes
- Other jobs (visual-regression-test, motion-performance-test, etc.) also install Playwright in app workspace context, but they run scripts from within the app workspace, so they don't have this version mismatch issue.
- **Follow-up recommendations** (not in this PR): Consider adding `pnpm.overrides` to unify Playwright versions across workspaces, or a CI guard to validate version consistency.
- Fixes: #2571

---
**Requested by:** Ryan Chen (@RC918)
**Link to Devin run:** https://app.devin.ai/sessions/e862be1eb7164a55b0881069f59efa69