### PR TITLE
fix(webhooks): use full UUID in task_id for DB compatibility

### DIFF
--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -561,9 +561,12 @@ class EventNormalizer:
         # Build context for Meta Agent
         context = self._build_context(event)
 
-        # Generate task ID
+        # Generate task ID with full UUID for DB compatibility
+        # Format: webhook-{source}-{full_uuid}
+        # The db_writer.normalize_and_validate_uuid() will extract the UUID portion
         import uuid
-        task_id = f"webhook-{event.source.value}-{uuid.uuid4().hex[:8]}"
+        task_uuid = str(uuid.uuid4())
+        task_id = f"webhook-{event.source.value}-{task_uuid}"
 
         task = NormalizedTask(
             task_id=task_id,


### PR DESCRIPTION
# fix(webhooks): use full UUID in task_id for DB compatibility

## Summary

Fixes DB write failures for webhook-triggered tasks by changing the task_id format to include a full UUID instead of a truncated 8-character hex string.

**Before:** `webhook-github-75c37705` (8 hex chars - not a valid UUID)
**After:** `webhook-github-550e8400-e29b-41d4-a716-446655440000` (full UUID)

The `db_writer.normalize_and_validate_uuid()` requires task_id to contain a valid UUID pattern. The old format caused errors like:
```
DB write failed for task webhook-github-75c37705 (done): No valid UUID found in task_id='webhook-github-75c37705'
```

## Review & Testing Checklist for Human

- [ ] Trigger a real webhook (e.g., create a test PR) and verify the DB write succeeds in Render logs - look for `DB write success: task {uuid}` instead of `DB write failed`
- [ ] Confirm no other code depends on the old 8-character task_id format (grep for `webhook-.*-[a-f0-9]{8}`)

### Notes

The `db_writer.normalize_and_validate_uuid()` already handles prefixed UUIDs by extracting the UUID portion, so this change is backward compatible with the existing DB schema.

**Link to Devin run:** https://app.devin.ai/sessions/5dd526bad8bf4aff82d9f88b1904cd31
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918