### PR TITLE
feat(reputation-engine): add unit tests and convert print to logger (P2 follow-up)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/governance/reputation_engine.py
+++ b/handoff/20250928/40_App/orchestrator/governance/reputation_engine.py
@@ -146,8 +146,8 @@ class ReputationEngine:
                 return response.data[0]['agent_id']
             
             return None
-        except Exception as e:
-            logger.error(f"[ReputationEngine] Error getting/creating agent: {e}")
+        except Exception:
+            logger.exception("[ReputationEngine] Error getting/creating agent")
             return None
     
     def record_event(
@@ -178,8 +178,8 @@ class ReputationEngine:
             
             logger.info(f"[ReputationEngine] Recorded {event_type} for {agent_id}: delta={delta}")
             return True
-        except Exception as e:
-            logger.error(f"[ReputationEngine] Error recording event: {e}")
+        except Exception:
+            logger.exception("[ReputationEngine] Error recording event")
             return False
     
     def get_reputation(self, agent_id: str) -> Optional[Dict]:
@@ -196,8 +196,8 @@ class ReputationEngine:
             if response.data:
                 return response.data
             return None
-        except Exception as e:
-            logger.error(f"[ReputationEngine] Error getting reputation: {e}")
+        except Exception:
+            logger.exception("[ReputationEngine] Error getting reputation")
             return None
     
     def get_permission_level(self, agent_id: str) -> str:
@@ -212,8 +212,8 @@ class ReputationEngine:
             if response.data:
                 return response.data['permission_level']
             return 'sandbox_only'
-        except Exception as e:
-            logger.error(f"[ReputationEngine] Error getting permission level: {e}")
+        except Exception:
+            logger.exception("[ReputationEngine] Error getting permission level")
             return 'sandbox_only'
     
     def get_reputation_score(self, agent_id: str) -> int:
@@ -228,8 +228,8 @@ class ReputationEngine:
             if response.data:
                 return response.data['reputation_score']
             return 100
-        except Exception as e:
-            logger.error(f"[ReputationEngine] Error getting reputation score: {e}")
+        except Exception:
+            logger.exception("[ReputationEngine] Error getting reputation score")
             return 100
     
     def update_permission_level(self, agent_id: str) -> str:
@@ -246,8 +246,8 @@ class ReputationEngine:
             if response.data:
                 return response.data
             return 'sandbox_only'
-        except Exception as e:
-            logger.error(f"[ReputationEngine] Error updating permission level: {e}")
+        except Exception:
+            logger.exception("[ReputationEngine] Error updating permission level")
             return 'sandbox_only'
     
     def get_allowed_operations(self, agent_id: str) -> list:
@@ -277,8 +277,8 @@ class ReputationEngine:
                 .execute()
             
             return response.data if response.data else []
-        except Exception as e:
-            logger.error(f"[ReputationEngine] Error getting recent events: {e}")
+        except Exception:
+            logger.exception("[ReputationEngine] Error getting recent events")
             return []
     
     def get_leaderboard(self, limit: int = 10) -> list:
@@ -295,8 +295,8 @@ class ReputationEngine:
                 .execute()
             
             return response.data if response.data else []
-        except Exception as e:
-            logger.error(f"[ReputationEngine] Error getting leaderboard: {e}")
+        except Exception:
+            logger.exception("[ReputationEngine] Error getting leaderboard")
             return []
     
     def apply_decay(self, agent_id: str) -> bool:
@@ -349,8 +349,8 @@ class ReputationEngine:
                 return True
             
             return False
-        except Exception as e:
-            logger.error(f"[ReputationEngine] Error applying decay: {e}")
+        except Exception:
+            logger.exception("[ReputationEngine] Error applying decay")
             return False
     
     def get_statistics(self) -> Dict:
@@ -384,8 +384,8 @@ class ReputationEngine:
                 'high_reputation_agents': len([a for a in agents if a['reputation_score'] >= 130]),
                 'low_reputation_agents': len([a for a in agents if a['reputation_score'] < 90])
             }
-        except Exception as e:
-            logger.error(f"[ReputationEngine] Error getting statistics: {e}")
+        except Exception:
+            logger.exception("[ReputationEngine] Error getting statistics")
             return {}
 
 

