### PR TITLE
feat(epic-b): Phase 3 P2 follow-up - improve commit_id validation

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_publisher_node.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_publisher_node.py
@@ -850,3 +850,173 @@ class TestPublisherNodeIntegration:
 
                             assert result["publish_result"]["dry_run"] is True
                             assert "DRY-RUN" in result["messages"][-1].content
+
+
+class TestPostPrReviewCommitId:
+    """Tests for post_pr_review() commit_id parameter - EPIC B Phase 3 P2 follow-up"""
+
+    def test_commit_id_passed_to_create_review(self):
+        """When commit_id is provided, should pass commit object to create_review()"""
+        mock_settings = MockSettings(
+            enable_github_review_posting=True,
+            github_review_posting_dry_run=False,
+            github_review_posting_max_comments=10
+        )
+
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_commit = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+        mock_repo.get_commit.return_value = mock_commit
+
+        captured_kwargs = [None]
+
+        def capture_create_review(**kwargs):
+            captured_kwargs[0] = kwargs
+
+        mock_pr.create_review.side_effect = capture_create_review
+
+        with patch("common.config.settings.settings", mock_settings):
+            from tools.github_api import post_pr_review
+
+            result = post_pr_review(
+                repo=mock_repo,
+                pr_number=123,
+                comments=[{"file": "test.py", "end_line": 10, "message": "Test"}],
+                commit_id="abc123def456"
+            )
+
+            assert result["success"] is True
+            mock_repo.get_commit.assert_called_once_with("abc123def456")
+            assert captured_kwargs[0] is not None
+            assert captured_kwargs[0].get("commit") == mock_commit
+
+    def test_commit_id_none_does_not_call_get_commit(self):
+        """When commit_id is None, should not call get_commit()"""
+        mock_settings = MockSettings(
+            enable_github_review_posting=True,
+            github_review_posting_dry_run=False,
+            github_review_posting_max_comments=10
+        )
+
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+
+        with patch("common.config.settings.settings", mock_settings):
+            from tools.github_api import post_pr_review
+
+            result = post_pr_review(
+                repo=mock_repo,
+                pr_number=123,
+                comments=[{"file": "test.py", "end_line": 10, "message": "Test"}],
+                commit_id=None
+            )
+
+            assert result["success"] is True
+            mock_repo.get_commit.assert_not_called()
+
+    def test_commit_id_get_commit_fails_proceeds_without_commit(self):
+        """When get_commit() fails, should proceed without commit (fail-open)"""
+        mock_settings = MockSettings(
+            enable_github_review_posting=True,
+            github_review_posting_dry_run=False,
+            github_review_posting_max_comments=10
+        )
+
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+        mock_repo.get_commit.side_effect = GithubException(
+            404, {"message": "Commit not found"}, None
+        )
+
+        captured_kwargs = [None]
+
+        def capture_create_review(**kwargs):
+            captured_kwargs[0] = kwargs
+
+        mock_pr.create_review.side_effect = capture_create_review
+
+        with patch("common.config.settings.settings", mock_settings):
+            from tools.github_api import post_pr_review
+
+            result = post_pr_review(
+                repo=mock_repo,
+                pr_number=123,
+                comments=[{"file": "test.py", "end_line": 10, "message": "Test"}],
+                commit_id="invalid_sha"
+            )
+
+            assert result["success"] is True
+            assert captured_kwargs[0] is not None
+            assert "commit" not in captured_kwargs[0]
+
+    def test_commit_id_unknown_object_exception_proceeds_without_commit(self):
+        """When get_commit() raises UnknownObjectException, should proceed without commit"""
+        mock_settings = MockSettings(
+            enable_github_review_posting=True,
+            github_review_posting_dry_run=False,
+            github_review_posting_max_comments=10
+        )
+
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+        mock_repo.get_commit.side_effect = UnknownObjectException(
+            404, {"message": "Not Found"}, None
+        )
+
+        captured_kwargs = [None]
+
+        def capture_create_review(**kwargs):
+            captured_kwargs[0] = kwargs
+
+        mock_pr.create_review.side_effect = capture_create_review
+
+        with patch("common.config.settings.settings", mock_settings):
+            from tools.github_api import post_pr_review
+
+            result = post_pr_review(
+                repo=mock_repo,
+                pr_number=123,
+                comments=[{"file": "test.py", "end_line": 10, "message": "Test"}],
+                commit_id="nonexistent_sha"
+            )
+
+            assert result["success"] is True
+            assert captured_kwargs[0] is not None
+            assert "commit" not in captured_kwargs[0]
+
+    def test_commit_id_logged_in_result(self):
+        """commit_id should be logged in the result extra fields"""
+        mock_settings = MockSettings(
+            enable_github_review_posting=True,
+            github_review_posting_dry_run=False,
+            github_review_posting_max_comments=10
+        )
+
+        mock_repo = MagicMock()
+        mock_pr = MagicMock()
+        mock_commit = MagicMock()
+        mock_repo.get_pull.return_value = mock_pr
+        mock_repo.get_commit.return_value = mock_commit
+
+        with patch("common.config.settings.settings", mock_settings):
+            with patch("tools.github_api.logger") as mock_logger:
+                from tools.github_api import post_pr_review
+
+                result = post_pr_review(
+                    repo=mock_repo,
+                    pr_number=123,
+                    comments=[{"file": "test.py", "end_line": 10, "message": "Test"}],
+                    commit_id="abc123def456"
+                )
+
+                assert result["success"] is True
+                # Verify commit_id was logged
+                info_calls = [call for call in mock_logger.info.call_args_list]
+                commit_logged = any(
+                    "commit_id" in str(call) for call in info_calls
+                )
+                assert commit_logged

