### PR TITLE
fix(phase-bb): use consistent queue_name pattern with None handling in worker.py

### DIFF
--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -1826,7 +1826,7 @@ def run_pr_updated_delayed_task(
                             redis_url = getattr(settings, 'redis_url', None)
                             if redis_url:
                                 redis_client = Redis.from_url(redis_url, decode_responses=False)
-                                queue_name = getattr(settings, 'rq_queue_name', 'orchestrator')
+                                queue_name = getattr(settings, 'rq_queue_name', None) or 'orchestrator'
                                 queue = Queue(queue_name, connection=redis_client, serializer=JSONSerializer())
                                 
                                 # Use same job_id to replace/deduplicate


### PR DESCRIPTION
## Summary

Fixes queue_name fallback pattern in `run_pr_updated_delayed_task()` to handle both attribute-not-exists and explicit `None` value cases.

**Before:** `getattr(settings, 'rq_queue_name', 'orchestrator')` - If `rq_queue_name` is explicitly set to `None`, this passes `None` to `Queue()`.

**After:** `getattr(settings, 'rq_queue_name', None) or 'orchestrator'` - Handles both missing attribute and `None` value, consistent with `rate_limit.py:967`.

This is a follow-up fix identified during CTO review of PR #2782.

## Review & Testing Checklist for Human

- [ ] Verify that `Queue(None, connection=...)` would indeed cause issues in RQ (this fix prevents that edge case)
- [ ] Confirm no other places in the codebase use the old pattern `getattr(settings, 'rq_queue_name', 'orchestrator')` that should also be updated

### Notes

- This is a minimal, low-risk fix for consistency
- The pattern `getattr(..., None) or 'default'` is already established in `rate_limit.py`

**Requested by:** Ryan Chen (@RC918)
**Link to Devin run:** https://app.devin.ai/sessions/9c05c26b3ef441f492ea32c8cf6a224e