--- a/handoff/20250928/40_App/orchestrator/governance/reputation_engine.py
+++ b/handoff/20250928/40_App/orchestrator/governance/reputation_engine.py
@@ -1,4 +1,5 @@
 """Reputation Engine - Agent reputation scoring and management"""
+import logging
 import os
 import uuid
 import yaml
@@ -7,6 +8,8 @@ from typing import Dict, Optional, Tuple
 from datetime import datetime, timedelta
 
 from common.config.settings import settings
+
+logger = logging.getLogger(__name__)
 
 
 def _is_valid_uuid(value: str) -> bool:
@@ -59,7 +62,7 @@ class ReputationEngine:
             with open(path, 'r') as f:
                 return yaml.safe_load(f)
         except Exception as e:
-            print(f"[ReputationEngine] Error loading policies: {e}")
+            logger.warning(f"[ReputationEngine] Error loading policies: {e}")
             return {}
     
     def _get_supabase(self):
@@ -75,10 +78,10 @@ class ReputationEngine:
                 from persistence.db_client import get_client
                 return get_client()
             except Exception as e:
-                print(f"[ReputationEngine] Supabase unavailable: {e}")
+                logger.warning(f"[ReputationEngine] Supabase unavailable: {e}")
                 return None
         except Exception as e:
-            print(f"[ReputationEngine] Supabase unavailable: {e}")
+            logger.warning(f"[ReputationEngine] Supabase unavailable: {e}")
             return None
     
     def resolve_agent_uuid(self, agent_identifier: str) -> Optional[str]:
@@ -114,9 +117,9 @@ class ReputationEngine:
         if agent_uuid:
             # Cache the mapping for future lookups
             self._agent_uuid_cache[agent_identifier] = agent_uuid
-            print(f"[ReputationEngine] Resolved agent_type '{agent_identifier}' to UUID '{agent_uuid}'")
+            logger.info(f"[ReputationEngine] Resolved agent_type '{agent_identifier}' to UUID '{agent_uuid}'")
         else:
-            print(f"[ReputationEngine] Failed to resolve agent_identifier '{agent_identifier}' to UUID")
+            logger.warning(f"[ReputationEngine] Failed to resolve agent_identifier '{agent_identifier}' to UUID")
         
         return agent_uuid
     
@@ -144,7 +147,7 @@ class ReputationEngine:
             
             return None
         except Exception as e:
-            print(f"[ReputationEngine] Error getting/creating agent: {e}")
+            logger.error(f"[ReputationEngine] Error getting/creating agent: {e}")
             return None
     
     def record_event(
@@ -158,7 +161,7 @@ class ReputationEngine:
         """Record a reputation event"""
         supabase = self._get_supabase()
         if not supabase:
-            print(f"[ReputationEngine] Supabase unavailable, skipping event recording")
+            logger.warning("[ReputationEngine] Supabase unavailable, skipping event recording")
             return False
         
         delta = self.scoring_rules.get(event_type, 0)
@@ -173,10 +176,10 @@ class ReputationEngine:
                 'p_metadata': metadata
             }).execute()
             
-            print(f"[ReputationEngine] Recorded {event_type} for {agent_id}: delta={delta}")
+            logger.info(f"[ReputationEngine] Recorded {event_type} for {agent_id}: delta={delta}")
             return True
         except Exception as e:
-            print(f"[ReputationEngine] Error recording event: {e}")
+            logger.error(f"[ReputationEngine] Error recording event: {e}")
             return False
     
     def get_reputation(self, agent_id: str) -> Optional[Dict]:
@@ -194,7 +197,7 @@ class ReputationEngine:
                 return response.data
             return None
         except Exception as e:
-            print(f"[ReputationEngine] Error getting reputation: {e}")
+            logger.error(f"[ReputationEngine] Error getting reputation: {e}")
             return None
     
     def get_permission_level(self, agent_id: str) -> str:
@@ -210,7 +213,7 @@ class ReputationEngine:
                 return response.data['permission_level']
             return 'sandbox_only'
         except Exception as e:
-            print(f"[ReputationEngine] Error getting permission level: {e}")
+            logger.error(f"[ReputationEngine] Error getting permission level: {e}")
             return 'sandbox_only'
     
     def get_reputation_score(self, agent_id: str) -> int:
