### PR TITLE
feat(diff): add ignore list and secrets redaction (Phase B-2.5)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
+++ b/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
@@ -39,38 +39,46 @@ logger = logging.getLogger(__name__)
 
 # Phase B-2.5: Secrets redaction patterns (#2703)
 # These patterns detect common secret formats to prevent leakage to LLM providers
+# Uses capturing groups to preserve original formatting (spaces, quotes, delimiters)
+# Includes negative lookahead (?!\[REDACTED) to avoid double-redaction
 SECRETS_REDACTION_PATTERNS = [
     # AWS Access Keys (AKIA followed by 16 alphanumeric chars)
     (r'AKIA[0-9A-Z]{16}', '[REDACTED_AWS_KEY]'),
     # AWS Secret Keys (40 char base64-like string after common prefixes)
-    (r'(?i)(aws_secret_access_key|aws_secret_key)\s*[=:]\s*["\']?([A-Za-z0-9/+=]{40})["\']?',
-     r'\1=[REDACTED_AWS_SECRET]'),
+    # Preserves delimiter and spacing
+    (r'(?i)(aws_secret_access_key|aws_secret_key)(\s*[=:]\s*)(["\']?)(?!\[REDACTED)[A-Za-z0-9/+=]{40}\3',
+     r'\1\2\3[REDACTED_AWS_SECRET]\3'),
     # GitHub tokens (ghp_, gho_, github_pat_)
     (r'ghp_[A-Za-z0-9]{36,}', '[REDACTED_GITHUB_TOKEN]'),
     (r'gho_[A-Za-z0-9]{36,}', '[REDACTED_GITHUB_TOKEN]'),
     (r'github_pat_[A-Za-z0-9_]{22,}', '[REDACTED_GITHUB_TOKEN]'),
     # Generic API keys (sk-... pattern used by OpenAI, Anthropic, etc.)
     (r'sk-[A-Za-z0-9]{32,}', '[REDACTED_API_KEY]'),
-    # Bearer tokens
-    (r'(?i)Bearer\s+[A-Za-z0-9\-_.~+/]+=*', 'Bearer [REDACTED_TOKEN]'),
+    # Bearer tokens - preserve "Bearer " prefix with original spacing
+    (r'(?i)(Bearer\s+)(?!\[REDACTED)[A-Za-z0-9\-_.~+/]+=*', r'\1[REDACTED_TOKEN]'),
     # Private keys (PEM format)
     (r'-----BEGIN\s+(RSA\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END\s+(RSA\s+)?PRIVATE\s+KEY-----',
      '[REDACTED_PRIVATE_KEY]'),
     (r'-----BEGIN\s+EC\s+PRIVATE\s+KEY-----[\s\S]*?-----END\s+EC\s+PRIVATE\s+KEY-----',
      '[REDACTED_PRIVATE_KEY]'),
     # Generic secret assignments (PASSWORD=, SECRET=, TOKEN=, API_KEY=)
-    # Be conservative to avoid false positives - require quotes or specific formats
-    (r'(?i)(PASSWORD|SECRET|TOKEN|API_KEY|APIKEY|SECRET_KEY|PRIVATE_KEY)\s*[=:]\s*["\'][^"\']{8,}["\']',
-     r'\1=[REDACTED_SECRET]'),
+    # Preserves delimiter, spacing, and quote style
+    (r'(?i)\b(PASSWORD|SECRET|TOKEN|API_KEY|APIKEY|SECRET_KEY|PRIVATE_KEY)\b'
+     r'(\s*[=:]\s*)'
+     r'(["\'])(?!\[REDACTED)[^"\']{8,}\3',
+     r'\1\2\3[REDACTED_SECRET]\3'),
     # Environment variable style (export SECRET=value)
-    (r'(?i)export\s+(PASSWORD|SECRET|TOKEN|API_KEY|APIKEY|SECRET_KEY)\s*=\s*[^\s]+',
-     r'export \1=[REDACTED_SECRET]'),
+    # Preserves "export " prefix and spacing
+    (r'(?i)(export\s+)(PASSWORD|SECRET|TOKEN|API_KEY|APIKEY|SECRET_KEY)(\s*=\s*)(?!\[REDACTED)[^\s]+',
+     r'\1\2\3[REDACTED_SECRET]'),
     # JSON style secrets ("api_key": "value")
-    (r'(?i)"(password|secret|token|api_key|apikey|secret_key|private_key|access_token)"\s*:\s*"[^"]{8,}"',
-     r'"\1": "[REDACTED_SECRET]"'),
+    # Preserves key name, colon spacing, and quotes
+    (r'(?i)("(?:password|secret|token|api_key|apikey|secret_key|private_key|access_token)")(\s*:\s*)"(?!\[REDACTED)[^"]{8,}"',
+     r'\1\2"[REDACTED_SECRET]"'),
     # YAML style secrets (api_key: value)
-    (r'(?i)^(\s*)(password|secret|token|api_key|apikey|secret_key|private_key|access_token)\s*:\s*[^\s#][^\n]*',
-     r'\1\2: [REDACTED_SECRET]'),
+    # Preserves indentation and colon spacing
+    (r'(?i)^(\s*)(password|secret|token|api_key|apikey|secret_key|private_key|access_token)(\s*:\s*)(?!\[REDACTED)[^\s#][^\n]*',
+     r'\1\2\3[REDACTED_SECRET]'),
 ]
 
 

