### PR TITLE
chore(deps): add orchestrator to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,6 +35,19 @@ updates:
       - "python"
     open-pull-requests-limit: 5
 
+  # Python dependencies for orchestrator (AI Agent 服務，對應 requirements.txt)
+  # 路徑說明：若目錄結構調整，需同步更新此處
+  - package-ecosystem: "pip"
+    directory: "/handoff/20250928/40_App/orchestrator"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+      - "python"
+    open-pull-requests-limit: 5
+
   # npm dependencies for owner-console (店家後台前端)
   # 路徑說明：若目錄結構調整，需同步更新此處
   - package-ecosystem: "npm"


### PR DESCRIPTION
## Summary

Adds the orchestrator service (`/handoff/20250928/40_App/orchestrator`) to Dependabot's automated dependency update configuration. This extends the existing Dependabot coverage to include the AI Agent service's Python dependencies (PyGithub, openai, langgraph, etc.).

The configuration follows the same pattern as the existing api-backend entry:
- Monthly update schedule
- `chore(deps)` commit prefix
- `dependencies` and `python` labels
- 5 open PR limit

## Review & Testing Checklist for Human

- [ ] Verify `/handoff/20250928/40_App/orchestrator/requirements.txt` exists and is the correct target
- [ ] Confirm monthly update interval is appropriate for orchestrator dependencies

### Notes

This PR addresses a gap identified in Issue #2384 (Dependabot setup). The `frontend-dashboard` was intentionally excluded as it will be refactored later.

After merge, Dependabot will begin creating dependency update PRs for orchestrator on the next monthly cycle.

---
Link to Devin run: https://app.devin.ai/sessions/9c892a0174ab43fcbfbffb8bd1a1ddd2
Requested by: Ryan Chen (@RC918)