@@ -226,7 +229,7 @@ class ReputationEngine:
                 return response.data['reputation_score']
             return 100
         except Exception as e:
-            print(f"[ReputationEngine] Error getting reputation score: {e}")
+            logger.error(f"[ReputationEngine] Error getting reputation score: {e}")
             return 100
     
     def update_permission_level(self, agent_id: str) -> str:
@@ -244,7 +247,7 @@ class ReputationEngine:
                 return response.data
             return 'sandbox_only'
         except Exception as e:
-            print(f"[ReputationEngine] Error updating permission level: {e}")
+            logger.error(f"[ReputationEngine] Error updating permission level: {e}")
             return 'sandbox_only'
     
     def get_allowed_operations(self, agent_id: str) -> list:
@@ -275,7 +278,7 @@ class ReputationEngine:
             
             return response.data if response.data else []
         except Exception as e:
-            print(f"[ReputationEngine] Error getting recent events: {e}")
+            logger.error(f"[ReputationEngine] Error getting recent events: {e}")
             return []
     
     def get_leaderboard(self, limit: int = 10) -> list:
@@ -293,7 +296,7 @@ class ReputationEngine:
             
             return response.data if response.data else []
         except Exception as e:
-            print(f"[ReputationEngine] Error getting leaderboard: {e}")
+            logger.error(f"[ReputationEngine] Error getting leaderboard: {e}")
             return []
     
     def apply_decay(self, agent_id: str) -> bool:
@@ -342,12 +345,12 @@ class ReputationEngine:
                     reason=f"Inactive for {days_inactive} days, decayed by {decay_amount} points"
                 )
                 
-                print(f"[ReputationEngine] Applied decay to {agent_id}: {current_score} -> {new_score}")
+                logger.info(f"[ReputationEngine] Applied decay to {agent_id}: {current_score} -> {new_score}")
                 return True
             
             return False
         except Exception as e:
-            print(f"[ReputationEngine] Error applying decay: {e}")
+            logger.error(f"[ReputationEngine] Error applying decay: {e}")
             return False
     
     def get_statistics(self) -> Dict:
@@ -382,7 +385,7 @@ class ReputationEngine:
                 'low_reputation_agents': len([a for a in agents if a['reputation_score'] < 90])
             }
         except Exception as e:
-            print(f"[ReputationEngine] Error getting statistics: {e}")
+            logger.error(f"[ReputationEngine] Error getting statistics: {e}")
             return {}
 
 

