### PR TITLE
test(phase-bb): staging verification for PR context fix

### DIFF
--- a/PHASE_BB_STAGING_VERIFICATION.md
+++ b/PHASE_BB_STAGING_VERIFICATION.md
@@ -1,0 +1,23 @@
+# Phase B-B Staging Verification
+
+This PR is created to verify that the Phase B-B PR context passing fix works correctly in staging.
+
+## Expected Behavior
+
+After PR #2721 is deployed to staging:
+
+1. Webhook receives `pull_request.opened` event
+2. EventNormalizer extracts `resource_id` (PR number) and `resource_type` ("pull_request")
+3. Worker passes `task.context` to `run_orchestrator`
+4. Orchestrator logs show `pr_number > 0` (not 0)
+5. `reviewer_node` executes (not skipped with "No PR to review")
+
+## Verification Checklist
+
+- [ ] Render logs show `Starting LangGraph orchestrator` with `pr_number=<this PR number>`
+- [ ] `reviewer_node` executes successfully
+- [ ] Telemetry fields (`pr_number`, `pr_url`, `trace_id`) are logged
+
+## Test Date
+
+$(date -u +"%Y-%m-%d %H:%M:%S UTC")


### PR DESCRIPTION
## Summary

Test PR to verify that PR #2721 (PR context passing fix) works correctly in staging. This PR triggers a `pull_request.opened` webhook event to test the end-to-end data flow.

**DO NOT MERGE** - Close after verification is complete.

## Review & Testing Checklist for Human

- [ ] Check Render logs for `Starting LangGraph orchestrator` with `pr_number=<this PR number>` (should be > 0, not 0)
- [ ] Verify `reviewer_node` executes (not skipped with "No PR to review")
- [ ] Confirm telemetry fields (`pr_number`, `pr_url`, `trace_id`) appear in logs

**Test plan:**
1. Wait for staging deployment of PR #2721
2. Check Render Dashboard logs for this PR's webhook processing
3. Search for `pr_number` in logs to verify it shows the correct PR number
4. Close this PR after verification (do not merge)

### Notes

This is a verification-only PR. The markdown file documents the expected behavior but has no functional impact.

**Link to Devin run:** https://app.devin.ai/sessions/67bc479436f84775b72aeeb8f3da0c33
**Requested by:** Ryan Chen (@RC918)