### PR TITLE
feat(observability): add commit_pinning metrics to log message for Render searchability

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -788,7 +788,8 @@ def post_pr_review(
                 commit_pinning_success = True
                 logger.info(
                     f"[GitHub] Using commit_id for review: {commit_id[:8]} "
-                    f"(commit_pinning_attempted=True, commit_pinning_success=True)",
+                    f"(commit_pinning_attempted={commit_pinning_attempted}, "
+                    f"commit_pinning_success={commit_pinning_success})",
                     extra={
                         "operation": "post_pr_review",
                         "pr_number": pr_number,
@@ -801,7 +802,8 @@ def post_pr_review(
                 logger.warning(
                     f"[GitHub] Failed to get commit {commit_id[:8]}, "
                     f"proceeding without commit_id: {commit_error} "
-                    f"(commit_pinning_attempted=True, commit_pinning_success=False)",
+                    f"(commit_pinning_attempted={commit_pinning_attempted}, "
+                    f"commit_pinning_success={commit_pinning_success})",
                     extra={
                         "operation": "post_pr_review",
                         "pr_number": pr_number,


### PR DESCRIPTION
# feat(observability): add commit_pinning metrics to log message for Render searchability

## Summary
Adds `commit_pinning_attempted` and `commit_pinning_success` metrics directly to log message strings in `post_pr_review()`. Previously these metrics were only in the `extra` dict, which Render's log viewer doesn't index for full-text search. Now they appear in the message itself, making them searchable.

Three log statements updated:
- Success case: `"[GitHub] Using commit_id for review: {sha} (commit_pinning_attempted={var}, commit_pinning_success={var})"`
- Failure case: `"[GitHub] Failed to get commit {sha}, proceeding without commit_id: {error} (commit_pinning_attempted={var}, commit_pinning_success={var})"`
- Posted review: `"[GitHub] Posted review to PR #{pr} with {n} comments (commit_pinning_attempted={var}, commit_pinning_success={var})"`

## Updates since last revision
- Replaced hardcoded `True`/`False` values with variable references (`{commit_pinning_attempted}`, `{commit_pinning_success}`) for consistency across all log statements

## Review & Testing Checklist for Human
- [ ] Verify log message format is readable and consistent across all three cases
- [ ] After deploying to staging, search for `commit_pinning_attempted` in Render logs to confirm searchability

### Notes
Follow-up to PR #2830 (commit_id validation). During staging testing, we discovered that Render's logger formatter doesn't serialize the `extra` dict to output, so searching for `commit_pinning_attempted` returned no results even though the metrics were being recorded.

Link to Devin run: https://app.devin.ai/sessions/74e8054d73a14cbeb45f51b0bc43591d
Requested by: Ryan Chen (@RC918)