### PR TITLE
feat(phase-bb): add 422 fault injection for fallback verification

### DIFF
--- a/common/config/settings.py
+++ b/common/config/settings.py
@@ -1451,6 +1451,22 @@ class Settings(BaseSettings):
         description="Comma-separated list of internal repos allowed for AI review in Staging (e.g., 'RC918/morningai,RC918/other-repo')"
     )
 
+    # Phase B-B: Fault Injection for 422 Fallback Verification (Staging Only)
+    # Enables controlled testing of the 422 fallback mechanism
+    enable_fault_injection: bool = Field(
+        default=False,
+        alias="ENABLE_FAULT_INJECTION",
+        description="Enable fault injection for testing fallback mechanisms. Only works when is_staging=True. Use with caution."
+    )
+
+    fault_injection_422_rate: float = Field(
+        default=1.0,
+        alias="FAULT_INJECTION_422_RATE",
+        ge=0.0,
+        le=1.0,
+        description="Rate at which to inject 422 errors (0.0-1.0). Only applies when enable_fault_injection=True and is_staging=True."
+    )
+
     # Phase 3 #1822: Meta Agent Integration (Integrated Development Tools)
     enable_meta_agent: bool = Field(
         default=False,

--- a/handoff/20250928/40_App/orchestrator/tests/test_fallback_metrics.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_fallback_metrics.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""
+Unit tests for 422 fallback metrics recording - Phase B-B C-lite Telemetry
+
+Tests cover:
+1. Fault injection safety gates (_should_inject_422_fault)
+2. Metrics recording when fallback is used (record_inline_comment_result)
+3. Correct counter increments (fallback_comments_total vs posted_total)
+4. delivery_rate calculation with fallback comments
+
+Issue #2741: C-lite Telemetry for EPIC B KPIs
+Phase B-B: 422 Fallback Verification
+"""
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest  # noqa: E402
+from unittest.mock import MagicMock, patch  # noqa: E402
+
+try:
+    from github import GithubException  # noqa: E402
+    HAS_GITHUB = True
+except ImportError:
+    HAS_GITHUB = False
+    GithubException = None
+
+
+class MockSettings:
+    """Mock settings object for testing fault injection"""
+    def __init__(
+        self,
+        enable_fault_injection=False,
+        is_staging=False,
+        fault_injection_422_rate=1.0,
+        enable_github_review_posting=True,
+        github_review_posting_dry_run=False,
+        github_review_posting_max_comments=10,
+    ):
+        self.enable_fault_injection = enable_fault_injection
+        self.is_staging = is_staging
+        self.fault_injection_422_rate = fault_injection_422_rate
+        self.enable_github_review_posting = enable_github_review_posting
+        self.github_review_posting_dry_run = github_review_posting_dry_run
+        self.github_review_posting_max_comments = github_review_posting_max_comments
+
+
+@pytest.mark.skipif(not HAS_GITHUB, reason="PyGithub not installed")
+class TestShouldInject422Fault:
+    """Tests for _should_inject_422_fault() safety gates"""
+
+    def test_returns_false_when_fault_injection_disabled(self):
+        """Fault injection disabled should return False"""
+        from tools.github_api import _should_inject_422_fault
+
+        settings = MockSettings(
+            enable_fault_injection=False,
+            is_staging=True,
+            fault_injection_422_rate=1.0
+        )
+        assert _should_inject_422_fault(settings) is False
+
+    def test_returns_false_when_not_staging(self):
+        """Non-staging environment should return False (safety gate)"""
+        from tools.github_api import _should_inject_422_fault
+
+        settings = MockSettings(
+            enable_fault_injection=True,
+            is_staging=False,
+            fault_injection_422_rate=1.0
+        )
+        assert _should_inject_422_fault(settings) is False
+
+    def test_returns_false_when_rate_is_zero(self):
+        """Zero injection rate should return False"""
+        from tools.github_api import _should_inject_422_fault
+
+        settings = MockSettings(
+            enable_fault_injection=True,
+            is_staging=True,
+            fault_injection_422_rate=0.0
+        )
+        # With rate=0.0, random.random() > 0.0 is always True, so returns False
+        assert _should_inject_422_fault(settings) is False
+
+    def test_returns_true_when_all_conditions_met(self):
+        """All conditions met with rate=1.0 should return True"""
+        from tools.github_api import _should_inject_422_fault
+
+        settings = MockSettings(
+            enable_fault_injection=True,
+            is_staging=True,
+            fault_injection_422_rate=1.0
+        )
+        # With rate=1.0, random.random() > 1.0 is always False, so returns True
+        assert _should_inject_422_fault(settings) is True
+
+    def test_respects_injection_rate(self):
+        """Injection rate should be respected (probabilistic test)"""
+        from tools.github_api import _should_inject_422_fault
+
+        settings = MockSettings(
+            enable_fault_injection=True,
+            is_staging=True,
+            fault_injection_422_rate=0.5
+        )
+
+        # Run multiple times and check that we get both True and False
+        results = [_should_inject_422_fault(settings) for _ in range(100)]
+        # With 50% rate, we should get some True and some False
+        assert True in results
+        assert False in results
+
+
+class TestFallbackMetricsRecording:
+    """Tests for metrics recording when 422 fallback is used"""
+
+    def _create_mock_redis_with_pipeline(self):
+        """Create a mock Redis client that tracks pipeline incrby calls"""
+        mock_redis = MagicMock()
+        mock_pipeline = MagicMock()
+        mock_redis.pipeline.return_value.__enter__ = MagicMock(
+            return_value=mock_pipeline
+        )
+        mock_redis.pipeline.return_value.__exit__ = MagicMock(return_value=False)
+        return mock_redis, mock_pipeline
+
+    def test_fallback_used_increments_fallback_counters(self):
+        """When fallback_used=True, should increment fallback_* counters"""
+        from orchestrator_metrics import OrchestratorMetrics
+
+        mock_redis, mock_pipeline = self._create_mock_redis_with_pipeline()
+
+        metrics = OrchestratorMetrics(redis_client=mock_redis, enabled=True)
+
+        metrics.record_inline_comment_result(
+            trace_id="test-trace-123",
+            eligible_count=3,
+            validated_count=3,
+            downgraded_count=0,
+            posted_count=3,
+            post_failed=False,
+            fallback_used=True,
+            dry_run=False,
+            feature_disabled=False
+        )
+
+        incrby_calls = [str(c) for c in mock_pipeline.incrby.call_args_list]
+
+        assert any("fallback_comments_total" in c for c in incrby_calls)
+        assert any("fallback_events_total" in c for c in incrby_calls)
+        assert not any(
+            "posted_total" in c and "fallback" not in c
+            for c in incrby_calls
+        )
+
+    def test_no_fallback_increments_posted_counters(self):
+        """When fallback_used=False, should increment posted_total counter"""
+        from orchestrator_metrics import OrchestratorMetrics
+
+        mock_redis, mock_pipeline = self._create_mock_redis_with_pipeline()
+
+        metrics = OrchestratorMetrics(redis_client=mock_redis, enabled=True)
+
+        metrics.record_inline_comment_result(
+            trace_id="test-trace-456",
+            eligible_count=3,
+            validated_count=3,
+            downgraded_count=0,
+            posted_count=3,
+            post_failed=False,
+            fallback_used=False,
+            dry_run=False,
+            feature_disabled=False
+        )
+
+        incrby_calls = [str(c) for c in mock_pipeline.incrby.call_args_list]
+
+        assert any(
+            "posted_total" in c and "fallback" not in c
+            for c in incrby_calls
+        )
+        assert not any("fallback_comments_total" in c for c in incrby_calls)
+        assert not any("fallback_events_total" in c for c in incrby_calls)
+
+    def test_fallback_comments_count_matches_posted_count(self):
+        """fallback_comments_total should be incremented by posted_count"""
+        from orchestrator_metrics import OrchestratorMetrics
+
+        mock_redis, mock_pipeline = self._create_mock_redis_with_pipeline()
+
+        metrics = OrchestratorMetrics(redis_client=mock_redis, enabled=True)
+
+        metrics.record_inline_comment_result(
+            trace_id="test-trace-789",
+            eligible_count=5,
+            validated_count=5,
+            downgraded_count=0,
+            posted_count=5,
+            post_failed=False,
+            fallback_used=True,
+            dry_run=False,
+            feature_disabled=False
+        )
+
+        for call_obj in mock_pipeline.incrby.call_args_list:
+            args = call_obj[0]
+            if "fallback_comments_total" in str(args[0]):
+                assert args[1] == 5
+                break
+
+
+class TestDeliveryRateCalculation:
+    """Tests for delivery_rate calculation with fallback comments"""
+
+    def test_delivery_rate_includes_fallback_comments(self):
+        """delivery_rate should include both inline and fallback comments"""
+        from orchestrator_metrics import OrchestratorMetrics
+
+        mock_redis = MagicMock()
+
+        # Mock get_window_count to return specific values
+        def mock_get(key):
+            if "eligible_total" in key:
+                return b"10"  # 10 eligible comments
+            elif "posted_total" in key:
+                return b"5"  # 5 posted inline
+            elif "fallback_comments_total" in key:
+                return b"3"  # 3 delivered via fallback
+            return b"0"
+
+        mock_redis.get.side_effect = mock_get
+
+        metrics = OrchestratorMetrics(redis_client=mock_redis, enabled=True)
+        summary = metrics.get_review_summary(window_minutes=15)
+
+        # delivery_rate = (posted + fallback_comments) / eligible * 100
+        # = (5 + 3) / 10 * 100 = 80%
+        assert summary["inline"]["delivery_rate"] == 80.0
+        assert summary["kpis"]["delivery_rate"] == 80.0
+
+    def test_delivery_rate_zero_when_no_eligible(self):
+        """delivery_rate should be 0 when no eligible comments"""
+        from orchestrator_metrics import OrchestratorMetrics
+
+        mock_redis = MagicMock()
+        mock_redis.get.return_value = b"0"
+
+        metrics = OrchestratorMetrics(redis_client=mock_redis, enabled=True)
+        summary = metrics.get_review_summary(window_minutes=15)
+
+        # No eligible comments = 0% delivery rate
+        assert summary["inline"]["delivery_rate"] == 0
+        assert summary["kpis"]["delivery_rate"] == 0
+
+
+@pytest.mark.skipif(not HAS_GITHUB, reason="PyGithub not installed")
+class TestFaultInjectionIntegration:
+    """Integration tests for fault injection triggering fallback"""
+
+    def test_fault_injection_triggers_fallback_path(self):
+        """Fault injection should trigger the 422 fallback path"""
+        mock_settings = MockSettings(
+            enable_fault_injection=True,
+            is_staging=True,
+            fault_injection_422_rate=1.0,
+            enable_github_review_posting=True,
+            github_review_posting_dry_run=False,
+            github_review_posting_max_comments=10
+        )
+
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+
+        # Track create_review calls
+        call_count = [0]
+
+        def create_review_side_effect(**kwargs):
+            call_count[0] += 1
+            # First call is the fallback (after 422 injection)
+            # Second call would be the actual fallback post
+
+        mock_pr.create_review.side_effect = create_review_side_effect
+
+        with patch("common.config.settings.settings", mock_settings):
+            from tools.github_api import post_pr_review
+
+            result = post_pr_review(
+                repo=mock_repo,
+                pr_number=123,
+                comments=[
+                    {"file": "test.py", "end_line": 10, "message": "Test 1"},
+                    {"file": "test.py", "end_line": 20, "message": "Test 2"},
+                    {"file": "test.py", "end_line": 30, "message": "Test 3"},
+                ]
+            )
+
+            # Should succeed via fallback
+            assert result["success"] is True
+            assert result.get("downgraded") is True
+            assert result["posted_count"] == 3
+            # create_review should be called once (fallback body post)
+            assert mock_pr.create_review.call_count == 1
+
+    def test_fault_injection_disabled_posts_normally(self):
+        """With fault injection disabled, should post normally"""
+        mock_settings = MockSettings(
+            enable_fault_injection=False,  # Disabled
+            is_staging=True,
+            fault_injection_422_rate=1.0,
+            enable_github_review_posting=True,
+            github_review_posting_dry_run=False,
+            github_review_posting_max_comments=10
+        )
+
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+
+        with patch("common.config.settings.settings", mock_settings):
+            from tools.github_api import post_pr_review
+
+            result = post_pr_review(
+                repo=mock_repo,
+                pr_number=123,
+                comments=[
+                    {"file": "test.py", "end_line": 10, "message": "Test 1"},
+                ]
+            )
+
+            # Should succeed normally (no fallback)
+            assert result["success"] is True
+            assert result.get("downgraded") is not True
+            # create_review should be called once with inline comments
+            assert mock_pr.create_review.call_count == 1
+            # Verify it was called with comments parameter
+            call_kwargs = mock_pr.create_review.call_args[1]
+            assert "comments" in call_kwargs

--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -543,6 +543,41 @@ def delete_branch(repo, branch: str):
         return False
 
 
+def _should_inject_422_fault(settings) -> bool:
+    """
+    Check if 422 fault injection should be triggered.
+
+    Phase B-B: Fault Injection for 422 Fallback Verification
+
+    This is a safety-gated function that only allows fault injection when:
+    1. settings.enable_fault_injection is True
+    2. settings.is_staging is True (NEVER in production)
+    3. Random check passes based on fault_injection_422_rate
+
+    Args:
+        settings: Application settings object
+
+    Returns:
+        True if fault should be injected, False otherwise
+    """
+    import random
+
+    # Safety gate 1: Must have fault injection enabled
+    if not getattr(settings, 'enable_fault_injection', False):
+        return False
+
+    # Safety gate 2: Must be in staging environment (NEVER production)
+    if not getattr(settings, 'is_staging', False):
+        return False
+
+    # Safety gate 3: Check injection rate (default 1.0 = always inject when enabled)
+    injection_rate = getattr(settings, 'fault_injection_422_rate', 1.0)
+    if random.random() > injection_rate:
+        return False
+
+    return True
+
+
 def post_pr_review(
     repo,
     pr_number: int,
@@ -669,6 +704,23 @@ def post_pr_review(
             result["posted_count"] = len(gh_comments)
             result["dry_run"] = True
             return result
+
+        # Phase B-B: Fault injection for 422 fallback verification (Staging only)
+        # This allows controlled testing of the fallback mechanism
+        if _should_inject_422_fault(settings):
+            logger.warning(
+                "[GitHub][FAULT_INJECTION] Injecting 422 error for fallback testing",
+                extra={
+                    "operation": "fault_injection_422",
+                    "pr_number": pr_number,
+                    "comment_count": len(gh_comments),
+                }
+            )
+            raise GithubException(
+                422,
+                {"message": "Validation Failed (FAULT_INJECTION)"},
+                None
+            )
 
         # Post the review
         pr.create_review(


### PR DESCRIPTION
# feat(phase-bb): add 422 fault injection for fallback verification

## Summary

Adds a controlled fault injection mechanism to test the 422 fallback path in `post_pr_review()`. This is the final verification point for PR #2741 (C-lite telemetry) to confirm that `fallback_comments_total`, `fallback_events_total`, and `delivery_rate` calculations work correctly when GitHub API rejects inline comments.

**Changes:**
- New `_should_inject_422_fault()` helper with triple safety gates (must be staging + enabled + rate check)
- Fault injection point in `post_pr_review()` that raises `GithubException(422)` before the actual API call
- Two new settings: `ENABLE_FAULT_INJECTION` (bool) and `FAULT_INJECTION_422_RATE` (float 0.0-1.0)
- Unit tests for safety gates, metrics recording, and delivery_rate calculation

**Usage (Staging only):**
```bash
ENABLE_FAULT_INJECTION=true
FAULT_INJECTION_422_RATE=1.0  # 100% injection rate
```

## Review & Testing Checklist for Human

- [ ] **CRITICAL: Verify safety gates in `_should_inject_422_fault()`** - Confirm that fault injection is impossible in production (requires both `is_staging=True` AND `enable_fault_injection=True`)
- [ ] **Verify injection triggers fallback path** - The 422 exception is raised before `pr.create_review()`, which should trigger the existing fallback handler at line 724
- [ ] **Note: 7 tests are skipped** - Tests requiring PyGithub are skipped in CI. The integration tests (`TestFaultInjectionIntegration`) that verify the full flow are in this category

**Recommended test plan:**
1. Deploy to staging with `ENABLE_FAULT_INJECTION=true`
2. Trigger a webhook on a test PR (e.g., PR #2755 or #2756)
3. Verify logs show `[GitHub][FAULT_INJECTION] Injecting 422 error`
4. Check Redis counters: `redis-cli KEYS metrics:orchestrator:review.inline.fallback_*`
5. Verify `fallback_comments_total` and `fallback_events_total` incremented
6. Call metrics summary endpoint and verify `delivery_rate` includes fallback comments

### Notes
- This PR is part of Phase B-B: 422 Fallback Verification for C-lite Telemetry
- Related: PR #2741 (C-lite telemetry - merged), PR #2763 (internal repo dogfooding - merged)
- Requested by: Ryan Chen (@RC918)
- Link to Devin run: https://app.devin.ai/sessions/ebf393321d4b42278a99e24a8f54d7da