### PR TITLE
test(phase-bb): Phase B-B Staging Verification Test PR

### DIFF
--- a/handoff/20250928/40_App/orchestrator/review_comment_schema.py
+++ b/handoff/20250928/40_App/orchestrator/review_comment_schema.py
@@ -10,10 +10,12 @@ This module provides:
 4. Severity mapping between different taxonomies
 5. Unified diff parser for extracting valid RIGHT-side line ranges (Phase B-3.1)
 6. Inline comment validator to gate comments against allowed line ranges (Phase B-3.1)
+7. Telemetry fields for Phase B-B staging verification
 
 Issue #2595: EPIC B - Diff-Aware Review Plumbing
 Phase B-2: Review Comment Schema Definition
 Phase B-3.1: Line Number Validation & Truncation Handling
+Phase B-B: Staging Verification (Dry-run)
 
 Usage:
     from review_comment_schema import parse_review_comment, normalize_review_comments
@@ -882,5 +884,7 @@ def get_diff_coverage_info(
         "total_files": total_files,
         "truncated_files": truncated_files,
         "total_allowed_lines": total_lines,
-        "files": list(allowed_lines_map.keys())
+        "files": list(allowed_lines_map.keys()),
+        # Phase B-B: Add coverage percentage for telemetry
+        "truncation_rate": truncated_files / total_files if total_files > 0 else 0.0
     }

--- a/handoff/20250928/40_App/orchestrator/review_comment_schema.py
+++ b/handoff/20250928/40_App/orchestrator/review_comment_schema.py
@@ -888,3 +888,4 @@ def get_diff_coverage_info(
         # Phase B-B: Add coverage percentage for telemetry
         "truncation_rate": truncated_files / total_files if total_files > 0 else 0.0
     }
+# Phase B-B Staging Verification Test - 20251219_122429


### PR DESCRIPTION
## Summary

This is a **test PR** created to trigger the staging review workflow and verify that Phase B-B telemetry fields are being logged correctly in Render.

Changes:
- Updated module docstring to document Phase B-B telemetry
- Added `truncation_rate` field to `get_diff_coverage_info()` for telemetry purposes

**Note: This PR is for verification purposes only.** Once we confirm the telemetry fields appear in staging logs, this PR can be closed without merging.

## Review & Testing Checklist for Human

- [ ] Verify this PR triggered the staging review workflow (check Render logs for `reviewer_node` / `publisher_node` activity)
- [ ] Confirm telemetry fields appear in logs: `github_total_files`, `raw_comment_count`, `normalized_comment_count`, `inline_eligible_count`, `downgrade_*`
- [ ] If telemetry is verified, close this PR without merging (or merge if the `truncation_rate` field is useful)

**Test Plan:**
1. Check Render Dashboard → `morningai-orchestrator-api-stg` logs
2. Search for `[Publisher]` or `reviewer_node` to find review execution logs
3. Verify the new telemetry fields are present in the log entries

### Notes

- Issue #2595: EPIC B - Diff-Aware Review Plumbing
- Phase B-B: Staging Verification (Dry-run)
- Link to Devin run: https://app.devin.ai/sessions/67bc479436f84775b72aeeb8f3da0c33
- Requested by: Ryan Chen (@RC918)