### PR TITLE
test(routing): add type error handling and multi-threading safety tests

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_routing_type_errors_threading.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_routing_type_errors_threading.py
@@ -3,118 +3,142 @@ Unit tests for type error handling and multi-threading safety in RoutingEngine
 
 Issue #2687 - EPIC #2594: Qwen3 Provider Integration
 
-Tests cover:
-- Type error handling for context_size parameter (None, string, float)
-- Multi-threading safety for concurrent select_model() calls
-- Thread-safe access to _task_routing and TIER_CONTEXT_LIMITS
+Type Contract for context_size parameter:
+- int: Supported (including negative values, which are treated as within limit)
+- float: Supported (implicit comparison works in Python)
+- bool: Supported (bool is subclass of int in Python)
+- None: Raises TypeError (cannot compare with int)
+- str/list/dict: Raises TypeError
+
+Threading Behavior:
+- Concurrent read operations (select_model, get_tier_for_task) are safe
+- Concurrent write operations (set_available_providers) during reads may have
+  race conditions but will not crash or produce invalid results
+- These tests verify basic invariants, not strict thread-safety guarantees
 """
 import concurrent.futures
+import queue
 import threading
 import pytest
 
 from core.routing import RoutingEngine, Tier, TaskType
 
 
-class TestContextSizeTypeErrors:
-    """Tests for type error handling in context_size parameter"""
+class TestContextSizeTypeContract:
+    """Tests documenting the type contract for context_size parameter.
+
+    These tests define the expected API behavior for different input types.
+    The contract is based on the current implementation where context_size
+    is compared with int using `context_size > 0`.
+    """
 
     def test_context_size_none_raises_type_error(self):
-        """context_size=None should raise TypeError (comparison with int fails)"""
+        """context_size=None raises TypeError (cannot compare None > int)"""
         engine = RoutingEngine(available_providers=["alicloud"])
 
-        # None cannot be compared with int, so TypeError is expected
         with pytest.raises(TypeError):
             engine.select_model(TaskType.CODING, context_size=None)
 
     def test_context_size_string_raises_type_error(self):
-        """context_size as string should raise TypeError"""
+        """context_size as string raises TypeError (cannot compare str > int)"""
         engine = RoutingEngine(available_providers=["alicloud"])
 
         with pytest.raises(TypeError):
             engine.select_model(TaskType.CODING, context_size="1000")
 
-    def test_context_size_float_handled_or_raises(self):
-        """context_size as float should either work (truncated) or raise TypeError"""
+    def test_context_size_float_is_supported(self):
+        """context_size as float is supported (implicit comparison works).
+
+        Float values are accepted because Python allows float > int comparison.
+        This is documented behavior, not a bug.
+        """
         engine = RoutingEngine(available_providers=["alicloud"])
 
-        # Float might be implicitly converted to int or raise TypeError
-        # This test documents the actual behavior
-        try:
-            model = engine.select_model(TaskType.CODING, context_size=1000.5)
-            # If it works, should return valid model
-            assert model is not None
-            assert model.tier == Tier.TIER_1
-        except TypeError:
-            # TypeError is also acceptable behavior
-            pass
+        model = engine.select_model(TaskType.CODING, context_size=1000.5)
 
-    def test_context_size_negative_float_handled(self):
-        """context_size as negative float should be handled gracefully"""
+        assert model is not None
+        assert model.tier == Tier.TIER_1
+        assert model.provider == "alicloud"
+
+    def test_context_size_negative_float_is_supported(self):
+        """context_size as negative float is supported (treated as within limit)"""
         engine = RoutingEngine(available_providers=["alicloud"])
 
-        try:
-            model = engine.select_model(TaskType.CODING, context_size=-1000.5)
-            # If it works, should return valid model with default tier
-            assert model is not None
-            assert model.tier == Tier.TIER_1
-        except TypeError:
-            # TypeError is also acceptable behavior
-            pass
+        model = engine.select_model(TaskType.CODING, context_size=-1000.5)
 
-    def test_context_size_bool_true_handled(self):
-        """context_size=True (bool) should be handled (bool is subclass of int)"""
+        assert model is not None
+        assert model.tier == Tier.TIER_1
+
+    def test_context_size_bool_true_is_supported(self):
+        """context_size=True is supported (bool is subclass of int, True==1)"""
         engine = RoutingEngine(available_providers=["alicloud"])
 
-        # True == 1 in Python, so this should work
         model = engine.select_model(TaskType.CODING, context_size=True)
 
         assert model is not None
-        # context_size=1 should not affect tier selection
         assert model.tier == Tier.TIER_1
 
-    def test_context_size_bool_false_handled(self):
-        """context_size=False (bool) should be handled (bool is subclass of int)"""
+    def test_context_size_bool_false_is_supported(self):
+        """context_size=False is supported (bool is subclass of int, False==0)"""
         engine = RoutingEngine(available_providers=["alicloud"])
 
-        # False == 0 in Python, so this should work
         model = engine.select_model(TaskType.CODING, context_size=False)
 
         assert model is not None
         assert model.tier == Tier.TIER_1
 
     def test_context_size_list_raises_type_error(self):
-        """context_size as list should raise TypeError"""
+        """context_size as list raises TypeError"""
         engine = RoutingEngine(available_providers=["alicloud"])
 
         with pytest.raises(TypeError):
             engine.select_model(TaskType.CODING, context_size=[1000])
 
     def test_context_size_dict_raises_type_error(self):
-        """context_size as dict should raise TypeError"""
+        """context_size as dict raises TypeError"""
         engine = RoutingEngine(available_providers=["alicloud"])
 
         with pytest.raises(TypeError):
             engine.select_model(TaskType.CODING, context_size={"size": 1000})
 
 
-class TestMultiThreadingSafety:
-    """Tests for multi-threading safety in RoutingEngine"""
+class TestConcurrentReadOperations:
+    """Tests for concurrent read operations on RoutingEngine.
 
