### PR TITLE
test: lockfile-only PR for C-lite telemetry verification

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20175,3 +20175,5 @@ snapshots:
       immer: 9.0.21
       react: 19.2.0
       use-sync-external-store: 1.6.0(react@19.2.0)
+
+# C-lite telemetry test - lockfile-only PR verification 1766204545


### PR DESCRIPTION
## Summary

This is a **test PR** to verify the C-lite telemetry lockfile-only detection logic implemented in PR #2741. It only modifies `pnpm-lock.yaml` by adding a comment.

**Expected behavior**: This PR should be excluded from the diff coverage KPI denominator because all files are lockfiles (ignored files).

## Review & Testing Checklist for Human

- [ ] **DO NOT MERGE** - This is a test PR that should be closed after verification
- [ ] Verify the review workflow processes this PR and correctly identifies it as lockfile-only
- [ ] Check Redis counters using `redis-cli KEYS review.*` to confirm `review.diff.lockfile_only` is incremented
- [ ] Verify this PR is NOT counted in the diff coverage denominator

### Test Plan
1. Wait for the review workflow to process this PR
2. Run `redis-cli KEYS review.diff.*` to see the counters
3. Verify `review.diff.lockfile_only` counter incremented
4. Close this PR without merging

### Notes

- Link to Devin run: https://app.devin.ai/sessions/ebf393321d4b42278a99e24a8f54d7da
- Requested by: Ryan Chen (@RC918)
- This is part of Phase B-B Staging verification for EPIC B: Diff-Aware Review Plumbing