### PR TITLE
test(epic-b): add integration tests for review webhook no-duplicate flow

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_review_webhook_no_duplicate_integration.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_review_webhook_no_duplicate_integration.py
@@ -266,9 +266,9 @@ class TestMarkerEmbeddingAndDetection:
             "morningai:autogen-review",
         ]
 
-        for partial_marker in partial_markers:
+        for i, partial_marker in enumerate(partial_markers):
             event = WebhookEvent(
-                event_id=f"test-partial-{hash(partial_marker)}",
+                event_id=f"test-partial-{i}",
                 source=WebhookSource.GITHUB,
                 event_type=WebhookEventType.PR_REVIEWED,
                 timestamp=datetime.now(timezone.utc),
@@ -517,5 +517,4 @@ Content with [SANITIZED] prompt injection removed.
         assert is_self_generated_review(event) is True
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
+if __name__ == "__main__": pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Adds 15 integration tests for the EPIC B Phase 3 requirement: "send review → receive webhook → verify no duplicate". These tests verify the self-trigger loop prevention mechanism that prevents the orchestrator from re-processing its own reviews.

**Test coverage includes:**
- Complete flow: orchestrator review → webhook → no duplicate triggered
- Marker embedding and detection (in description and raw_payload)
- External review handling (should be processed, not blocked)
- Partial/modified marker rejection (no false positives)
- Rapid webhook events handling
- Mixed orchestrator/external reviews on same PR
- Event type filtering (only PR_REVIEWED checked for marker)
- Integration with LLM JSON repair (marker preserved after repair/sanitization)

All 15 tests pass locally. This is a test-only PR with no production code changes.

## Review & Testing Checklist for Human

- [ ] Verify test payloads match real GitHub `pull_request_review` webhook structure
- [ ] Confirm `is_self_generated_review()` function exists and works as expected in production
- [ ] Check if any edge cases are missing (e.g., empty review body, malformed payloads)

**Recommended test plan:**
1. Run `pytest tests/test_review_webhook_no_duplicate_integration.py -v` locally
2. Optionally trigger a real PR review on staging and verify no duplicate review is created

### Notes

This PR completes the "Integration Test" requirement for EPIC B Phase 3. The tests simulate webhook payloads rather than triggering actual GitHub webhooks, so they verify the detection logic but not the full network flow.

---
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918
**Link to Devin run**: https://app.devin.ai/sessions/5119ab5a69484a408bf72d49d727ca05