### PR TITLE
feat(agents): add RefactorAgentV2 migration validation

### DIFF
--- a/handoff/20250928/40_App/orchestrator/refactor_agent/agent_v2.py
+++ b/handoff/20250928/40_App/orchestrator/refactor_agent/agent_v2.py
@@ -180,6 +180,21 @@ STRATEGY_TO_TEMPLATE: Dict[str, str] = {
     "possibly_undefined": "null_check",
 }
 
+# Module-level constants for risk level determination
+# Moved from _determine_risk_level() for better performance
+_HIGH_RISK_CODES = {"TS2322", "TS2345"}
+_MEDIUM_RISK_CODES = {"TS2339", "TS2554", "TS7006", "TS7031"}
+
+# Module-level constant for minimum LLM fix length validation
+MIN_LLM_FIX_LENGTH = 5
+
+# Module-level mapping for risk level to RefactorRisk enum
+_RISK_LEVEL_TO_ENUM = {
+    "high": RefactorRisk.HIGH,
+    "medium": RefactorRisk.MEDIUM,
+    "low": RefactorRisk.LOW,
+}
+
 
 class RefactorAgentV2(BaseAgent):
     """
@@ -227,7 +242,10 @@ class RefactorAgentV2(BaseAgent):
             self.errors_per_run = getattr(
                 settings, 'refactor_agent_errors_per_run', 10
             )
-        except (ImportError, AttributeError):
+        except (ImportError, AttributeError) as e:
+            logger.warning(
+                f"[RefactorAgentV2] Failed to load settings: {e}, using defaults"
+            )
             self.enabled = True
             self.errors_per_run = 10
 
@@ -285,7 +303,7 @@ class RefactorAgentV2(BaseAgent):
 
             fix_content = result.get("content", "")
 
-            if len(fix_content.strip()) < 5:
+            if len(fix_content.strip()) < MIN_LLM_FIX_LENGTH:
                 return AgentOutput(
                     task_id=input.task_id,
                     success=False,
@@ -351,25 +369,33 @@ class RefactorAgentV2(BaseAgent):
         """
         Determine risk level based on error type
 
+        Uses module-level constants _HIGH_RISK_CODES and _MEDIUM_RISK_CODES
+        for better performance.
+
         Args:
             error: TSError to analyze
 
         Returns:
             Risk level string: "high", "medium", or "low"
-        """
-        high_risk_codes = {"TS2322", "TS2345"}
-        medium_risk_codes = {"TS2339", "TS2554", "TS7006", "TS7031"}
 
-        if error.error_code in high_risk_codes:
+        Note:
+            Unknown error codes default to "medium" (conservative approach)
+            to avoid underestimating risk for new/unknown error types.
+        """
+        if error.error_code in _HIGH_RISK_CODES:
             return "high"
-        elif error.error_code in medium_risk_codes:
+        elif error.error_code in _MEDIUM_RISK_CODES:
             return "medium"
         else:
-            return "low"
+            # Unknown error codes default to medium (conservative approach)
+            # This prevents underestimating risk for new TypeScript error codes
+            return "medium"
 
     def analyze_error(self, error: TSError) -> RefactorTask:
         """
         Analyze a TS error and create a refactor task
+
+        Uses module-level _RISK_LEVEL_TO_ENUM mapping for better performance.
 
         Args:
             error: TSError to analyze
@@ -380,11 +406,8 @@ class RefactorAgentV2(BaseAgent):
         strategy = TS_FIX_STRATEGIES.get(error.error_code, "generic")
         risk_level = self._determine_risk_level(error)
 
-        risk_enum = {
-            "high": RefactorRisk.HIGH,
-            "medium": RefactorRisk.MEDIUM,
-            "low": RefactorRisk.LOW
-        }.get(risk_level, RefactorRisk.MEDIUM)
+        # Use module-level constant for risk level to enum mapping
+        risk_enum = _RISK_LEVEL_TO_ENUM.get(risk_level, RefactorRisk.MEDIUM)
 
         return RefactorTask(
             task_id=f"task-{error.error_code}-{error.line}",

--- a/handoff/20250928/40_App/orchestrator/refactor_agent/tests/test_agent_v2_migration.py
+++ b/handoff/20250928/40_App/orchestrator/refactor_agent/tests/test_agent_v2_migration.py
@@ -264,11 +264,12 @@ class TestRefactorAgentV2RiskLevel:
         assert agent._determine_risk_level(medium_risk_error) == "medium"
 
     @patch('refactor_agent.agent_v2.RefactorAgentV2._load_settings')
-    def test_low_risk_codes(self, mock_settings):
-        """Verify low risk error codes"""
+    def test_unknown_risk_codes_default_to_medium(self, mock_settings):
+        """Verify unknown error codes default to medium (conservative approach)"""
         agent = RefactorAgentV2()
 
-        low_risk_error = TSError(
+        # TS2531 is not in HIGH or MEDIUM risk codes, so it defaults to medium
+        unknown_risk_error = TSError(
             file_path="test.ts",
             line=1,
             column=1,
@@ -276,7 +277,8 @@ class TestRefactorAgentV2RiskLevel:
             message="Possibly null"
         )
 
-        assert agent._determine_risk_level(low_risk_error) == "low"
+        # Unknown codes now default to "medium" for conservative risk assessment
+        assert agent._determine_risk_level(unknown_risk_error) == "medium"
 
 
 class TestRefactorAgentV2AnalyzeError:
@@ -300,7 +302,8 @@ class TestRefactorAgentV2AnalyzeError:
         assert isinstance(task, RefactorTask)
         assert task.error == error
         assert task.fix_strategy == "null_check"
-        assert task.estimated_risk == RefactorRisk.LOW
+        # TS2531 is not in HIGH or MEDIUM risk codes, defaults to MEDIUM
+        assert task.estimated_risk == RefactorRisk.MEDIUM
 
     @patch('refactor_agent.agent_v2.RefactorAgentV2._load_settings')
     def test_analyze_error_unknown_code(self, mock_settings):


### PR DESCRIPTION
# feat(agents): add RefactorAgentV2 migration validation

## Summary

This PR adds a reference implementation demonstrating how to migrate existing agents to use the new `BaseAgent` class with `RoutingEngine` integration. Part of EPIC #2594, addressing issue #2676.

**Migration pattern demonstrated:**
```python
# Before (RefactorAgent)
self.llm_client = LLMClient(provider="auto", model=None)
result = self.llm_client.generate(prompt)

# After (RefactorAgentV2)
class RefactorAgentV2(BaseAgent):
    result = self.call_llm(prompt, task_type="coding", risk_level="low")
```

Key changes:
- `RefactorAgentV2` inherits from `BaseAgent` instead of standalone class
- Uses `self.call_llm()` with task-based routing instead of direct `LLMClient` calls
- Risk level determined by TypeScript error code (high/medium/unknown defaults to medium)
- Telemetry v2 events emitted automatically through BaseAgent

## Updates since last revision

Addressed CTO review feedback and Gemini Code Assist suggestions:

1. **Conservative risk assessment** - Unknown error codes now default to "medium" instead of "low" to avoid underestimating risk for new/unknown TypeScript error types
2. **Improved debugging** - Added `logger.warning()` in `_load_settings()` when configuration fails to load
3. **Code quality improvements** - Moved constants to module level for better performance:
   - `MIN_LLM_FIX_LENGTH = 5` (replaces magic number)
   - `_HIGH_RISK_CODES` and `_MEDIUM_RISK_CODES` sets
   - `_RISK_LEVEL_TO_ENUM` mapping

Tests updated to reflect the new conservative risk assessment behavior (23 tests passing).

## Review & Testing Checklist for Human

- [ ] **Verify the conservative risk default makes sense** - Unknown TS error codes now route to "medium" risk instead of "low". This is safer but may use more expensive models for unknown errors. Confirm this aligns with your cost/safety tradeoffs.
- [ ] **Test with real LLM calls** - All 23 tests use mocks. After merge, manually test RefactorAgentV2 with a real TypeScript error to verify end-to-end routing works.
- [ ] **Review risk level mappings** - High: TS2322/TS2345, Medium: TS2339/TS2554/TS7006/TS7031, Unknown: defaults to medium. Verify these mappings make sense for your codebase.

**Suggested test plan:**
1. After merge, run RefactorAgentV2 against a real TypeScript error with an unknown error code (e.g., TS9999) and verify it routes to medium-tier model
2. Check logs for the warning message when settings fail to load
3. Verify Telemetry v2 events are emitted correctly

### Notes

- Depends on PR #2674 (BaseAgent) which has been merged
- This is a non-breaking change - original RefactorAgent remains unchanged
- 23 unit tests covering inheritance, execute(), risk levels, and telemetry

Closes #2676

---
**Link to Devin run:** https://app.devin.ai/sessions/74ebce460cde41a8957c963d433f7a73
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918