### PR TITLE
fix(phase-bb): use single quotes for pr_url to preserve JSON format

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -3571,7 +3571,7 @@ def run_orchestrator(
     # Note: extra fields are not output by worker.py's basicConfig formatter, so we put key fields in message
     has_context = context is not None
     logger.info(
-        f"Starting LangGraph orchestrator trace_id={trace_id} pr_number={pr_number} pr_url=\"{pr_url}\" has_context={has_context}",
+        f"Starting LangGraph orchestrator trace_id={trace_id} pr_number={pr_number} pr_url='{pr_url}' has_context={has_context}",
         extra={
             "operation": "run_orchestrator",
             "trace_id": trace_id,
@@ -3617,7 +3617,7 @@ def run_orchestrator(
         result_status = final_result.get("status") or "unknown"
         result_pr_url = final_result.get("pr_url") or ""
         logger.info(
-            f"LangGraph orchestrator completed trace_id={trace_id} status={result_status} pr_url=\"{result_pr_url}\"",
+            f"LangGraph orchestrator completed trace_id={trace_id} status={result_status} pr_url='{result_pr_url}'",
             extra={
                 "operation": "run_orchestrator",
                 "trace_id": trace_id,


### PR DESCRIPTION
## Summary

Fixes a JSON formatting issue introduced in PR #2726 where the log messages were breaking Render's JSON parser.

**Problem**: The previous fix used escaped double quotes (`\"`) in Python f-strings, but Python outputs literal `"` characters which breaks the outer JSON structure:
```
{"message":"...pr_url="https://..."..."}  ← Invalid JSON
```

**Solution**: Use single quotes instead of double quotes to wrap the `pr_url` value:
```
{"message":"...pr_url='https://...'..."}  ← Valid JSON
```

This was verified locally by simulating the worker.py `basicConfig` formatter and confirming the output is valid JSON.

## Review & Testing Checklist for Human

- [ ] **Deploy to staging and verify logs** - Search Render Dashboard for `Starting LangGraph orchestrator` and confirm the full message with `pr_number=`, `pr_url=`, and `trace_id=` is now visible
- [ ] **Verify JSON parsing** - Confirm the log entries can be expanded in Render's structured log view (not just raw text)
- [ ] **Test with PR #2729** - The existing test PR should trigger a new webhook after deployment; verify the telemetry fields appear correctly

**Recommended test plan:**
1. Merge and deploy to staging
2. Check Render logs for `morningai-backend-v2-stg-worker`
3. Search for `pr_number=2729` or `has_context=` (these keywords only exist in the new format)
4. Verify the message field shows the complete telemetry data

### Notes

This is a follow-up fix to PR #2726. The original fix correctly embedded telemetry fields in the log message, but the JSON escaping was incorrect.

**Link to Devin run:** https://app.devin.ai/sessions/67bc479436f84775b72aeeb8f3da0c33
**Requested by:** Ryan Chen (@RC918)