--- a/handoff/20250928/40_App/orchestrator/tests/test_llm_reviewer_adapter.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_llm_reviewer_adapter.py
@@ -873,6 +873,30 @@ class TestPhaseB25SecretsRedaction:
         # Only actual secrets should be redacted, not variable names
         assert count == 0 or "password" in result.lower()
 
+    def test_sanitize_preserves_format_regression(self):
+        """
+        Regression test: Redaction should preserve original formatting.
+        Issue: Previous implementation lost spaces and quotes during redaction.
+        Example: SECRET = "value" became SECRET=[REDACTED_SECRET] instead of
+                 SECRET = "[REDACTED_SECRET]"
+        """
+        # Test generic secret assignment with spaces and quotes
+        diff_with_secret = 'SECRET = "my-secret-value-12345678"'
+        result, count = sanitize_diff_content(diff_with_secret)
+        # Secret value should be redacted
+        assert "my-secret-value-12345678" not in result
+        # Format should be preserved: spaces around = and quotes
+        assert ' = "' in result or " = '" in result
+        assert count >= 1
+
+        # Test JSON format preservation
+        json_secret = '"api_key": "super_secret_key_12345678"'
+        result, count = sanitize_diff_content(json_secret)
+        assert "super_secret_key_12345678" not in result
+        # JSON format should be preserved
+        assert '": "' in result
+        assert count >= 1
+
     def test_build_diff_aware_user_prompt_sanitizes_diff(self):
         """Test that _build_diff_aware_user_prompt sanitizes the diff"""
         adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)

--- a/handoff/20250928/40_App/orchestrator/tests/test_pr_diff_fetcher.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_pr_diff_fetcher.py
@@ -23,7 +23,8 @@ from tools.github_api import (  # noqa: E402
     # Phase B-2.5: Ignore list constants (#2702)
     DIFF_IGNORE_FILENAMES,
     DIFF_IGNORE_EXTENSIONS,
-    DIFF_IGNORE_PATH_PATTERNS,
+    DIFF_IGNORE_ROOT_DIRS,
+    DIFF_IGNORE_ANYWHERE_DIRS,
     _should_ignore_file
 )
 
@@ -748,13 +749,20 @@ class TestPhaseB25IgnoreList:
         assert '.pyo' in DIFF_IGNORE_EXTENSIONS
         assert '.class' in DIFF_IGNORE_EXTENSIONS
 
-    def test_ignore_path_patterns_contains_build_dirs(self):
-        """Test that DIFF_IGNORE_PATH_PATTERNS contains build directories"""
-        assert 'dist/' in DIFF_IGNORE_PATH_PATTERNS
-        assert 'build/' in DIFF_IGNORE_PATH_PATTERNS
-        assert '.next/' in DIFF_IGNORE_PATH_PATTERNS
-        assert 'node_modules/' in DIFF_IGNORE_PATH_PATTERNS
-        assert '__pycache__/' in DIFF_IGNORE_PATH_PATTERNS
+    def test_ignore_root_dirs_contains_build_dirs(self):
+        """Test that DIFF_IGNORE_ROOT_DIRS contains root-level build directories"""
+        assert 'dist' in DIFF_IGNORE_ROOT_DIRS
+        assert 'build' in DIFF_IGNORE_ROOT_DIRS
+        assert '.next' in DIFF_IGNORE_ROOT_DIRS
+        assert 'out' in DIFF_IGNORE_ROOT_DIRS
+
+    def test_ignore_anywhere_dirs_contains_generated_dirs(self):
+        """Test that DIFF_IGNORE_ANYWHERE_DIRS contains always-generated directories"""
+        assert 'node_modules' in DIFF_IGNORE_ANYWHERE_DIRS
+        assert '__pycache__' in DIFF_IGNORE_ANYWHERE_DIRS
+        assert 'vendor' in DIFF_IGNORE_ANYWHERE_DIRS
+        assert '.tox' in DIFF_IGNORE_ANYWHERE_DIRS
+        assert '.pytest_cache' in DIFF_IGNORE_ANYWHERE_DIRS
 
     def test_should_ignore_file_lockfiles(self):
         """Test _should_ignore_file correctly identifies lockfiles"""