-    def test_concurrent_select_model_calls(self):
-        """Multiple threads calling select_model() should not cause race conditions"""
-        engine = RoutingEngine(available_providers=["alicloud", "siliconflow"])
-        results = []
-        errors = []
+    These tests verify that concurrent calls to read-only methods
+    (select_model, get_tier_for_task) maintain basic invariants:
+    - No exceptions raised
+    - Results are valid (provider in allowed set, tier is valid enum)
+    - Consistent results for identical inputs
+    """
 
-        def call_select_model(task_type, context_size):
-            try:
-                model = engine.select_model(task_type, context_size=context_size)
-                results.append((task_type, model.tier, model.model_name))
-            except Exception as e:
-                errors.append((task_type, str(e)))
+    def test_concurrent_select_model_maintains_invariants(self):
+        """Concurrent select_model() calls maintain basic invariants.
 
-        # Create multiple threads with different task types and context sizes
-        threads = []
+        Uses threading.Barrier to synchronize thread start for maximum contention.
+        Verifies that all results have valid provider, tier, and model_name.
+        """
+        allowed_providers = ["alicloud", "siliconflow"]
+        engine = RoutingEngine(available_providers=allowed_providers)
+        results = queue.Queue()
+        errors = queue.Queue()
+        num_threads = 8
+        iterations_per_thread = 50
+        barrier = threading.Barrier(num_threads)
+
+        def worker(task_type, context_size):
+            barrier.wait()  # Synchronize start for maximum contention
+            for _ in range(iterations_per_thread):
+                try:
+                    model = engine.select_model(task_type, context_size=context_size)
+                    # Verify invariants
+                    assert model.provider in allowed_providers
+                    assert model.tier in list(Tier)
+                    assert model.model_name
+                    results.put((task_type, model.tier, model.model_name, model.provider))
+                except Exception as e:
+                    errors.put((task_type, str(e)))
+
         test_cases = [
             (TaskType.PLANNING, 1000),
             (TaskType.CODING, 50000),
@@ -126,31 +150,38 @@ class TestMultiThreadingSafety:
             (TaskType.CHAT, 10000),
         ]
 
-        for task_type, context_size in test_cases:
-            t = threading.Thread(target=call_select_model, args=(task_type, context_size))
-            threads.append(t)
+        threads = [
+            threading.Thread(target=worker, args=test_cases[i % len(test_cases)])
+            for i in range(num_threads)
+        ]
 
-        # Start all threads
         for t in threads:
             t.start()
-
-        # Wait for all threads to complete
         for t in threads:
             t.join()
 
         # Verify no errors occurred
-        assert len(errors) == 0, f"Errors occurred: {errors}"
+        error_list = []
+        while not errors.empty():
+            error_list.append(errors.get())
+        assert len(error_list) == 0, f"Errors occurred: {error_list}"
 
-        # Verify all calls returned results
-        assert len(results) == len(test_cases)
+        # Verify expected number of results
+        assert results.qsize() == num_threads * iterations_per_thread
 
     def test_concurrent_select_model_with_thread_pool(self):
-        """ThreadPoolExecutor should handle concurrent select_model() calls"""
-        engine = RoutingEngine(available_providers=["alicloud", "siliconflow"])
+        """ThreadPoolExecutor handles concurrent select_model() with invariant checks"""
+        allowed_providers = ["alicloud", "siliconflow"]
+        engine = RoutingEngine(available_providers=allowed_providers)
 
-        def select_model_task(args):
+        def select_and_verify(args):
             task_type, context_size = args
-            return engine.select_model(task_type, context_size=context_size)
+            model = engine.select_model(task_type, context_size=context_size)
+            # Verify invariants
+            assert model.provider in allowed_providers
+            assert model.tier in list(Tier)
+            assert model.model_name
+            return model
 
         test_cases = [
             (TaskType.PLANNING, 1000),
@@ -161,29 +192,29 @@ class TestMultiThreadingSafety:
             (TaskType.SUMMARIZATION, 30000),
             (TaskType.ANALYSIS, 80000),
             (TaskType.CHAT, 10000),
-        ] * 10  # Run each case 10 times
+        ] * 20  # Run each case 20 times
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
-            futures = [executor.submit(select_model_task, case) for case in test_cases]
+            futures = [executor.submit(select_and_verify, case) for case in test_cases]
             results = [f.result() for f in concurrent.futures.as_completed(futures)]
 
-        # All calls should succeed
         assert len(results) == len(test_cases)
-        for model in results:
-            assert model is not None
-            assert model.tier in list(Tier)
 
-    def test_concurrent_access_to_task_routing(self):
-        """Concurrent reads of _task_routing should be safe"""
+    def test_concurrent_get_tier_for_task_is_consistent(self):
+        """Concurrent get_tier_for_task() returns consistent results"""
         engine = RoutingEngine(available_providers=["alicloud"])
-        results = []
+        results = queue.Queue()
+        num_threads = 4
+        iterations = 100
+        barrier = threading.Barrier(num_threads)
 
-        def read_task_routing():
-            for _ in range(100):
+        def worker():
+            barrier.wait()
+            for _ in range(iterations):
                 tier = engine.get_tier_for_task(TaskType.CODING)
-                results.append(tier)
+                results.put(tier)
 
-        threads = [threading.Thread(target=read_task_routing) for _ in range(4)]
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
 
         for t in threads:
             t.start()
@@ -191,106 +222,147 @@ class TestMultiThreadingSafety:
             t.join()
 
         # All reads should return consistent results
-        assert len(results) == 400
-        assert all(tier == Tier.TIER_1 for tier in results)
+        result_list = []
+        while not results.empty():
+            result_list.append(results.get())
 
-    def test_concurrent_select_model_same_task_type(self):
-        """Multiple threads selecting model for same task type should be consistent"""
+        assert len(result_list) == num_threads * iterations
+        assert all(tier == Tier.TIER_1 for tier in result_list)
+
+    def test_concurrent_select_model_same_input_is_consistent(self):
+        """Concurrent select_model() with same input returns consistent results"""
         engine = RoutingEngine(available_providers=["alicloud"])
-        results = []
-        lock = threading.Lock()
+        results = queue.Queue()
+        num_threads = 4
+        iterations = 50
+        barrier = threading.Barrier(num_threads)
 
-        def select_same_task():
-            for _ in range(50):
+        def worker():
+            barrier.wait()
+            for _ in range(iterations):
                 model = engine.select_model(TaskType.PLANNING, context_size=1000)
-                with lock:
-                    results.append(model.model_name)
+                results.put(model.model_name)
 
-        threads = [threading.Thread(target=select_same_task) for _ in range(4)]
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
 
         for t in threads:
             t.start()
         for t in threads:
             t.join()
 
-        # All results should be the same model
-        assert len(results) == 200
-        assert len(set(results)) == 1  # All same model name
+        result_list = []
+        while not results.empty():
+            result_list.append(results.get())
 
-    def test_concurrent_select_model_with_large_context(self):
-        """Concurrent calls with large context should all upgrade tier correctly"""
+        assert len(result_list) == num_threads * iterations
+        assert len(set(result_list)) == 1  # All same model name
+
+    def test_concurrent_select_model_tier_upgrade_is_consistent(self):
+        """Concurrent calls with large context consistently upgrade tier"""
         engine = RoutingEngine(available_providers=["alicloud"])
-        results = []
+        results = queue.Queue()
+        num_threads = 4
+        iterations = 25
+        barrier = threading.Barrier(num_threads)
 
-        def select_with_large_context():
-            for _ in range(25):
+        def worker():
+            barrier.wait()
+            for _ in range(iterations):
                 # UX_COPY defaults to Tier 3, but 50000 tokens should upgrade
                 model = engine.select_model(TaskType.UX_COPY, context_size=50000)
-                results.append(model.tier)
+                results.put(model.tier)
 
-        threads = [threading.Thread(target=select_with_large_context) for _ in range(4)]
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
 
         for t in threads:
             t.start()
         for t in threads:
             t.join()
 
-        # All results should be upgraded tier (Tier 0 or 1)
-        assert len(results) == 100
-        for tier in results:
+        result_list = []
+        while not results.empty():
+            result_list.append(results.get())
+
+        assert len(result_list) == num_threads * iterations
+        for tier in result_list:
             assert tier.value <= Tier.TIER_1.value
 
 
-class TestThreadSafeProviderAccess:
-    """Tests for thread-safe access to provider configurations"""
+class TestConcurrentMixedOperations:
+    """Tests for concurrent read and write operations.
 
