### PR TITLE
test(publisher): add comprehensive unit tests for post_pr_review and publisher_node (Issue #2706)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_publisher_node.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_publisher_node.py
@@ -571,8 +571,8 @@ class TestPublisherNodeNoOp:
         }
 
         with patch("langgraph_orchestrator.settings", mock_settings):
-            with patch("langgraph_orchestrator.metrics", mock_metrics):
-                with patch("langgraph_orchestrator.get_repo") as mock_get_repo:
+            with patch("langgraph_orchestrator._get_metrics", return_value=mock_metrics):
+                with patch("tools.github_api.get_repo") as mock_get_repo:
                     from langgraph_orchestrator import publisher_node
 
                     result = publisher_node(state)
@@ -596,8 +596,8 @@ class TestPublisherNodeNoOp:
         }
 
         with patch("langgraph_orchestrator.settings", mock_settings):
-            with patch("langgraph_orchestrator.metrics", mock_metrics):
-                with patch("langgraph_orchestrator.get_repo") as mock_get_repo:
+            with patch("langgraph_orchestrator._get_metrics", return_value=mock_metrics):
+                with patch("tools.github_api.get_repo") as mock_get_repo:
                     from langgraph_orchestrator import publisher_node
 
                     result = publisher_node(state)
@@ -620,8 +620,8 @@ class TestPublisherNodeNoOp:
         }
 
         with patch("langgraph_orchestrator.settings", mock_settings):
-            with patch("langgraph_orchestrator.metrics", mock_metrics):
-                with patch("langgraph_orchestrator.get_repo") as mock_get_repo:
+            with patch("langgraph_orchestrator._get_metrics", return_value=mock_metrics):
+                with patch("tools.github_api.get_repo") as mock_get_repo:
                     from langgraph_orchestrator import publisher_node
 
                     result = publisher_node(state)
@@ -644,9 +644,9 @@ class TestPublisherNodeNoOp:
         }
 
         with patch("langgraph_orchestrator.settings", mock_settings):
-            with patch("langgraph_orchestrator.metrics", mock_metrics):
-                with patch("langgraph_orchestrator.is_inline_comment", return_value=False):
-                    with patch("langgraph_orchestrator.get_repo") as mock_get_repo:
+            with patch("langgraph_orchestrator._get_metrics", return_value=mock_metrics):
+                with patch("review_comment_schema.is_inline_comment", return_value=False):
+                    with patch("tools.github_api.get_repo") as mock_get_repo:
                         from langgraph_orchestrator import publisher_node
 
                         result = publisher_node(state)
@@ -687,10 +687,10 @@ class TestPublisherNodeIntegration:
         }
 
         with patch("langgraph_orchestrator.settings", mock_settings):
-            with patch("langgraph_orchestrator.metrics", mock_metrics):
-                with patch("langgraph_orchestrator.get_repo", return_value=mock_repo):
-                    with patch("langgraph_orchestrator.post_pr_review", return_value=mock_post_result):
-                        with patch("langgraph_orchestrator.is_inline_comment", return_value=True):
+            with patch("langgraph_orchestrator._get_metrics", return_value=mock_metrics):
+                with patch("tools.github_api.get_repo", return_value=mock_repo):
+                    with patch("tools.github_api.post_pr_review", return_value=mock_post_result):
+                        with patch("review_comment_schema.is_inline_comment", return_value=True):
                             from langgraph_orchestrator import publisher_node
 
                             result = publisher_node(state)
@@ -724,10 +724,10 @@ class TestPublisherNodeIntegration:
         }
 
         with patch("langgraph_orchestrator.settings", mock_settings):
-            with patch("langgraph_orchestrator.metrics", mock_metrics):
-                with patch("langgraph_orchestrator.get_repo", return_value=mock_repo):
-                    with patch("langgraph_orchestrator.post_pr_review", return_value=mock_post_result):
-                        with patch("langgraph_orchestrator.is_inline_comment", return_value=True):
+            with patch("langgraph_orchestrator._get_metrics", return_value=mock_metrics):
+                with patch("tools.github_api.get_repo", return_value=mock_repo):
+                    with patch("tools.github_api.post_pr_review", return_value=mock_post_result):
+                        with patch("review_comment_schema.is_inline_comment", return_value=True):
                             from langgraph_orchestrator import publisher_node
 
                             result = publisher_node(state)
