### PR TITLE
test: verify webhook UUID fix (PR #2777)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -564,6 +564,7 @@ class EventNormalizer:
         # Generate task ID with full UUID for DB compatibility
         # Format: webhook-{source}-{full_uuid}
         # The db_writer.normalize_and_validate_uuid() will extract the UUID portion
+        # Fix verified: PR #2777
         import uuid
         task_uuid = str(uuid.uuid4())
         task_id = f"webhook-{event.source.value}-{task_uuid}"


### PR DESCRIPTION
## Summary

Minimal documentation change to trigger a webhook event and verify that the UUID fix from PR #2777 is working correctly in staging.

This PR adds a single comment line - the real purpose is to generate a webhook event so we can confirm the DB write no longer fails with `No valid UUID found` errors.

## Review & Testing Checklist for Human

- [ ] Check Render logs for `morningai-backend-v2-stg-worker` after this PR triggers a webhook
- [ ] Verify task_id format is now `webhook-github-{full-uuid}` (36 char UUID) instead of `webhook-github-{8-hex-chars}`
- [ ] Confirm no `DB write failed` or `No valid UUID found` errors appear in logs

### Test Plan
1. After this PR is created, check Render logs within 2-3 minutes
2. Search for `webhook-github-` to find the new task
3. Verify the task_id contains a full UUID (e.g., `webhook-github-550e8400-e29b-41d4-a716-446655440000`)
4. Search for `DB write` to confirm success instead of failure

### Notes

This is a test PR to verify PR #2777 fix. Can be closed without merging after verification is complete.

**Link to Devin run:** https://app.devin.ai/sessions/5dd526bad8bf4aff82d9f88b1904cd31
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918