### PR TITLE
test: add Qwen3 MoE flagship model to verify Reviewer Agent

### DIFF
--- a/handoff/20250928/40_App/orchestrator/llm/providers/alicloud_provider.py
+++ b/handoff/20250928/40_App/orchestrator/llm/providers/alicloud_provider.py
@@ -63,6 +63,7 @@ class AliCloudProvider(BaseLLMProvider):
         "qwen-plus-latest",
         "qwen-turbo",
         "qwen-turbo-latest",
+        "qwen3-235b-a22b",  # Qwen3 MoE flagship model
     ]
 
     def __init__(self, model: Optional[str] = None):


### PR DESCRIPTION
## Summary

Adds `qwen3-235b-a22b` (Qwen3 MoE flagship model) to the `SUPPORTED_MODELS` list in the AliCloud provider.

**Note:** This PR was created primarily to test that the Reviewer Agent webhook is functioning correctly after Render staging service recovery from a 502 outage.

## Review & Testing Checklist for Human

- [ ] Verify `qwen3-235b-a22b` is the correct model identifier from [DashScope documentation](https://help.aliyun.com/zh/model-studio/getting-started/models)
- [ ] Decide whether to merge this change or close the PR (it was created as a webhook test)

### Notes

- **Purpose:** Test PR to verify Reviewer Agent triggers on `pull_request.opened` webhook after Render recovery
- **Risk:** Low - single line addition to a static list
- **Requested by:** Ryan Chen (@RC918)
- **Link to Devin run:** https://app.devin.ai/sessions/74e8054d73a14cbeb45f51b0bc43591d