@@ -785,6 +793,36 @@ class TestPhaseB25IgnoreList:
         assert _should_ignore_file('components/Button.tsx') is False
         assert _should_ignore_file('README.md') is False
         assert _should_ignore_file('package.json') is False  # Not lockfile
+
+    def test_should_ignore_file_false_positive_regression(self):
+        """
+        Regression test: src/build/main.py and src/dist/utils.py should NOT be ignored.
+        These are source files in directories named 'build' or 'dist', not build outputs.
+        Issue: Previous implementation used substring matching which caused false positives.
+        """
+        # These should NOT be ignored - they are source files in src/ directory
+        assert _should_ignore_file('src/build/main.py') is False
+        assert _should_ignore_file('src/dist/utils.py') is False
+        assert _should_ignore_file('lib/build/helper.ts') is False
+        assert _should_ignore_file('packages/core/dist/index.js') is False
+
+        # These SHOULD be ignored - they are actual build outputs at root level
+        assert _should_ignore_file('dist/bundle.js') is True
+        assert _should_ignore_file('build/output.js') is True
+
+    def test_should_ignore_file_anywhere_dirs_at_any_depth(self):
+        """Test that anywhere-ignore directories are filtered at any depth"""
+        # node_modules should be ignored at any depth
+        assert _should_ignore_file('node_modules/lodash/index.js') is True
+        assert _should_ignore_file('packages/foo/node_modules/bar/index.js') is True
+
+        # __pycache__ should be ignored at any depth
+        assert _should_ignore_file('__pycache__/module.cpython-39.pyc') is True
+        assert _should_ignore_file('src/utils/__pycache__/helper.cpython-39.pyc') is True
+
+        # vendor should be ignored at any depth
+        assert _should_ignore_file('vendor/github.com/pkg/errors/errors.go') is True
+        assert _should_ignore_file('lib/vendor/some/package.go') is True
 
     def test_get_pr_diff_filters_lockfiles(self):
         """Test that get_pr_diff filters out lockfiles"""

--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -184,26 +184,35 @@ DIFF_IGNORE_EXTENSIONS = {
     '.dll',
 }
 
-DIFF_IGNORE_PATH_PATTERNS = [
-    # Build output directories
-    'dist/',
-    'build/',
-    '.next/',
-    'out/',
-    '__pycache__/',
-    'node_modules/',
-    'vendor/',
-    '.tox/',
-    '.pytest_cache/',
-    # Generated code directories
-    'generated/',
-    'auto_generated/',
-]
+# Root-only ignore patterns: only match when directory is at the root level
+# These are typically project-level build outputs, not source directories
+DIFF_IGNORE_ROOT_DIRS = {
+    'dist',
+    'build',
+    '.next',
+    'out',
+}
+
+# Anywhere ignore patterns: match at any depth in the path
+# These are always generated/cached content regardless of location
+DIFF_IGNORE_ANYWHERE_DIRS = {
+    '__pycache__',
+    'node_modules',
+    'vendor',
+    '.tox',
+    '.pytest_cache',
+    'generated',
+    'auto_generated',
+}
 
 
 def _should_ignore_file(filename: str) -> bool:
     """
     Check if a file should be ignored based on Phase B-2.5 ignore list.
+
+    Uses path-segment matching to avoid false positives like src/build/main.py.
+    - Root-only patterns (dist, build, .next, out): only match at path root
+    - Anywhere patterns (node_modules, __pycache__): match at any depth
 
     Args:
         filename: File path to check
@@ -211,8 +220,19 @@ def _should_ignore_file(filename: str) -> bool:
     Returns:
         True if file should be ignored, False otherwise
     """