-    def test_concurrent_provider_availability_check(self):
-        """Concurrent checks of provider availability should be safe"""
-        engine = RoutingEngine(available_providers=["alicloud", "siliconflow"])
-        results = []
+    These tests verify that concurrent reads and writes do not crash
+    and maintain basic invariants. They do NOT guarantee strict
+    thread-safety or atomicity - that would require design-level
+    synchronization in RoutingEngine.
 
-        def check_providers():
-            for _ in range(100):
+    Purpose: Regression guard to catch obvious shared-state corruption.
+    """
+
+    def test_concurrent_provider_reads_maintain_invariants(self):
+        """Concurrent provider availability checks maintain invariants"""
+        allowed_providers = ["alicloud", "siliconflow"]
+        engine = RoutingEngine(available_providers=allowed_providers)
+        results = queue.Queue()
+        num_threads = 4
+        iterations = 100
+        barrier = threading.Barrier(num_threads)
+
+        def worker():
+            barrier.wait()
+            for _ in range(iterations):
                 model = engine.select_model(TaskType.CODING)
-                results.append(model.provider)
+                results.put(model.provider)
 
-        threads = [threading.Thread(target=check_providers) for _ in range(4)]
+        threads = [threading.Thread(target=worker) for _ in range(num_threads)]
 
         for t in threads:
             t.start()
         for t in threads:
             t.join()
 
-        # All results should be valid providers
-        assert len(results) == 400
-        assert all(p in ["alicloud", "siliconflow"] for p in results)
+        result_list = []
+        while not results.empty():
+            result_list.append(results.get())
 
-    def test_concurrent_set_available_providers(self):
-        """Concurrent updates to available_providers should not crash"""
+        assert len(result_list) == num_threads * iterations
+        assert all(p in allowed_providers for p in result_list)
+
+    def test_concurrent_read_write_no_crash(self):
+        """Concurrent reads and writes do not crash (best-effort regression guard).
+
+        This test verifies that concurrent set_available_providers() calls
+        during select_model() calls do not cause crashes or produce invalid
+        results (provider not in any valid set, invalid tier, empty model_name).
+
+        NOTE: This does NOT guarantee strict thread-safety. The test catches
+        obvious corruption but cannot detect all race conditions.
+        """
+        all_valid_providers = {"alicloud", "siliconflow"}
         engine = RoutingEngine(available_providers=["alicloud"])
-        errors = []
+        errors = queue.Queue()
+        num_iterations = 50
+        barrier = threading.Barrier(3)
 
         def update_providers():
-            try:
-                for i in range(50):
-                    if i % 2 == 0:
-                        engine.set_available_providers(["alicloud"])
-                    else:
-                        engine.set_available_providers(["alicloud", "siliconflow"])
-            except Exception as e:
-                errors.append(str(e))
+            barrier.wait()
+            for i in range(num_iterations):
+                providers = ["alicloud"] if i % 2 == 0 else ["alicloud", "siliconflow"]
+                engine.set_available_providers(providers)
 
-        def select_models():
-            try:
-                for _ in range(50):
-                    engine.select_model(TaskType.CODING)
-            except Exception as e:
-                errors.append(str(e))
+        def select_and_verify():
+            barrier.wait()
+            for _ in range(num_iterations):
+                try:
+                    model = engine.select_model(TaskType.CODING)
+                    self._verify_model_invariants(model, all_valid_providers, errors)
+                except ValueError:
+                    pass  # Acceptable if no provider available briefly
 
         threads = [
             threading.Thread(target=update_providers),
-            threading.Thread(target=select_models),
-            threading.Thread(target=select_models),
+            threading.Thread(target=select_and_verify),
+            threading.Thread(target=select_and_verify),
         ]
 
         for t in threads:
@@ -298,44 +370,54 @@ class TestThreadSafeProviderAccess:
         for t in threads:
             t.join()
 
-        # Should not have any errors (or only expected ones)
-        # Note: This test may reveal race conditions if they exist
-        assert len(errors) == 0, f"Errors occurred: {errors}"
+        error_list = list(errors.queue)
+        assert len(error_list) == 0, f"Errors occurred: {error_list}"
+
+    def _verify_model_invariants(self, model, valid_providers, errors):
+        """Helper to verify model invariants and report errors."""
+        if model.provider not in valid_providers:
+            errors.put(f"Invalid provider: {model.provider}")
+        if model.tier not in list(Tier):
+            errors.put(f"Invalid tier: {model.tier}")
+        if not model.model_name:
+            errors.put("Empty model_name")
 
 
 class TestEdgeCasesWithTypeCoercion:
     """Tests for edge cases involving type coercion"""
 
-    def test_context_size_numpy_int_if_available(self):
-        """context_size as numpy int should work if numpy is available"""
+    def test_context_size_numpy_int_is_supported(self):
+        """context_size as numpy int is supported if numpy is available"""
         try:
             import numpy as np
-            engine = RoutingEngine(available_providers=["alicloud"])
-
-            model = engine.select_model(TaskType.CODING, context_size=np.int64(1000))
-
-            assert model is not None
-            assert model.tier == Tier.TIER_1
         except ImportError:
             pytest.skip("numpy not available")
 
-    def test_context_size_large_int(self):
-        """Very large int context_size should be handled"""
         engine = RoutingEngine(available_providers=["alicloud"])
 
-        # Python can handle arbitrarily large integers
+        model = engine.select_model(TaskType.CODING, context_size=np.int64(1000))
+
+        assert model is not None
+        assert model.tier == Tier.TIER_1
+
+    def test_context_size_large_int_uses_tier_0(self):
+        """Very large int context_size uses Tier 0 (highest capability).
+
+        Python handles arbitrarily large integers without overflow.
+        This test documents that extremely large values are handled gracefully.
+        """
+        engine = RoutingEngine(available_providers=["alicloud"])
+
         model = engine.select_model(TaskType.CODING, context_size=10**18)
 
-        # Should use Tier 0 (highest capability)
         assert model.tier == Tier.TIER_0
 
-    def test_context_size_zero_vs_default(self):
-        """context_size=0 should behave same as not specifying context_size"""
+    def test_context_size_zero_same_as_default(self):
+        """context_size=0 behaves same as not specifying context_size"""
         engine = RoutingEngine(available_providers=["alicloud"])
 
         model_zero = engine.select_model(TaskType.CODING, context_size=0)
         model_default = engine.select_model(TaskType.CODING)
 
-        # Both should return same tier (context_size=0 doesn't trigger adjustment)
         assert model_zero.tier == model_default.tier
         assert model_zero.model_name == model_default.model_name


### PR DESCRIPTION
# test(routing): add type error handling and multi-threading safety tests

## Summary

Adds 18 unit tests for RoutingEngine covering type error handling and multi-threading safety. This addresses issue #2687 as part of EPIC #2594 (Qwen3 Provider Integration).

**Test coverage includes:**
- Type contract tests for `context_size` parameter: None, string, float, bool, list, dict (8 tests)
- Concurrent read operations with invariant verification (5 tests)
- Concurrent mixed operations (read/write) regression guard (2 tests)
- Edge cases with type coercion: numpy int, large int, zero vs default (3 tests)

**Type Contract (documented in file header):**
- `int`: Supported (including negative values)
- `float`: Supported (implicit comparison works)
- `bool`: Supported (bool is subclass of int)
- `None/str/list/dict`: Raises TypeError

**Threading Behavior:**
- Concurrent read operations maintain basic invariants
- Concurrent write operations during reads may have race conditions but will not crash or produce invalid results
- Tests verify invariants, not strict thread-safety guarantees

## Updates since last revision

Addressed CTO review feedback:
- Renamed test classes to better reflect purpose (`TestContextSizeTypeContract`, `TestConcurrentReadOperations`, `TestConcurrentMixedOperations`)
- Removed try/except patterns - all tests now use explicit assertions
- Added comprehensive docstrings documenting API behavior
- Using `queue.Queue` instead of lists for thread-safe result collection
- Using `threading.Barrier` for synchronized thread start (maximum contention)
- Added invariant verification in all concurrent tests
- Extracted `_verify_model_invariants` helper to reduce complexity
- **Flakiness check passed:** 20 consecutive runs with 0 failures

## Review & Testing Checklist for Human

- [ ] **Verify threading tests are not flaky** - Run `pytest tests/test_routing_type_errors_threading.py -v` multiple times
- [ ] **Review `test_concurrent_read_write_no_crash`** - This test explicitly does NOT guarantee strict thread-safety; it's a regression guard for obvious corruption only
- [ ] **Confirm type contract is desired** - Tests now enforce that `context_size=None` raises TypeError. Is this the intended API contract?

**Suggested test plan:**
```bash
# Run the new test file
pytest tests/test_routing_type_errors_threading.py -v

# Run multiple times to check for flakiness
for i in {1..10}; do pytest tests/test_routing_type_errors_threading.py -q; done
```

### Notes

- Test-only PR, no production code changes
- 1 test skipped when numpy is not available (`test_context_size_numpy_int_is_supported`)
- Local testing: 17 passed, 1 skipped in 0.14s
- 20 consecutive runs passed with no failures

Closes #2687

---
**Link to Devin run:** https://app.devin.ai/sessions/74ebce460cde41a8957c963d433f7a73
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918