### PR TITLE
fix(agent-eval): skip ci_pass_rate check for review-only workflows

### DIFF
--- a/handoff/20250928/40_App/orchestrator/agent_eval_integration.py
+++ b/handoff/20250928/40_App/orchestrator/agent_eval_integration.py
@@ -711,7 +711,10 @@ class AgentEvalIntegration:
                     "Check if there are new task types causing issues."
                 )
 
-            if ci_pass_rate < ci_pass_rate_threshold:
+            # Only check ci_pass_rate if there are PRs to evaluate.
+            # Review-only workflows (pr_created_count == 0) should not trigger
+            # ci_pass_rate regression warnings as they don't create PRs by design.
+            if pr_created_count > 0 and ci_pass_rate < ci_pass_rate_threshold:
                 regressions.append({
                     "type": "ci_pass_rate",
                     "current": ci_pass_rate,
@@ -760,14 +763,19 @@ class AgentEvalIntegration:
             }
 
             if has_regression:
+                regression_types = [r["type"] for r in regressions]
                 logger.warning(
-                    "[AgentEval] Capability regression detected",
+                    f"[AgentEval] Capability regression detected "
+                    f"(types={regression_types}, success_rate={success_rate:.1f}%, "
+                    f"ci_pass_rate={ci_pass_rate:.1f}%, pr_count={pr_created_count})",
                     extra={
                         "operation": "detect_regression",
                         "regressions": len(regressions),
+                        "regression_types": regression_types,
                         "has_critical": has_critical,
                         "success_rate": success_rate,
-                        "ci_pass_rate": ci_pass_rate
+                        "ci_pass_rate": ci_pass_rate,
+                        "pr_created_count": pr_created_count
                     }
                 )
             else:


### PR DESCRIPTION
# fix(agent-eval): skip ci_pass_rate check for review-only workflows

## Summary

Fixes false positive "Capability regression detected" warnings for review-only workflows like MorningAI Reviewer Agent.

**Root cause:** When `pr_created_count == 0`, `ci_pass_rate` is calculated as `0.0%`, which triggers the `< 80%` threshold check. Review-only workflows don't create PRs by design, so this check is not applicable.

**Changes:**
1. Skip `ci_pass_rate` regression check when `pr_created_count == 0`
2. Improve warning log message to include regression types and PR count in the message string (for Render log searchability)

## Review & Testing Checklist for Human

- [ ] **Verify design intent**: Confirm that review-only workflows should skip `ci_pass_rate` checks entirely. Consider if a separate `pr_creation_rate` metric should be added to detect "workflows that should create PRs but aren't"
- [ ] **Test in staging**: Trigger a `/gemini review` and verify the "Capability regression detected" warning no longer appears in Render logs
- [ ] **Log parsing**: Confirm no downstream systems depend on the exact format of the old warning message `"[AgentEval] Capability regression detected"`

### Notes

- The existing code comment (line 694-696) states `ci_pass_rate = 0.0` is intentional "to avoid masking regression when agent stops creating PRs" - this fix bypasses that detection for review-only workflows
- If you want to detect "PR-creating workflows that stopped creating PRs", consider adding a separate `pr_creation_rate` threshold in a follow-up PR

---
Link to Devin run: https://app.devin.ai/sessions/bcf7378aec2f4498944226ac6907cdc8
Requested by: Ryan Chen (@RC918)