### PR TITLE
feat(checkpointer): add PostgreSQL checkpointer support for LangGraph

### DIFF
--- a/common/config/settings.py
+++ b/common/config/settings.py
@@ -794,6 +794,12 @@ class Settings(BaseSettings):
         description="Use Redis-based checkpointer for LangGraph state persistence instead of in-memory MemorySaver. Enables cross-process state recovery."
     )
 
+    use_postgres_checkpointer: bool = Field(
+        default=False,
+        alias="USE_POSTGRES_CHECKPOINTER",
+        description="Use PostgreSQL-based checkpointer for LangGraph state persistence. Recommended over Redis for Upstash (which doesn't support RediSearch). Requires DATABASE_URL."
+    )
+
     use_distributed_vm_locking: bool = Field(
         default=False,
         alias="USE_DISTRIBUTED_VM_LOCKING",

--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -209,15 +209,60 @@ def get_checkpointer():
     Factory function to create the appropriate checkpointer based on configuration.
 
     Returns:
+        - PostgresSaver if USE_POSTGRES_CHECKPOINTER=true and DATABASE_URL is configured
         - RedisSaver if USE_REDIS_CHECKPOINTER=true and REDIS_URL is configured
         - MemorySaver as fallback (default)
 
     Configuration:
+        - USE_POSTGRES_CHECKPOINTER: Enable PostgreSQL-based checkpointer (default: false)
+        - DATABASE_URL: PostgreSQL connection URL (required for PostgreSQL checkpointer)
         - USE_REDIS_CHECKPOINTER: Enable Redis-based checkpointer (default: false)
         - REDIS_CHECKPOINTER_TTL: TTL in seconds for checkpoint entries (default: 86400)
         - REDIS_URL: Redis connection URL (required for Redis checkpointer)
+
+    Note:
+        PostgreSQL checkpointer is recommended over Redis for Upstash Redis,
+        which doesn't support RediSearch (required by langgraph-checkpoint-redis).
     """
     import os
+
+    use_postgres = settings.use_postgres_checkpointer
+    database_url = settings.database_url or os.environ.get("DATABASE_URL")
+
+    if use_postgres and database_url:
+        try:
+            from langgraph.checkpoint.postgres import PostgresSaver
+
+            checkpointer = PostgresSaver.from_conn_string(database_url)
+            checkpointer.setup()
+
+            logger.info(
+                "Using PostgreSQL checkpointer for LangGraph state persistence",
+                extra={
+                    "operation": "get_checkpointer",
+                    "checkpointer_type": "postgres",
+                    "database_url_masked": database_url[:30] + "..." if len(database_url) > 30 else "[hidden]"
+                }
+            )
+
+            return checkpointer
+
+        except ImportError as e:
+            logger.warning(
+                f"langgraph-checkpoint-postgres not installed, trying Redis checkpointer: {e}",
+                extra={
+                    "operation": "get_checkpointer",
+                    "error": str(e)
+                }
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to initialize PostgreSQL checkpointer, trying Redis checkpointer: {e}",
+                extra={
+                    "operation": "get_checkpointer",
+                    "error": str(e)
+                }
+            )
 
     use_redis = settings.use_redis_checkpointer
     redis_url = settings.redis_url or os.environ.get("REDIS_URL")
@@ -228,8 +273,6 @@ def get_checkpointer():
 
             ttl_seconds = settings.redis_checkpointer_ttl
 
-            # Build TTL configuration dict for RedisSaver
-            # RedisSaver expects TTL in minutes, so convert from seconds
             ttl_config = None
             if ttl_seconds and ttl_seconds > 0:
                 ttl_minutes = ttl_seconds / 60
@@ -238,7 +281,6 @@ def get_checkpointer():
                     "refresh_on_read": True
                 }
 
-            # Create RedisSaver with TTL configuration
             checkpointer = RedisSaver(redis_url=redis_url, ttl=ttl_config)
             checkpointer.setup()
 
@@ -272,12 +314,13 @@ def get_checkpointer():
                 }
             )
 
-    # Fallback to in-memory checkpointer
     logger.info(
         "Using in-memory MemorySaver for LangGraph state persistence",
         extra={
             "operation": "get_checkpointer",
             "checkpointer_type": "memory",
+            "use_postgres_configured": use_postgres,
+            "database_url_available": bool(database_url),
             "use_redis_configured": use_redis,
             "redis_url_available": bool(redis_url)
         }

--- a/handoff/20250928/40_App/orchestrator/requirements.txt
+++ b/handoff/20250928/40_App/orchestrator/requirements.txt
@@ -12,6 +12,7 @@ pydantic-settings>=2.0.0
 tiktoken>=0.5.0
 langgraph>=0.2.4
 langgraph-checkpoint-redis>=0.2.1
+langgraph-checkpoint-postgres>=2.0.0
 langchain-core>=0.3.0
 # aiohttp for MCP HTTP client in VSCodeIDEService
 aiohttp>=3.12.14

--- a/render.yaml
+++ b/render.yaml
@@ -128,6 +128,10 @@ services:
         value: false
       - key: RQ_MAX_JOBS
         value: "15"
+      - key: DATABASE_URL
+        sync: false
+      - key: USE_POSTGRES_CHECKPOINTER
+        value: "true"
 
   - type: web
     name: braintrust-processor


### PR DESCRIPTION
## Summary

Adds PostgreSQL-based checkpointer as the primary option for LangGraph state persistence to fix OOM issues on `morningai-backend-v2-stg-worker`.

**Root Cause**: The Redis checkpointer (`langgraph-checkpoint-redis`) requires RediSearch support (`FT._LIST` command), which Upstash Redis does not provide. This causes every LangGraph job to silently fall back to in-memory `MemorySaver`, which accumulates state across concurrent jobs and eventually causes OOM when memory exceeds 16GB.

**Solution**: Add PostgreSQL checkpointer (`langgraph-checkpoint-postgres`) which uses the existing Supabase PostgreSQL database. The checkpointer priority is now: PostgreSQL → Redis → MemorySaver.

Changes:
- Add `USE_POSTGRES_CHECKPOINTER` setting to `settings.py`
- Add `langgraph-checkpoint-postgres>=2.0.0` to requirements
- Update `get_checkpointer()` to try PostgreSQL first
- Enable `USE_POSTGRES_CHECKPOINTER=true` for worker in `render.yaml`

## Review & Testing Checklist for Human

- [ ] **CRITICAL**: Verify `DATABASE_URL` is configured in Render Dashboard for `morningai-agent-worker` service (the fix won't work without this)
- [ ] After deployment, check worker logs for `"Using PostgreSQL checkpointer for LangGraph state persistence"` to confirm it's active
- [ ] Monitor memory metrics on Render Dashboard after deployment - memory should no longer spike to 16GB during concurrent jobs
- [ ] If OOM persists, check logs for PostgreSQL connection errors that might cause fallback to MemorySaver

**Recommended test plan**:
1. Merge and deploy to staging
2. Trigger multiple concurrent LangGraph jobs
3. Monitor memory usage in Render Dashboard
4. Verify logs show PostgreSQL checkpointer is being used

### Notes

- The PostgreSQL checkpointer has not been tested locally - verification must happen in staging
- If `DATABASE_URL` is not set, the system will fall back to Redis (which fails) then MemorySaver (which causes OOM)
- User has already reduced `RQ_MAX_JOBS` to 3 as a temporary mitigation

---
Link to Devin run: https://app.devin.ai/sessions/5dd526bad8bf4aff82d9f88b1904cd31
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918