### PR TITLE
refactor: use variables instead of hardcoded values in extra dict for commit_pinning metrics

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -794,8 +794,8 @@ def post_pr_review(
                         "operation": "post_pr_review",
                         "pr_number": pr_number,
                         "commit_id": commit_id[:8],
-                        "commit_pinning_attempted": True,
-                        "commit_pinning_success": True
+                        "commit_pinning_attempted": commit_pinning_attempted,
+                        "commit_pinning_success": commit_pinning_success
                     }
                 )
             except (GithubException, UnknownObjectException) as commit_error:
@@ -808,8 +808,8 @@ def post_pr_review(
                         "operation": "post_pr_review",
                         "pr_number": pr_number,
                         "commit_id": commit_id[:8],
-                        "commit_pinning_attempted": True,
-                        "commit_pinning_success": False,
+                        "commit_pinning_attempted": commit_pinning_attempted,
+                        "commit_pinning_success": commit_pinning_success,
                         "error": str(commit_error)
                     }
                 )


### PR DESCRIPTION
## Summary
Replaces hardcoded `True`/`False` values with variable references (`commit_pinning_attempted`, `commit_pinning_success`) in the `extra` dict of two log statements in `post_pr_review()`.

This is a follow-up to PR #2831 which added commit_pinning metrics to log message strings. The log message text already uses variables, but the `extra` dict was still using hardcoded values. This change ensures consistency between the message text and structured logging fields.

**Changes:**
- Success case log (line 797-798): `True, True` → `commit_pinning_attempted, commit_pinning_success`
- Failure case log (line 811-812): `True, False` → `commit_pinning_attempted, commit_pinning_success`

## Review & Testing Checklist for Human
- [ ] Verify that `commit_pinning_attempted` and `commit_pinning_success` are properly initialized before these log statements execute (they are: lines 782-783 initialize to `False`, line 785 sets `attempted=True`, line 788 sets `success=True` on success)
- [ ] Confirm the third log statement (line 847-848) already uses variables (it does)

### Notes
This is a low-risk refactoring change. The `extra` dict is not indexed by Render for full-text search, so this change is purely for code consistency and maintainability.

Link to Devin run: https://app.devin.ai/sessions/74e8054d73a14cbeb45f51b0bc43591d
Requested by: Ryan Chen (@RC918)