### PR TITLE
fix(phase-bb): put key fields in log message for observability

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -3571,7 +3571,7 @@ def run_orchestrator(
     # Note: extra fields are not output by worker.py's basicConfig formatter, so we put key fields in message
     has_context = context is not None
     logger.info(
-        f"Starting LangGraph orchestrator trace_id={trace_id} pr_number={pr_number} pr_url={pr_url} has_context={has_context}",
+        f"Starting LangGraph orchestrator trace_id={trace_id} pr_number={pr_number} pr_url=\"{pr_url}\" has_context={has_context}",
         extra={
             "operation": "run_orchestrator",
             "trace_id": trace_id,
@@ -3617,7 +3617,7 @@ def run_orchestrator(
         result_status = final_result.get("status") or "unknown"
         result_pr_url = final_result.get("pr_url") or ""
         logger.info(
-            f"LangGraph orchestrator completed trace_id={trace_id} status={result_status} pr_url={result_pr_url}",
+            f"LangGraph orchestrator completed trace_id={trace_id} status={result_status} pr_url=\"{result_pr_url}\"",
             extra={
                 "operation": "run_orchestrator",
                 "trace_id": trace_id,


### PR DESCRIPTION
## Summary

Fixes Phase B-B staging verification by putting key observability fields directly in the log message string. The `worker.py` `basicConfig` formatter only outputs `timestamp/level/message/name`, so `extra` dict fields (`pr_number`, `pr_url`, `trace_id`) were invisible in Render logs.

**Before:** `{"message":"Starting LangGraph orchestrator","operation":"langgraph_orchestrator"}` (no pr_number visible)

**After:** `{"message":"Starting LangGraph orchestrator trace_id=abc123 pr_number=2725 pr_url=\"https://...\" has_context=True",...}`

The `extra` dict is preserved for future use if the formatter is updated.

## Updates since last revision

Per CTO review suggestions:
- **URL quoting**: Wrapped `pr_url` in quotes (`pr_url=\"{pr_url}\"`) for JSON parsing stability
- **None handling**: Added default values for completion log to avoid `status=None` in logs:
  - `result_status = final_result.get("status") or "unknown"`
  - `result_pr_url = final_result.get("pr_url") or ""`

## Review & Testing Checklist for Human

- [ ] **Verify quoted URL format** - Confirm the escaped quotes in the f-string don't cause JSON parsing issues in Render logs
- [ ] **Test on staging** - After deployment, create a test PR and search Render logs for `pr_number=` to verify the fields are now visible
- [ ] **Verify workflow completion** - Search for `LangGraph orchestrator completed` to confirm it shows `trace_id`, `status`, and `pr_url`

**Recommended test plan:**
1. Merge and deploy to staging
2. Create a test PR (e.g., `test(phase-bb): verify log message fix`)
3. Search Render logs for `Starting LangGraph orchestrator` 
4. Verify the message contains `pr_number=<PR number>` (not 0) and `pr_url="https://..."`
5. Close the test PR after verification

### Notes

This is a follow-up to PR #2721 which passed PR context to the orchestrator. That fix was correct, but the fields were invisible due to the logger formatter configuration.

**Link to Devin run:** https://app.devin.ai/sessions/67bc479436f84775b72aeeb8f3da0c33
**Requested by:** Ryan Chen (@RC918)