--- a/handoff/20250928/40_App/orchestrator/tests/test_reputation_engine_uuid.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_reputation_engine_uuid.py
@@ -4,9 +4,11 @@ Tests for reputation_engine.py UUID resolution functions
 P2 Follow-up: Unit tests for resolve_agent_uuid() and _is_valid_uuid()
 Focus: Deterministic unit tests without external dependencies
 """
+import logging
 import pytest
 from unittest.mock import patch
 
+import governance.reputation_engine as re_mod
 from governance.reputation_engine import (
     _is_valid_uuid,
     ReputationEngine,
@@ -146,7 +148,7 @@ class TestResolveAgentUuid:
 
 
 class TestResolveAgentUuidLogging:
-    """Test logging behavior of resolve_agent_uuid"""
+    """Test logging behavior of resolve_agent_uuid using caplog.records"""
 
     @pytest.fixture
     def mock_engine(self):
@@ -156,26 +158,43 @@ class TestResolveAgentUuidLogging:
             return engine
 
     def test_logs_successful_resolution(self, mock_engine, caplog):
-        """Should log successful agent_type to UUID resolution"""
+        """Should log INFO with agent_type and UUID on successful resolution"""
         expected_uuid = "550e8400-e29b-41d4-a716-446655440000"
 
         with patch.object(mock_engine, 'get_or_create_agent', return_value=expected_uuid):
-            import logging
-            with caplog.at_level(logging.INFO):
+            with caplog.at_level(logging.INFO, logger=re_mod.logger.name):
                 mock_engine.resolve_agent_uuid("orchestrator")
 
-            # Check that resolution was logged (via logger or print)
-            # Note: After converting print to logger, this will capture the log
-            assert expected_uuid in str(mock_engine._agent_uuid_cache)
+            # Filter records by logger name
+            records = [r for r in caplog.records if r.name == re_mod.logger.name]
+
+            # Verify log level and message content
+            assert any(
+                r.levelno == logging.INFO
+                and "Resolved agent_type" in r.getMessage()
+                and "orchestrator" in r.getMessage()
+                and expected_uuid in r.getMessage()
+                for r in records
+            ), f"Expected INFO log with 'Resolved agent_type', 'orchestrator', and UUID. Got: {[r.getMessage() for r in records]}"
 
     def test_logs_failed_resolution(self, mock_engine, caplog):
-        """Should log failed agent_type resolution"""
+        """Should log WARNING with agent_identifier on failed resolution"""
         with patch.object(mock_engine, 'get_or_create_agent', return_value=None):
-            import logging
-            with caplog.at_level(logging.WARNING):
+            with caplog.at_level(logging.WARNING, logger=re_mod.logger.name):
                 result = mock_engine.resolve_agent_uuid("unknown_agent")
 
             assert result is None
+
+            # Filter records by logger name
+            records = [r for r in caplog.records if r.name == re_mod.logger.name]
+
+            # Verify log level and message content
+            assert any(
+                r.levelno == logging.WARNING
+                and "Failed to resolve" in r.getMessage()
+                and "unknown_agent" in r.getMessage()
+                for r in records
+            ), f"Expected WARNING log with 'Failed to resolve' and 'unknown_agent'. Got: {[r.getMessage() for r in records]}"
 
 
 class TestAgentUuidCacheIsolation:

--- a/handoff/20250928/40_App/orchestrator/tests/test_reputation_engine_uuid.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_reputation_engine_uuid.py
@@ -1,0 +1,194 @@
+"""
+Tests for reputation_engine.py UUID resolution functions
+
+P2 Follow-up: Unit tests for resolve_agent_uuid() and _is_valid_uuid()
+Focus: Deterministic unit tests without external dependencies
+"""
+import pytest
+from unittest.mock import patch
+
+from governance.reputation_engine import (
+    _is_valid_uuid,
+    ReputationEngine,
+)
+
+
+class TestIsValidUuid:
+    """Test _is_valid_uuid helper function"""
+
+    def test_valid_uuid_v4(self):
+        """Should return True for valid UUID v4"""
+        assert _is_valid_uuid("550e8400-e29b-41d4-a716-446655440000") is True
+        assert _is_valid_uuid("123e4567-e89b-12d3-a456-426614174000") is True
+
+    def test_valid_uuid_uppercase(self):
+        """Should return True for uppercase UUID"""
+        assert _is_valid_uuid("550E8400-E29B-41D4-A716-446655440000") is True
+
+    def test_valid_uuid_no_hyphens(self):
+        """Should return True for UUID without hyphens"""
+        assert _is_valid_uuid("550e8400e29b41d4a716446655440000") is True
+
+    def test_invalid_uuid_agent_type_string(self):
+        """Should return False for agent_type strings like 'orchestrator'"""
+        assert _is_valid_uuid("orchestrator") is False
+        assert _is_valid_uuid("ops_agent") is False
+        assert _is_valid_uuid("dev_agent") is False
+
+    def test_invalid_uuid_empty_string(self):
+        """Should return False for empty string"""
+        assert _is_valid_uuid("") is False
+
+    def test_invalid_uuid_none(self):
+        """Should return False for None"""
+        assert _is_valid_uuid(None) is False
+
+    def test_invalid_uuid_malformed(self):
+        """Should return False for malformed UUID strings"""
+        assert _is_valid_uuid("not-a-uuid") is False
+        assert _is_valid_uuid("550e8400-e29b-41d4-a716") is False  # Too short
+        assert _is_valid_uuid("550e8400-e29b-41d4-a716-446655440000-extra") is False  # Too long
+        assert _is_valid_uuid("gggggggg-gggg-gggg-gggg-gggggggggggg") is False  # Invalid hex
+
+    def test_invalid_uuid_integer(self):
+        """Should return False for integer input"""
+        assert _is_valid_uuid(12345) is False
+
+    def test_invalid_uuid_list(self):
+        """Should return False for list input"""
+        assert _is_valid_uuid(["550e8400-e29b-41d4-a716-446655440000"]) is False
+
+
+class TestResolveAgentUuid:
+    """Test ReputationEngine.resolve_agent_uuid method"""
+
+    @pytest.fixture
+    def mock_engine(self):
+        """Create a ReputationEngine with mocked dependencies"""
+        with patch.object(ReputationEngine, '_load_policies', return_value={}):
+            engine = ReputationEngine(supabase_client=None, policies_path='/nonexistent')
+            return engine
+
+    def test_resolve_valid_uuid_returns_as_is(self, mock_engine):
+        """Should return valid UUID as-is without DB lookup"""
+        valid_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        result = mock_engine.resolve_agent_uuid(valid_uuid)
+        assert result == valid_uuid
+
+    def test_resolve_none_returns_none(self, mock_engine):
+        """Should return None for None input"""
+        result = mock_engine.resolve_agent_uuid(None)
+        assert result is None
+
+    def test_resolve_empty_string_returns_none(self, mock_engine):
+        """Should return None for empty string"""
+        result = mock_engine.resolve_agent_uuid("")
+        assert result is None
+
+    def test_resolve_agent_type_with_db_lookup(self, mock_engine):
+        """Should look up agent_type in DB and return UUID"""
+        expected_uuid = "550e8400-e29b-41d4-a716-446655440000"
+
+        with patch.object(mock_engine, 'get_or_create_agent', return_value=expected_uuid):
+            result = mock_engine.resolve_agent_uuid("orchestrator")
+            assert result == expected_uuid
+
+    def test_resolve_agent_type_caches_result(self, mock_engine):
+        """Should cache resolved UUID for subsequent calls"""
+        expected_uuid = "550e8400-e29b-41d4-a716-446655440000"
+
+        with patch.object(mock_engine, 'get_or_create_agent', return_value=expected_uuid) as mock_get:
+            # First call - should hit DB
+            result1 = mock_engine.resolve_agent_uuid("orchestrator")
+            assert result1 == expected_uuid
+            assert mock_get.call_count == 1
+
+            # Second call - should use cache
+            result2 = mock_engine.resolve_agent_uuid("orchestrator")
+            assert result2 == expected_uuid
+            assert mock_get.call_count == 1  # Still 1, not 2
+
+    def test_resolve_agent_type_db_failure_returns_none(self, mock_engine):
+        """Should return None when DB lookup fails"""
+        with patch.object(mock_engine, 'get_or_create_agent', return_value=None):
+            result = mock_engine.resolve_agent_uuid("orchestrator")
+            assert result is None
+
+    def test_resolve_agent_type_does_not_cache_failure(self, mock_engine):
+        """Should not cache failed resolutions"""
+        with patch.object(mock_engine, 'get_or_create_agent', return_value=None) as mock_get:
+            # First call - fails
+            result1 = mock_engine.resolve_agent_uuid("orchestrator")
+            assert result1 is None
+            assert mock_get.call_count == 1
+
+            # Second call - should try again (not cached)
+            result2 = mock_engine.resolve_agent_uuid("orchestrator")
+            assert result2 is None
+            assert mock_get.call_count == 2
+
+    def test_resolve_different_agent_types_cached_separately(self, mock_engine):
+        """Should cache different agent types separately"""
+        uuid1 = "550e8400-e29b-41d4-a716-446655440001"
+        uuid2 = "550e8400-e29b-41d4-a716-446655440002"
+
+        def mock_get_or_create(agent_type):
+            return uuid1 if agent_type == "orchestrator" else uuid2
+
+        with patch.object(mock_engine, 'get_or_create_agent', side_effect=mock_get_or_create):
+            result1 = mock_engine.resolve_agent_uuid("orchestrator")
+            result2 = mock_engine.resolve_agent_uuid("ops_agent")
+
+            assert result1 == uuid1
+            assert result2 == uuid2
+            assert mock_engine._agent_uuid_cache["orchestrator"] == uuid1
+            assert mock_engine._agent_uuid_cache["ops_agent"] == uuid2
+
+
+class TestResolveAgentUuidLogging:
+    """Test logging behavior of resolve_agent_uuid"""
+
+    @pytest.fixture
+    def mock_engine(self):
+        """Create a ReputationEngine with mocked dependencies"""
+        with patch.object(ReputationEngine, '_load_policies', return_value={}):
+            engine = ReputationEngine(supabase_client=None, policies_path='/nonexistent')
+            return engine
+
+    def test_logs_successful_resolution(self, mock_engine, caplog):
+        """Should log successful agent_type to UUID resolution"""
+        expected_uuid = "550e8400-e29b-41d4-a716-446655440000"
+
+        with patch.object(mock_engine, 'get_or_create_agent', return_value=expected_uuid):
+            import logging
+            with caplog.at_level(logging.INFO):
+                mock_engine.resolve_agent_uuid("orchestrator")
+
+            # Check that resolution was logged (via logger or print)
+            # Note: After converting print to logger, this will capture the log
+            assert expected_uuid in str(mock_engine._agent_uuid_cache)
+
+    def test_logs_failed_resolution(self, mock_engine, caplog):
+        """Should log failed agent_type resolution"""
+        with patch.object(mock_engine, 'get_or_create_agent', return_value=None):
+            import logging
+            with caplog.at_level(logging.WARNING):
+                result = mock_engine.resolve_agent_uuid("unknown_agent")
+
+            assert result is None
+
+
+class TestAgentUuidCacheIsolation:
+    """Test that cache is properly isolated per engine instance"""
+
+    def test_cache_isolated_between_instances(self):
+        """Each ReputationEngine instance should have its own cache"""
+        with patch.object(ReputationEngine, '_load_policies', return_value={}):
+            engine1 = ReputationEngine(supabase_client=None, policies_path='/nonexistent')
+            engine2 = ReputationEngine(supabase_client=None, policies_path='/nonexistent')
+
+            # Populate cache in engine1
+            engine1._agent_uuid_cache["orchestrator"] = "uuid-1"
+
+            # engine2 should not see engine1's cache
+            assert "orchestrator" not in engine2._agent_uuid_cache


### PR DESCRIPTION
# feat(reputation-engine): add unit tests and convert print to logger (P2 follow-up)

## Summary

This PR is a P2 follow-up to PR #2783 (UUID resolution fix) that adds:

1. **20 unit tests** for `_is_valid_uuid()` and `resolve_agent_uuid()` functions covering:
   - UUID validation (valid v4, uppercase, no hyphens)
   - Invalid inputs (agent_type strings, empty, None, malformed, wrong types)
   - UUID resolution with DB lookup and caching behavior
   - Cache isolation between engine instances
   - Logging behavior verification using `caplog.records`

2. **Logging consistency** - Converted all `print()` statements to proper `logger` calls:
   - `logger.info()` for successful operations
   - `logger.warning()` for failures and unavailable services
   - `logger.exception()` in except blocks to preserve traceback for debugging

## Updates since last revision

- **Improved logging tests**: Now use `caplog.records` to verify log level (`levelno`) and message content, filtered by logger name for precise assertions
- **Better exception logging**: Changed `logger.error(f"... {e}")` to `logger.exception("...")` in all except blocks to preserve full traceback
- **Kept `[ReputationEngine]` prefix**: Preserved for compatibility with existing troubleshooting docs (e.g., `WORKER_DEPLOYMENT_TROUBLESHOOTING.md`)

## Review & Testing Checklist for Human

- [ ] Verify `logger.exception()` calls no longer include `{e}` in message (traceback is auto-included)
- [ ] Confirm logging tests correctly filter by `re_mod.logger.name` and verify both level and message
- [ ] Run tests locally to confirm all 20 pass

### Test Plan
```bash
cd handoff/20250928/40_App/orchestrator
PYTHONPATH="$PWD:$PYTHONPATH" pytest tests/test_reputation_engine_uuid.py -v
```

### Notes

- Local tests: 20/20 passed
- Pre-existing W293 (trailing whitespace) lint warnings in `reputation_engine.py` were not modified as they are outside the scope of this PR
- `[ReputationEngine]` prefix retained because troubleshooting docs reference it for log searching

---
**Link to Devin run:** https://app.devin.ai/sessions/5119ab5a69484a408bf72d49d727ca05
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918