### PR TITLE
feat(config): change DASHSCOPE_BASE_URL default to international endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -431,11 +431,11 @@ DASHSCOPE_API_KEY=your-secret-here
 # AliCloud DashScope API base URL (EPIC
 # OpenAI-compatible endpoint for DashScope API.
 # IMPORTANT: DashScope has TWO different regional endpoints:
-# - China (default): https://dashscope.aliyuncs.com/compatible-mode/v1
-# - International: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+# - International (default): https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+# - China: https://dashscope.aliyuncs.com/compatible-mode/v1
 # Your API key is region-specific! A China API key will NOT work with the International endpoint, and vice versa. Set this URL to match your API key region.
 # Required: False
-DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # SiliconFlow API key for Qwen models (EPIC
 # Required for SiliconFlow provider (Qwen models).

--- a/common/config/settings.py
+++ b/common/config/settings.py
@@ -577,9 +577,9 @@ class Settings(BaseSettings):
         return self.siliconflow_api_key_secret.get_secret_value() if self.siliconflow_api_key_secret else None
 
     dashscope_base_url: str = Field(
-        default="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        default="https://dashscope-intl.aliyuncs.com/compatible-mode/v1",
         alias="DASHSCOPE_BASE_URL",
-        description="AliCloud DashScope API base URL (EPIC #2594)"
+        description="AliCloud DashScope API base URL - International endpoint (EPIC #2594)"
     )
 
     siliconflow_base_url: str = Field(

--- a/config/env.schema.yaml
+++ b/config/env.schema.yaml
@@ -369,7 +369,7 @@ fields:
   DASHSCOPE_BASE_URL:
     type: url
     required: false
-    default: https://dashscope.aliyuncs.com/compatible-mode/v1
+    default: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
     description: AliCloud DashScope API base URL (EPIC #2594)
     category: Integration
     security_level: public
@@ -377,9 +377,9 @@ fields:
 
       IMPORTANT: DashScope has TWO different regional endpoints:
 
-      - China (default): https://dashscope.aliyuncs.com/compatible-mode/v1
+      - International (default): https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
-      - International: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+      - China: https://dashscope.aliyuncs.com/compatible-mode/v1
 
       Your API key is region-specific! A China API key will NOT work with the
       International endpoint, and vice versa. Set this URL to match your API key region.

--- a/docs/ENV_REFERENCE.md
+++ b/docs/ENV_REFERENCE.md
@@ -1003,7 +1003,7 @@ Latency alert threshold in milliseconds
 | `LLM_PROVIDER` | string (openai, gemini, auto) | No | openai | PUBLIC |
 | `GEMINI_API_KEY` | secret | No | - | CRITICAL |
 | `DASHSCOPE_API_KEY` | secret | No | - | CRITICAL |
-| `DASHSCOPE_BASE_URL` | url | No | https://dashscope.aliyuncs.com/compatible-mode/v1 | PUBLIC |
+| `DASHSCOPE_BASE_URL` | url | No | https://dashscope-intl.aliyuncs.com/compatible-mode/v1 | PUBLIC |
 | `SILICONFLOW_API_KEY` | secret | No | - | CRITICAL |
 | `SILICONFLOW_BASE_URL` | url | No | https://api.siliconflow.cn/v1 | PUBLIC |
 | `SLACK_WEBHOOK_URL` | url | No | - | SECRET |
@@ -1099,14 +1099,14 @@ AliCloud DashScope API base URL (EPIC
 
 - **Type**: url
 - **Required**: No
-- **Default**: `https://dashscope.aliyuncs.com/compatible-mode/v1`
+- **Default**: `https://dashscope-intl.aliyuncs.com/compatible-mode/v1`
 - **Security Level**: PUBLIC
 
 **Notes**:
 > OpenAI-compatible endpoint for DashScope API.
 > IMPORTANT: DashScope has TWO different regional endpoints:
-> - China (default): https://dashscope.aliyuncs.com/compatible-mode/v1
-> - International: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+> - International (default): https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+> - China: https://dashscope.aliyuncs.com/compatible-mode/v1
 > Your API key is region-specific! A China API key will NOT work with the International endpoint, and vice versa. Set this URL to match your API key region.
 
 #### `SILICONFLOW_API_KEY`

--- a/handoff/20250928/40_App/api-backend/.env.example
+++ b/handoff/20250928/40_App/api-backend/.env.example
@@ -431,11 +431,11 @@ DASHSCOPE_API_KEY=your-secret-here
 # AliCloud DashScope API base URL (EPIC
 # OpenAI-compatible endpoint for DashScope API.
 # IMPORTANT: DashScope has TWO different regional endpoints:
-# - China (default): https://dashscope.aliyuncs.com/compatible-mode/v1
-# - International: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+# - International (default): https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+# - China: https://dashscope.aliyuncs.com/compatible-mode/v1
 # Your API key is region-specific! A China API key will NOT work with the International endpoint, and vice versa. Set this URL to match your API key region.
 # Required: False
-DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # SiliconFlow API key for Qwen models (EPIC
 # Required for SiliconFlow provider (Qwen models).

--- a/handoff/20250928/40_App/orchestrator/llm/providers/alicloud_provider.py
+++ b/handoff/20250928/40_App/orchestrator/llm/providers/alicloud_provider.py
@@ -11,12 +11,12 @@ Supports:
 
 Environment Variables:
 - DASHSCOPE_API_KEY: AliCloud DashScope API key
-- DASHSCOPE_BASE_URL: API endpoint (optional, defaults to China endpoint)
+- DASHSCOPE_BASE_URL: API endpoint (optional, defaults to International endpoint)
 
 IMPORTANT - Regional Endpoints:
 DashScope has TWO different endpoints with region-specific API keys:
-- China (default): https://dashscope.aliyuncs.com/compatible-mode/v1
-- International:   https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+- International (default): https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+- China:                   https://dashscope.aliyuncs.com/compatible-mode/v1
 
 Your API key is region-specific! A China API key will NOT work with the
 International endpoint, and vice versa. Set DASHSCOPE_BASE_URL to match

--- a/handoff/20250928/40_App/orchestrator/tests/test_qwen_providers.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_qwen_providers.py
@@ -18,7 +18,7 @@ from llm.providers.alicloud_provider import AliCloudProvider
 from llm.providers.siliconflow_provider import SiliconFlowProvider
 from common.config.settings import settings
 
-DASHSCOPE_BASE_URL = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+DASHSCOPE_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
 SILICONFLOW_BASE_URL = "https://api.siliconflow.cn/v1"
 
 

--- a/orchestrator/.env.example
+++ b/orchestrator/.env.example
@@ -265,11 +265,11 @@ DASHSCOPE_API_KEY=your-secret-here
 # AliCloud DashScope API base URL (EPIC
 # OpenAI-compatible endpoint for DashScope API.
 # IMPORTANT: DashScope has TWO different regional endpoints:
-# - China (default): https://dashscope.aliyuncs.com/compatible-mode/v1
-# - International: https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+# - International (default): https://dashscope-intl.aliyuncs.com/compatible-mode/v1
+# - China: https://dashscope.aliyuncs.com/compatible-mode/v1
 # Your API key is region-specific! A China API key will NOT work with the International endpoint, and vice versa. Set this URL to match your API key region.
 # Required: False
-DASHSCOPE_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1
+DASHSCOPE_BASE_URL=https://dashscope-intl.aliyuncs.com/compatible-mode/v1
 
 # SiliconFlow API key for Qwen models (EPIC
 # Required for SiliconFlow provider (Qwen models).


### PR DESCRIPTION
# feat(config): change DASHSCOPE_BASE_URL default to international endpoint

## Summary

Changes the default value of `DASHSCOPE_BASE_URL` from the China endpoint (`dashscope.aliyuncs.com`) to the International endpoint (`dashscope-intl.aliyuncs.com`).

This ensures that users with international DashScope API keys can use the Qwen provider out of the box without explicitly setting `DASHSCOPE_BASE_URL`.

**Files updated:**
- `common/config/settings.py` - actual default value
- `config/env.schema.yaml` - schema definition
- `docs/ENV_REFERENCE.md` - documentation (table + detailed section)
- `.env.example` files (3 locations)
- `alicloud_provider.py` - docstring
- `test_qwen_providers.py` - test expectations

## Review & Testing Checklist for Human

- [ ] **BREAKING CHANGE**: Verify that staging/production environments using China-region API keys have `DASHSCOPE_BASE_URL` explicitly set to `https://dashscope.aliyuncs.com/compatible-mode/v1`
- [ ] Confirm the international endpoint URL (`https://dashscope-intl.aliyuncs.com/compatible-mode/v1`) is correct per AliCloud documentation
- [ ] After deployment, trigger a review job to verify Qwen routing works with international API key

**Test Plan:**
1. Deploy to staging
2. Ensure `DASHSCOPE_API_KEY` is set with an international-region key
3. Remove or unset `DASHSCOPE_BASE_URL` (to use new default)
4. Trigger a PR review and verify logs show `Selected provider: alicloud`

### Notes

**Requested by:** Ryan Chen (@RC918)
**Devin session:** https://app.devin.ai/sessions/74e8054d73a14cbeb45f51b0bc43591d