### PR TITLE
test(routing): add routing_policy.json loading and error handling tests

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_routing_policy_loading.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_routing_policy_loading.py
@@ -10,6 +10,7 @@ Tests cover:
 - Configuration precedence (JSON vs Python defaults)
 """
 import json
+import logging
 import pytest  # noqa: F401 - pytest fixtures (tmp_path, caplog) are used implicitly
 from pathlib import Path
 from unittest.mock import patch
@@ -123,7 +124,11 @@ class TestPolicyPartialJSON:
         assert engine._task_routing == DEFAULT_TASK_ROUTING
 
     def test_load_policy_empty_task_types_uses_empty(self, tmp_path):
-        """Should use empty task_types when section is empty dict"""
+        """Should use empty task_types when section is empty dict.
+
+        Design intent: Empty task_types dict is valid and intentional.
+        select_model() will safely fallback to tier 2 via .get() default.
+        """
         partial_json = tmp_path / "empty_tasks.json"
         partial_json.write_text(json.dumps({
             "version": "1.0",
@@ -134,7 +139,7 @@ class TestPolicyPartialJSON:
             policy_path=partial_json,
             available_providers=["alicloud"]
         )
-        # Should use empty task_types from JSON
+        # Empty task_types is valid - select_model() uses .get() with default tier 2
         assert engine._task_routing == {}
 
     def test_load_policy_only_version_uses_defaults(self, tmp_path):
@@ -214,21 +219,18 @@ class TestPolicyFilePermissions:
 
     def test_load_policy_permission_denied_uses_defaults(self, tmp_path):
         """Should use defaults when file permission is denied"""
-        # Create a file and make it unreadable
-        restricted_json = tmp_path / "restricted.json"
-        restricted_json.write_text('{"task_types": {}}')
-        restricted_json.chmod(0o000)
+        # Use mock to simulate PermissionError for cross-platform stability
+        # (chmod-based tests can be flaky on CI runners with root or special FS)
+        policy_path = tmp_path / "restricted.json"
 
-        try:
-            engine = RoutingEngine(
-                policy_path=restricted_json,
-                available_providers=["alicloud"]
-            )
-            # Should fall back to defaults due to OSError
-            assert engine._task_routing == DEFAULT_TASK_ROUTING
-        finally:
-            # Restore permissions for cleanup
-            restricted_json.chmod(0o644)
+        with patch.object(Path, 'exists', return_value=True):
+            with patch.object(Path, 'read_text', side_effect=PermissionError("Permission denied")):
+                engine = RoutingEngine(
+                    policy_path=policy_path,
+                    available_providers=["alicloud"]
+                )
+                # Should fall back to defaults due to PermissionError
+                assert engine._task_routing == DEFAULT_TASK_ROUTING
 
 
 class TestPolicyValidJSON:
@@ -346,7 +348,6 @@ class TestPolicyLogging:
         valid_json = tmp_path / "valid.json"
         valid_json.write_text(json.dumps({"task_types": {}}))
 
-        import logging
         with caplog.at_level(logging.INFO):
             RoutingEngine(
                 policy_path=valid_json,
@@ -360,7 +361,6 @@ class TestPolicyLogging:
         bad_json = tmp_path / "bad.json"
         bad_json.write_text("{ invalid }")
 
-        import logging
         with caplog.at_level(logging.WARNING):
             RoutingEngine(
                 policy_path=bad_json,
@@ -371,7 +371,6 @@ class TestPolicyLogging:
 
     def test_load_policy_logs_info_when_no_file(self, caplog):
         """Should log info when no policy file found"""
-        import logging
         with caplog.at_level(logging.INFO):
             # Use a path that definitely doesn't exist
             with patch.object(Path, 'exists', return_value=False):


### PR DESCRIPTION
# test(routing): add routing_policy.json loading and error handling tests

## Summary

Adds 25 unit tests for `routing_policy.json` loading and error handling in the RoutingEngine. This addresses issue #2672 as part of EPIC #2594 (Qwen3 Provider Integration).

**Test coverage includes:**
- File not found scenarios (3 tests)
- Malformed JSON handling (4 tests) - empty, truncated, invalid syntax
- Partial JSON with missing sections (3 tests)
- Custom task_types from JSON (3 tests)
- File permission issues (1 test) - now mock-based for CI stability
- Valid JSON loading (3 tests)
- Invalid values handling (3 tests) - tier 99, negative tier, string tier
- Logging verification (3 tests)
- Integration with select_model (2 tests)

All tests verify that the engine gracefully falls back to `DEFAULT_TASK_ROUTING` when JSON loading fails.

## Updates since last revision

Addressed CTO review feedback:
- Moved `import logging` to top of file (PEP 8 compliance)
- Converted permission test from `chmod(0o000)` to mock-based approach for cross-platform CI stability
- Added docstring to `test_load_policy_empty_task_types_uses_empty` explaining design intent (empty dict is valid, `select_model()` safely falls back to tier 2)

## Review & Testing Checklist for Human

- [ ] **Verify mock-based permission test** - `test_load_policy_permission_denied_uses_defaults` now uses `patch.object(Path, 'read_text', side_effect=PermissionError)` instead of chmod
- [ ] **Run tests locally** - `pytest tests/test_routing_policy_loading.py -v` should pass all 25 tests

**Suggested test plan:**
1. Run the new test file: `cd orchestrator && pytest tests/test_routing_policy_loading.py -v`
2. Verify no regressions in existing routing tests: `pytest tests/test_routing_engine.py -v`

### Notes

- Test-only PR, no production code changes
- Invalid tier values (99, -1, "0") are intentionally loaded without validation - validation happens at `select_model()` time
- Empty `task_types: {}` is valid by design - `select_model()` uses `.get()` with default tier 2

Closes #2672

---
**Link to Devin run:** https://app.devin.ai/sessions/74ebce460cde41a8957c963d433f7a73
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918