### PR TITLE
fix(phase-bb): add context observability fields to diagnose pr_number=0

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -3570,13 +3570,19 @@ def run_orchestrator(
     # Issue: Phase B-B - Avoid black-box issues where upstream extracts but downstream doesn't receive
     # Note: extra fields are not output by worker.py's basicConfig formatter, so we put key fields in message
     has_context = context is not None
-    # Diagnostic fields to debug pr_number=0 issue
+    # TODO: Remove these diagnostic fields after pr_number=0 root cause is identified (Phase B-B)
+    # Diagnostic fields to debug pr_number=0 issue - use structure info instead of raw content to avoid JSON breakage
     resource_type = context.get("resource_type", "MISSING") if context else "NO_CONTEXT"
     context_keys = ",".join(sorted(context.keys())) if context else ""
-    # Capture raw payload summary (first 200 chars) to see structure
-    raw_payload = str(context.get("payload", {}))[:200] if context else ""
+    # Use payload structure info instead of raw content (raw content may contain quotes that break JSON)
+    payload = context.get("payload", {}) if context else {}
+    payload_keys = ",".join(sorted(payload.keys())) if isinstance(payload, dict) else "NOT_DICT"
+    payload_len = len(str(payload)) if payload else 0
+    # Capture raw values before extraction to diagnose pr_number=0
+    raw_pr_number = context.get("pr_number") or context.get("resource_id") if context else "MISSING"
+    raw_pr_url = context.get("pr_url") or context.get("url") if context else "MISSING"
     logger.info(
-        f"Starting LangGraph orchestrator trace_id={trace_id} pr_number={pr_number} pr_url='{pr_url}' has_context={has_context} resource_type='{resource_type}' context_keys=[{context_keys}] payload_summary='{raw_payload}'",
+        f"Starting LangGraph orchestrator trace_id={trace_id} pr_number={pr_number} pr_url='{pr_url}' has_context={has_context} resource_type='{resource_type}' context_keys=[{context_keys}] payload_keys=[{payload_keys}] payload_len={payload_len} raw_pr_number={raw_pr_number} raw_pr_url='{raw_pr_url}'",
         extra={
             "operation": "run_orchestrator",
             "trace_id": trace_id,


### PR DESCRIPTION
## Summary

Adds diagnostic fields to the orchestrator start log to help identify why `pr_number=0` and `pr_url=''` appear in staging logs even though `has_context=True`. This is a temporary debugging enhancement for Phase B-B verification.

New fields added to the log message:
- `resource_type`: Shows actual value from context (expected: `pull_request`), or `MISSING`/`NO_CONTEXT` for clearer diagnosis
- `context_keys`: Comma-separated list of all keys in the context dict
- `payload_keys`: Shows keys in the payload dict (or `NOT_DICT` if not a dict)
- `payload_len`: Shows payload size without exposing content
- `raw_pr_number`: Shows raw value before extraction to diagnose type/key issues
- `raw_pr_url`: Shows raw value before extraction

## Updates since last revision

Per CTO review feedback:
- **Removed `payload_summary`** - Raw payload content may contain quotes that break JSON parsing in Render Dashboard
- **Added structure-based diagnostics** - `payload_keys` and `payload_len` provide structural info without risking JSON breakage or sensitive data exposure
- **Added raw value capture** - `raw_pr_number` and `raw_pr_url` show values before extraction logic to pinpoint where data is lost
- **Added TODO comment** - Reminder to remove diagnostic fields after root cause is identified

## Review & Testing Checklist for Human

- [ ] Verify the log message length is acceptable for Render Dashboard display
- [ ] Confirm the `or` logic in `raw_pr_number` captures the right fallback behavior (note: if `pr_number` is `0`, it will fall through to `resource_id`)
- [ ] Plan to remove these diagnostic fields after root cause is identified (this is temporary debugging code)

**Test Plan:**
1. Merge and deploy to staging
2. Trigger webhook with a new test PR
3. Search Render logs for `resource_type=` to see the diagnostic output
4. Analyze whether `resource_type` is `pull_request` or `MISSING`, what keys are in `context_keys`, and what `raw_pr_number`/`raw_pr_url` show

### Notes

This is a diagnostic PR to help identify the root cause of the `pr_number=0` issue discovered during Phase B-B staging verification. Once the root cause is identified and fixed, these diagnostic fields should be simplified or removed.

**Link to Devin run:** https://app.devin.ai/sessions/67bc479436f84775b72aeeb8f3da0c33
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918