@@ -762,10 +762,10 @@ class TestPublisherNodeIntegration:
         }
 
         with patch("langgraph_orchestrator.settings", mock_settings):
-            with patch("langgraph_orchestrator.metrics", mock_metrics):
-                with patch("langgraph_orchestrator.get_repo", return_value=mock_repo):
-                    with patch("langgraph_orchestrator.post_pr_review", return_value=mock_post_result):
-                        with patch("langgraph_orchestrator.is_inline_comment", return_value=True):
+            with patch("langgraph_orchestrator._get_metrics", return_value=mock_metrics):
+                with patch("tools.github_api.get_repo", return_value=mock_repo):
+                    with patch("tools.github_api.post_pr_review", return_value=mock_post_result):
+                        with patch("review_comment_schema.is_inline_comment", return_value=True):
                             from langgraph_orchestrator import publisher_node
 
                             result = publisher_node(state)
@@ -799,10 +799,10 @@ class TestPublisherNodeIntegration:
         }
 
         with patch("langgraph_orchestrator.settings", mock_settings):
-            with patch("langgraph_orchestrator.metrics", mock_metrics):
-                with patch("langgraph_orchestrator.get_repo", return_value=mock_repo):
-                    with patch("langgraph_orchestrator.post_pr_review", return_value=mock_post_result):
-                        with patch("langgraph_orchestrator.is_inline_comment", return_value=True):
+            with patch("langgraph_orchestrator._get_metrics", return_value=mock_metrics):
+                with patch("tools.github_api.get_repo", return_value=mock_repo):
+                    with patch("tools.github_api.post_pr_review", return_value=mock_post_result):
+                        with patch("review_comment_schema.is_inline_comment", return_value=True):
                             from langgraph_orchestrator import publisher_node
 
                             result = publisher_node(state)


### PR DESCRIPTION
# test(publisher): add unit tests for post_pr_review and publisher_node (Issue #2706)

## Summary
Adds comprehensive unit tests for the `post_pr_review()` function and `publisher_node` that were added in PR #2701 but lacked test coverage due to local environment import conflicts.

**Test coverage includes:**
- Feature flag behavior (disabled, dry-run, live mode) - 3 tests
- Fallback mechanism for 422/404 errors (Review Body Appendix) - 5 tests
- Error handling for 401, 403, UnknownObjectException - 4 tests
- Comment processing (empty, missing fields, truncation, multi-line) - 5 tests
- Publisher node no-op behavior - 4 tests
- Publisher node integration with post_pr_review - 4 tests

**Total: 25 tests (17 for post_pr_review, 8 for publisher_node)**

Publisher node tests require `langgraph` and are skipped when not available locally.

## Updates since last revision
- Fixed mock paths for publisher_node tests - was incorrectly patching non-existent `langgraph_orchestrator.metrics`, now correctly patches `langgraph_orchestrator._get_metrics`
- Fixed import paths for functions imported inside `publisher_node`: `tools.github_api.get_repo`, `tools.github_api.post_pr_review`, `review_comment_schema.is_inline_comment`
- All 40 CI checks now pass (previously 8 publisher_node tests were failing with AttributeError)

## Review & Testing Checklist for Human
- [ ] **Verify mock paths match actual imports**: Tests patch `common.config.settings.settings` for post_pr_review and `langgraph_orchestrator.settings` for publisher_node - confirm these match how settings is imported in each module
- [ ] **Spot-check fallback behavior**: Review `TestPostPrReviewFallback` tests to ensure 422/404 fallback logic matches implementation in `tools/github_api.py` lines 402-632
- [ ] **Verify all 25 tests passed in CI**: 17 post_pr_review + 8 publisher_node tests should all pass (not skipped) in CI environment

**Recommended test plan:**
1. Confirm CI shows 25 tests passed in Orchestrator Tests job
2. Optionally run tests locally with langgraph installed to verify publisher_node tests

### Notes
- Closes Issue #2706
- Related: EPIC B #2595, Phase B-3 PR #2701

Link to Devin run: https://app.devin.ai/sessions/67bc479436f84775b72aeeb8f3da0c33
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918