### PR TITLE
feat(reviewer): add review comment schema with start_line/end_line support (EPIC B Phase B-2)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/review_comment_schema.py
+++ b/handoff/20250928/40_App/orchestrator/review_comment_schema.py
@@ -26,7 +26,7 @@ Usage:
     normalized = normalize_review_comments(raw_comments)
 """
 import logging
-from typing import Any, Dict, List, Optional, TypedDict, Literal
+from typing import Any, Dict, List, Optional, TypedDict, Literal, get_args
 
 logger = logging.getLogger(__name__)
 
@@ -140,10 +140,8 @@ def _normalize_category(category: Optional[str]) -> CommentCategory:
         return DEFAULT_CATEGORY
 
     category_lower = category.lower().strip()
-    valid_categories = {
-        "style", "bug", "performance", "security",
-        "maintainability", "documentation", "other"
-    }
+    # Use get_args to keep Literal and set in sync
+    valid_categories = set(get_args(CommentCategory))
 
     if category_lower in valid_categories:
         return category_lower  # type: ignore
@@ -303,11 +301,19 @@ def parse_review_comment(
     if file_path and isinstance(file_path, str):
         comment["file"] = file_path.strip()
 
-    # Add line numbers if valid
-    if start_line is not None:
-        comment["start_line"] = start_line
-    if end_line is not None:
-        comment["end_line"] = end_line
+    # Add line numbers only if valid
+    # When line_valid=False (e.g., range > 500 lines), downgrade to file-level comment
+    # This prevents suspicious/hallucinated ranges from being posted as inline comments
+    if line_valid:
+        if start_line is not None:
+            comment["start_line"] = start_line
+        if end_line is not None:
+            comment["end_line"] = end_line
+    else:
+        logger.warning(
+            f"[ReviewCommentSchema] Downgrading to file-level comment due to "
+            f"invalid line range (start={start_line}, end={end_line})"
+        )
 
     # Optionally preserve raw for debugging
     if preserve_raw:

--- a/handoff/20250928/40_App/orchestrator/tests/test_review_comment_schema.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_review_comment_schema.py
@@ -503,3 +503,36 @@ class TestEdgeCases:
 
         assert comment is not None
         assert "修復" in comment["message"]
+
+    def test_large_range_downgrades_to_file_level(self):
+        """When line range is too large (>500), downgrade to file-level comment"""
+        raw = {
+            "message": "Suspicious range",
+            "file": "src/test.py",
+            "start_line": 1,
+            "end_line": 600  # > MAX_LINE_RANGE (500)
+        }
+        comment = parse_review_comment(raw)
+
+        assert comment is not None
+        assert comment["file"] == "src/test.py"
+        # Line info should be stripped (downgraded to file-level)
+        assert comment.get("start_line") is None
+        assert comment.get("end_line") is None
+        # Should NOT be considered an inline comment
+        assert is_inline_comment(comment) is False
+
+    def test_valid_range_keeps_line_info(self):
+        """Valid line ranges should keep line info"""
+        raw = {
+            "message": "Valid range",
+            "file": "src/test.py",
+            "start_line": 1,
+            "end_line": 100  # < MAX_LINE_RANGE (500)
+        }
+        comment = parse_review_comment(raw)
+
+        assert comment is not None
+        assert comment["start_line"] == 1
+        assert comment["end_line"] == 100
+        assert is_inline_comment(comment) is True


### PR DESCRIPTION
# feat(reviewer): add review comment schema with start_line/end_line support (EPIC B Phase B-2)

## Summary

Adds a new `review_comment_schema.py` module that defines a canonical schema for review comments, supporting both the old `line` format and the new `start_line/end_line` format for multi-line comments. This is Phase B-2 of EPIC B (Diff-Aware Review Plumbing) - schema definition only, no integration with existing code yet.

Key features:
- **Backward compatible parser**: Handles both `{"line": 42}` and `{"start_line": 10, "end_line": 15}` formats
- **Severity normalization**: Maps LLM severities (nit/suggestion/warning/error) and CI severities (low/medium/high/critical) to a canonical taxonomy
- **Line range validation**: Swaps reversed ranges, rejects negative/zero values, **downgrades suspicious ranges (>500 lines) to file-level comments**
- **GitHub payload helper**: `to_github_inline_payload()` prepares comments for Phase B-3 inline review posting

## Updates since last revision

Addressed review feedback:
1. **[Critical fix]** When `line_valid=False` (e.g., range > 500 lines), line info is now stripped to downgrade to file-level comment. This prevents suspicious/hallucinated ranges from being posted as inline comments.
2. **[Maintainability]** Use `get_args(CommentCategory)` to keep Literal type and validation set in sync.

Added 2 new tests: `test_large_range_downgrades_to_file_level` and `test_valid_range_keeps_line_info`.

## Review & Testing Checklist for Human

- [ ] **Verify downgrade behavior**: Comments with range > 500 lines should have `start_line`/`end_line` stripped and `is_inline_comment()` should return `False` (see `test_large_range_downgrades_to_file_level`)
- [ ] **Verify severity mappings are correct**: LLM "nit" → "info", CI "high" → "error", etc. (lines 79-93 in `review_comment_schema.py`)
- [ ] **Confirm schema design is compatible** with existing `reviewer_node` and `comment_triage.py` consumers before Phase B-3 integration

**Recommended test plan:**
1. Run `pytest tests/test_review_comment_schema.py -v` (59 tests should pass)
2. Review the severity mapping tables to ensure they align with business requirements
3. This module is not integrated yet - no end-to-end testing needed until Phase B-3

### Notes

- This is a **standalone module** - not yet integrated into the workflow. Integration happens in Phase B-3.
- The `to_github_inline_payload()` function is included as a preview but should not be used until Phase B-3 is implemented.
- Issue #2595: EPIC B - Diff-Aware Review Plumbing

Link to Devin run: https://app.devin.ai/sessions/67bc479436f84775b72aeeb8f3da0c33
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918