--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -779,18 +779,24 @@ def post_pr_review(
         # This prevents 422 errors from race conditions where new commits
         # are pushed between diff generation and review posting
         commit_obj = None
+        commit_pinning_attempted = False
+        commit_pinning_success = False
         if commit_id:
+            commit_pinning_attempted = True
             try:
                 commit_obj = repo.get_commit(commit_id)
+                commit_pinning_success = True
                 logger.info(
                     f"[GitHub] Using commit_id for review: {commit_id[:8]}",
                     extra={
                         "operation": "post_pr_review",
                         "pr_number": pr_number,
-                        "commit_id": commit_id[:8]
+                        "commit_id": commit_id[:8],
+                        "commit_pinning_attempted": True,
+                        "commit_pinning_success": True
                     }
                 )
-            except Exception as commit_error:
+            except (GithubException, UnknownObjectException) as commit_error:
                 logger.warning(
                     f"[GitHub] Failed to get commit {commit_id[:8]}, "
                     f"proceeding without commit_id: {commit_error}",
@@ -798,6 +804,8 @@ def post_pr_review(
                         "operation": "post_pr_review",
                         "pr_number": pr_number,
                         "commit_id": commit_id[:8],
+                        "commit_pinning_attempted": True,
+                        "commit_pinning_success": False,
                         "error": str(commit_error)
                     }
                 )
@@ -818,6 +826,8 @@ def post_pr_review(
 
         result["success"] = True
         result["posted_count"] = len(gh_comments)
+        result["commit_pinning_attempted"] = commit_pinning_attempted
+        result["commit_pinning_success"] = commit_pinning_success
 
         logger.info(
             f"[GitHub] Posted review to PR #{pr_number} with {len(gh_comments)} comments",
@@ -827,7 +837,9 @@ def post_pr_review(
                 "comment_count": len(gh_comments),
                 "skipped_count": result["skipped_count"],
                 "truncated_count": result["truncated_count"],
-                "commit_id": commit_id[:8] if commit_id else None
+                "commit_id": commit_id[:8] if commit_id else None,
+                "commit_pinning_attempted": commit_pinning_attempted,
+                "commit_pinning_success": commit_pinning_success
             }
         )
 


### PR DESCRIPTION
# feat(epic-b): Phase 3 P2 follow-up - improve commit_id validation

## Summary

Follow-up improvements to PR #2829 (commit_id validation feature) that was just merged. This PR addresses three suggested improvements:

1. **Specific exception handling**: Changed `except Exception` to `except (GithubException, UnknownObjectException)` to avoid catching programming errors and only handle GitHub-specific failures

2. **Metrics tracking**: Added `commit_pinning_attempted` and `commit_pinning_success` fields to:
   - Logger extra fields (for observability)
   - Result dict (for programmatic access)

3. **Unit tests**: Added 5 test cases covering:
   - commit_id passed correctly to create_review()
   - commit_id=None skips get_commit() call
   - GithubException triggers fail-open behavior
   - UnknownObjectException triggers fail-open behavior
   - commit_id logged in result

## Review & Testing Checklist for Human

- [ ] Verify that `GithubException` and `UnknownObjectException` are the correct exception types for `repo.get_commit()` failures (check PyGithub docs if needed)
- [ ] Confirm the new result dict fields (`commit_pinning_attempted`, `commit_pinning_success`) don't break any downstream consumers
- [ ] Run the new unit tests: `pytest handoff/20250928/40_App/orchestrator/tests/test_publisher_node.py::TestPostPrReviewCommitId -v`

**Recommended test plan**: After merging, monitor staging logs for `commit_pinning_attempted` and `commit_pinning_success` fields to verify metrics are being recorded correctly.

### Notes

- This is a low-risk follow-up to PR #2829
- The fail-open pattern is preserved - if commit resolution fails, review posting proceeds without commit pinning
- Link to Devin run: https://app.devin.ai/sessions/74e8054d73a14cbeb45f51b0bc43591d
- Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918