### PR TITLE
test(orchestrator): remove obsolete Simple Mode tests (#2738)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_worker.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_worker.py
@@ -118,7 +118,9 @@ class TestRunOrchestratorTask:
     @pytest.mark.skipif(not HAS_LANGGRAPH, reason="langgraph not installed")
     @patch('redis_queue.worker.redis')
     @patch('langgraph_orchestrator.run_orchestrator')
-    def test_run_orchestrator_langgraph_mode_success(self, mock_run_orch, mock_redis):
+    @patch('redis_queue.worker.upsert_task_running')
+    @patch('redis_queue.worker.upsert_task_done')
+    def test_run_orchestrator_langgraph_mode_success(self, mock_upsert_done, mock_upsert_running, mock_run_orch, mock_redis):
         """Test orchestrator task always uses LangGraph mode"""
         mock_run_orch.return_value = {
             "pr_url": "https://github.com/pr/2",
@@ -134,6 +136,8 @@ class TestRunOrchestratorTask:
         assert result["trace_id"] == "trace-456"
 
         mock_run_orch.assert_called_once_with("Generate docs", "owner/repo", task_id, context=None)
+        mock_upsert_running.assert_called_once_with(task_id=task_id, trace_id=task_id)
+        mock_upsert_done.assert_called_once_with(task_id=task_id, trace_id="trace-456", pr_url="https://github.com/pr/2")
 
     @pytest.mark.skipif(not HAS_LANGGRAPH, reason="langgraph not installed")
     @patch('redis_queue.worker.redis')


### PR DESCRIPTION
# test(orchestrator): remove obsolete Simple Mode tests (#2738)

## Summary

Removes obsolete test code from `test_worker.py` that tested Simple Mode functionality. Simple Mode was removed in PR #2720, making these tests invalid as they test code paths that no longer exist.

**Removed tests (14 total):**
- `test_run_orchestrator_simple_mode_success` - tested `USE_LANGGRAPH=false`
- `TestCanaryDeployment` class (7 tests) - tested canary routing between Simple/LangGraph modes
- `TestFAQSimplePath` class (5 tests) - tested FAQ tasks being forced to Simple Mode
- `test_rollout_tracker_receives_elapsed_ms_in_simple_mode` - tested Simple Mode latency tracking

**Updated tests:**
- Changed mocks from `graph.execute` to `langgraph_orchestrator.run_orchestrator` for remaining orchestrator tests
- Removed `@patch.dict(os.environ, {"USE_LANGGRAPH": "..."})` decorators (no longer needed)
- Added `@pytest.mark.skipif(not HAS_LANGGRAPH, ...)` for tests requiring langgraph module

**Cleanup:**
- Removed unused imports: `time`, `MagicMock`, `call`, `datetime`, `timezone`, `shutting_down`
- Fixed trailing whitespace and blank line issues

File reduced from 877 lines to 566 lines (-311 lines, -35%).

## Updates since last revision

- Fixed test assertion in `test_run_orchestrator_langgraph_mode_success` to include `context=None` parameter
- Added `upsert_task_running` and `upsert_task_done` mocks to `test_run_orchestrator_langgraph_mode_success` to prevent side effects and verify persistence calls

## Review & Testing Checklist for Human

- [ ] **Verify mock parameter ordering** - The decorator order (bottom-up) must match function parameter order. Current: `mock_upsert_done, mock_upsert_running, mock_run_orch, mock_redis`
- [ ] **Verify `upsert_task_running` signature** - Confirm `upsert_task_running(task_id=..., trace_id=...)` matches the actual implementation in `worker.py`
- [ ] **Verify `upsert_task_done` signature** - Confirm `upsert_task_done(task_id=..., trace_id=..., pr_url=...)` matches the actual implementation
- [ ] **Confirm CI passes** - The Orchestrator Tests job should pass with these changes

### Notes

Closes #2738

Link to Devin run: https://app.devin.ai/sessions/e862be1eb7164a55b0881069f59efa69
Requested by: Ryan Chen (@RC918)