### PR TITLE
test(phase-bb): verify LangGraph orchestrator telemetry fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,3 +654,5 @@ Morning AI 已部署兩個 AI Agent Sandbox 到 Fly.io，提供安全隔離的�
 **架構文檔**: [Agent Sandbox Architecture](docs/agent-sandbox-architecture.md)  
 **總成本**: ~$4/月（閒置時自動縮放至 $0）
 
+
+<!-- Phase B-B LangGraph Verification: 20251219_124654 -->


### PR DESCRIPTION
## Summary

This is a **test PR** to verify that the LangGraph orchestrator telemetry fields (Phase B-B) are being logged correctly in staging after configuring `USE_LANGGRAPH=true` and `USE_LANGGRAPH_PERCENT=100`.

The PR contains only a trivial HTML comment in README.md with no functional changes. Its sole purpose is to trigger a `pull_request.opened` webhook event.

## Review & Testing Checklist for Human

- [ ] Verify webhook delivery shows HTTP 200 in GitHub Settings > Webhooks > Recent Deliveries
- [ ] Check `morningai-backend-v2-stg-worker` logs for `Using LangGraph orchestrator` (not `Using simple orchestrator`)
- [ ] Search for telemetry fields: `github_total_files`, `raw_comment_count`, `inline_eligible_count`, `downgrade_`
- [ ] Confirm `[DRY_RUN]` mode is active (no actual comments posted to GitHub)

### Notes

**This PR should NOT be merged** - it's purely for staging verification purposes. After verification is complete, this PR can be closed without merging.

**Background:** Previous test (PR #2718) used Simple Orchestrator due to canary routing. This test verifies LangGraph execution after staging env vars were updated.

---
Link to Devin run: https://app.devin.ai/sessions/67bc479436f84775b72aeeb8f3da0c33
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918