### PR TITLE
docs: improve docstring clarity based on MorningAI Code Review feedback

### DIFF
--- a/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
+++ b/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
@@ -702,7 +702,7 @@ Remember: You cannot see the actual code changes, so focus on risk assessment ba
         """
         Parse JSON with retry and repair logic.
 
-        Three-stage repair: direct parse -> regex cleaning -> LLM repair (if enabled).
+        Three-stage repair: direct parse -> string cleaning -> LLM repair (if enabled).
 
         Args:
             content: Raw LLM response
@@ -770,7 +770,7 @@ Remember: You cannot see the actual code changes, so focus on risk assessment ba
                     {"role": "user", "content": _REPAIR_JSON_PROMPT + truncated_input}
                 ],
                 temperature=0.0,  # Deterministic for repair
-                max_tokens=1000   # Output token budget (separate from input char truncation)
+                max_tokens=1000   # Output token budget
             )
             repair_time_ms = (time.time() - start_time) * 1000
 


### PR DESCRIPTION
## Summary

Documentation-only improvements to `llm_reviewer_adapter.py` based on MorningAI Code Review feedback from PR #2836:

1. **Removed redundant EPIC B reference** from `_parse_json_with_retry()` docstring - replaced with a clearer description of the three-stage repair flow (direct parse → string cleaning → LLM repair)

2. **Simplified max_tokens comment** - now reads "Output token budget" for clarity

## Updates since last revision

Applied additional feedback:
- **Gemini**: Changed "regex cleaning" → "string cleaning" for technical accuracy (the `_clean_json_response()` method uses string operations, not regex)
- **Reviewer Agent**: Simplified max_tokens comment to be more concise

## Review & Testing Checklist for Human

- [ ] Verify the docstring accurately describes the three-stage repair flow terminology

No testing required - these are pure documentation/comment changes with no behavioral impact.

### Notes

This is a follow-up to PR #2836 (EPIC B Phase 3 P2/P3) which has already been merged.

Requested by: Ryan Chen (@RC918)
Link to Devin run: https://app.devin.ai/sessions/74e8054d73a14cbeb45f51b0bc43591d