### PR TITLE
test(phase-bb): verify JSON format fix for log observability

### DIFF
--- a/PHASE_BB_JSON_FIX_VERIFICATION.md
+++ b/PHASE_BB_JSON_FIX_VERIFICATION.md
@@ -1,0 +1,34 @@
+# Phase B-B JSON Format Fix Verification
+
+This PR is created to trigger the GitHub webhook and verify that PR #2730 (JSON format fix) is working correctly in staging.
+
+## Verification Checklist
+
+- [ ] `pr_number` is visible in Render logs (not 0)
+- [ ] `pr_url` is visible with single quotes (e.g., `pr_url='https://...'`)
+- [ ] `trace_id` is visible in Render logs
+- [ ] `has_context` is visible in Render logs
+- [ ] JSON format is valid (log entries can be expanded in Render)
+
+## Expected Log Format
+
+```json
+{"timestamp":"...","level":"INFO","message":"Starting LangGraph orchestrator trace_id=abc123 pr_number=<this PR number> pr_url='https://github.com/RC918/morningai/pull/<this PR number>' has_context=True","operation":"langgraph_orchestrator"}
+```
+
+## Search Keywords
+
+Use these keywords in Render Dashboard to verify the fix:
+- `pr_number=` (only exists in new format)
+- `has_context=` (only exists in new format)
+- `pr_url='` (single quotes indicate new format)
+
+## Related PRs
+
+- PR #2721: Pass PR context from webhook to LangGraph orchestrator
+- PR #2726: Put key fields in log message for observability
+- PR #2730: Use single quotes for pr_url to preserve JSON format
+
+---
+
+**This file should be deleted after verification is complete.**


### PR DESCRIPTION
## Summary

Test PR to trigger the GitHub webhook and verify that PR #2730 (JSON format fix) is working correctly in staging. This PR adds a temporary markdown file documenting the verification checklist.

**Purpose:** Verify that the telemetry fields (`pr_number`, `pr_url`, `trace_id`, `has_context`) are now visible in Render logs after the JSON format fix.

## Review & Testing Checklist for Human

- [ ] **DO NOT MERGE** - This is a test PR. Close it after verification is complete.
- [ ] Wait for staging deployment of PR #2730 to complete
- [ ] Search Render Dashboard for `pr_number=` or `has_context=` (these keywords only exist in the new format)
- [ ] Verify the log message shows `pr_number=<this PR number>` (not 0) and `pr_url='https://...'` with single quotes
- [ ] Close this PR and delete the test file after verification

**Test Plan:**
1. Wait for webhook to trigger the review workflow
2. Go to Render Dashboard → `morningai-backend-v2-stg-worker`
3. Search for `Starting LangGraph orchestrator` and expand the log entry
4. Confirm the message field contains the telemetry data with valid JSON format

### Notes

Related PRs:
- PR #2721: Pass PR context from webhook to LangGraph orchestrator
- PR #2726: Put key fields in log message for observability  
- PR #2730: Use single quotes for pr_url to preserve JSON format

**Link to Devin run:** https://app.devin.ai/sessions/67bc479436f84775b72aeeb8f3da0c33
**Requested by:** Ryan Chen (@RC918)