-    import os
-    basename = os.path.basename(filename)
+    from pathlib import PurePosixPath
+
+    # Normalize path to POSIX format
+    normalized = filename.replace('\\', '/')
+    # Strip leading ./ but preserve dotfiles like .next
+    if normalized.startswith('./'):
+        normalized = normalized[2:]
+    parts = PurePosixPath(normalized).parts
+
+    if not parts:
+        return False
+
+    basename = parts[-1]
 
     # Check exact filename match (lockfiles)
     if basename in DIFF_IGNORE_FILENAMES:
@@ -223,9 +243,15 @@ def _should_ignore_file(filename: str) -> bool:
         if filename.endswith(ext):
             return True
 
-    # Check path pattern match (build directories)
-    for pattern in DIFF_IGNORE_PATH_PATTERNS:
-        if pattern in filename:
+    # Check root-only directory patterns (first segment only)
+    # This avoids false positives like src/build/main.py
+    if parts[0] in DIFF_IGNORE_ROOT_DIRS:
+        return True
+
+    # Check anywhere directory patterns (any segment)
+    # These are always generated content regardless of depth
+    for part in parts[:-1]:  # Exclude filename itself
+        if part in DIFF_IGNORE_ANYWHERE_DIRS:
             return True
 
     return False


### PR DESCRIPTION
# feat(diff): add ignore list and secrets redaction (Phase B-2.5)

## Summary

Implements EPIC B Phase B-2.5 (Issues #2702 + #2703) to improve diff quality and security before sending to LLM providers.

**#2702 - Ignore list for lockfiles and generated assets:**
- Filters out lockfiles (package-lock.json, yarn.lock, etc.), minified files (.min.js, .map), and build directories from PR diffs
- Uses path-segment matching to avoid false positives (e.g., `src/build/main.py` is NOT filtered)
- Split into `DIFF_IGNORE_ROOT_DIRS` (dist, build, .next, out - root level only) and `DIFF_IGNORE_ANYWHERE_DIRS` (node_modules, __pycache__ - any depth)
- Tracks `ignored_file_count` and `ignored_filenames` in truncation_info
- PRs with only lockfiles return empty diff for metadata-only review

**#2703 - Secrets redaction before LLM injection:**
- Redacts AWS keys, GitHub tokens, OpenAI-style API keys, Bearer tokens, private keys, and common secret patterns
- Uses capturing groups to preserve original formatting (spaces, quotes, delimiters)
- Includes negative lookahead to prevent double-redaction
- Applied in `_build_diff_aware_user_prompt()` before diff is injected into LLM prompt

## Updates since last revision

**Fixed BLOCKER - Path matching false positives:**
- Changed from substring matching (`if pattern in filename`) to path-segment matching
- `src/build/main.py` and `src/dist/utils.py` are now correctly NOT ignored
- Root-level `dist/` and `build/` are still correctly ignored

**Fixed HIGH - Regex format preservation:**
- `SECRET = "value"` now becomes `SECRET = "[REDACTED_SECRET]"` (preserves spaces and quotes)
- Previously it became `SECRET=[REDACTED_SECRET]` (lost formatting context)

**Added regression tests** for both issues (31 total tests, up from 27)

## Review & Testing Checklist for Human

- [ ] **Verify path-segment matching works correctly**: Test that `src/build/main.py` appears in diff while `build/output.js` is filtered. The `test_should_ignore_file_false_positive_regression` test covers this but manual verification recommended.
- [ ] **Verify regex patterns don't over-redact**: Check that normal code like `def get_password_hash(password)` isn't incorrectly redacted.
- [ ] **Test format preservation**: Verify that `SECRET = "value"` becomes `SECRET = "[REDACTED_SECRET]"` with spaces and quotes preserved.

**Recommended test plan:**
1. Create a test PR with `src/build/main.py` + `build/output.js` changes, verify only `src/build/main.py` appears in diff
2. Create a test PR with `SECRET = "my-secret"` in the diff, verify it's redacted as `SECRET = "[REDACTED_SECRET]"` (with formatting preserved)
3. Run the orchestrator with `DEBUG` logging to verify ignored files are logged correctly

### Notes

- 31 unit tests added (15 for ignore list including regression tests, 16 for secrets redaction including format preservation test)
- Pre-existing lint errors in the files (E402, C901) are not addressed in this PR
- This is a gate for Phase B-3 rollout to production

**Link to Devin run:** https://app.devin.ai/sessions/67bc479436f84775b72aeeb8f3da0c33
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918