### PR TITLE
feat(epic-b): P2 follow-up - add metrics for drift downgrade path

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -3071,11 +3071,16 @@ def publisher_node(state: AgentState) -> AgentState:
                     state["publish_result"]["line_drift_downgraded"] = drift_downgrade_count
                     # P2 Follow-up: Record metrics for drift downgrade path
                     # This ensures inline comment delivery metrics are captured even when drift occurs
+                    # Metrics semantics:
+                    # - eligible_count: original inline-eligible before validation (funnel start)
+                    # - validated_count: comments that passed validation (drift_downgrade_count)
+                    # - downgraded_count: total downgrades (validation + drift)
+                    # - posted_count: 0 (no inline comments posted due to drift)
                     metrics.record_inline_comment_result(
                         trace_id=trace_id,
-                        eligible_count=drift_downgrade_count,
-                        validated_count=drift_downgrade_count,  # Already validated before drift check
-                        downgraded_count=drift_downgrade_count,
+                        eligible_count=inline_eligible_count,  # Original eligible before validation
+                        validated_count=drift_downgrade_count,  # Validated comments at drift time
+                        downgraded_count=downgraded_count + drift_downgrade_count,  # Total: validation + drift
                         posted_count=0,  # No inline comments posted due to drift
                         post_failed=False,
                         fallback_used=True,  # Comments delivered via file-level fallback


### PR DESCRIPTION
## Summary

Adds missing metrics recording when line drift is detected and inline comments are downgraded to file-level delivery. Previously, the drift downgrade path did not call `metrics.record_inline_comment_result()`, causing inline comment delivery metrics to be missing when drift occurs.

**Metrics semantics (corrected):**
- `eligible_count`: `inline_eligible_count` - original inline-eligible before validation (funnel start)
- `validated_count`: `drift_downgrade_count` - comments that passed validation at drift time
- `downgraded_count`: `downgraded_count + drift_downgrade_count` - total downgrades (validation + drift)
- `posted_count`: 0 (no inline comments posted due to drift)
- `fallback_used`: True (comments delivered via file-level fallback)

## Updates since last revision

Fixed metrics semantics per review feedback:
- Changed `eligible_count` from `drift_downgrade_count` to `inline_eligible_count` (original count before validation)
- Changed `downgraded_count` to sum of validation downgrades + drift downgrades
- This ensures KPI funnel is coherent: eligible → validated → posted/fallback

## Review & Testing Checklist for Human

- [ ] **Verify funnel math**: Confirm that `eligible_count=inline_eligible_count` and `downgraded_count=downgraded_count + drift_downgrade_count` correctly represents the KPI funnel
- [ ] **Verify no double-counting**: Check that this metrics call doesn't result in double-counting if there's another `record_inline_comment_result()` call later in the unified file-level delivery path for the same comments
- [ ] **Verify variable scope**: Confirm `inline_eligible_count` and `downgraded_count` are always initialized before the drift check block (they are initialized at lines 2960-2962)

**Recommended test plan:**
1. Deploy to staging
2. Trigger a PR review, then push a new commit while the review is in progress to cause line drift
3. Check logs for `[Publisher] Line drift detected` message
4. Verify metrics are recorded with correct values (check Redis keys or metrics dashboard for `review.inline.*` counters)

### Notes
- No unit tests added for this change - consider adding in follow-up
- The `dry_run` parameter uses `settings.github_review_posting_dry_run` directly since `result` dict is not yet populated at this point in the code

Link to Devin run: https://app.devin.ai/sessions/74e8054d73a14cbeb45f51b0bc43591d
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918