### PR TITLE
feat(governance): Phase 0 - Reviewer Stability Dashboard

### DIFF
--- a/.github/workflows/reviewer-scorecard.yml
+++ b/.github/workflows/reviewer-scorecard.yml
@@ -16,6 +16,10 @@ permissions:
   issues: write
   pull-requests: read
 
+concurrency:
+  group: scorecard-${{ github.repository }}
+  cancel-in-progress: false
+
 env:
   TRACKING_ISSUE: 2859
   ANALYSIS_DAYS: 7
@@ -64,28 +68,25 @@ jobs:
         run: |
           set -eo pipefail
           
-          # Run scorecard and capture output
+          # Run scorecard with explicit file outputs (avoids fragile sed parsing)
           python tools/reviewer_stability_scorecard.py \
             --days ${{ env.ANALYSIS_DAYS }} \
             --output both \
             --repo ${{ github.repository }} \
-            > scorecard_output.txt 2>&1 || true
+            --json-out scorecard.json \
+            --md-out scorecard.md \
+            || true
           
-          # Extract JSON output
-          sed -n '/^{/,/^}/p' scorecard_output.txt > scorecard.json || true
-          
-          # Extract status from output
-          if grep -q '"status":' scorecard.json 2>/dev/null; then
+          # Extract status from JSON file
+          if [ -f scorecard.json ] && grep -q '"status":' scorecard.json 2>/dev/null; then
             CURRENT_STATUS=$(python -c "import json; print(json.load(open('scorecard.json'))['status'])")
           else
             CURRENT_STATUS="ERROR"
+            echo "::warning::Scorecard execution failed or produced invalid output"
           fi
           
           echo "status=$CURRENT_STATUS" >> $GITHUB_OUTPUT
           echo "Current status: $CURRENT_STATUS"
-          
-          # Extract markdown section
-          sed -n '/^# MorningAI/,$ p' scorecard_output.txt > scorecard.md || true
 
       - name: Save current status
         run: echo "${{ steps.scorecard.outputs.status }}" > .scorecard-status

--- a/docs/governance/reviewer-stability.md
+++ b/docs/governance/reviewer-stability.md
@@ -42,6 +42,8 @@ Where:
 - `slow_review_penalty`: +10 points if average latency > 5 minutes
 - `coverage_percent`: Reward for higher coverage (subtracted from score)
 
+Note: The score is clamped at 0 (negative values become 0). High coverage alone cannot produce a negative score.
+
 ## Monitoring Schedule
 
 - **Frequency**: Daily at 00:00 UTC
@@ -79,7 +81,25 @@ Before progressing to EPIC C (Flow Controller), the following criteria must be m
 - [Scorecard Tool](../../tools/reviewer_stability_scorecard.py)
 - [Tool Documentation](../../tools/README.md)
 - [Tracking Issue](https://github.com/RC918/morningai/issues/2859)
-- [Workflow](.github/workflows/reviewer-scorecard.yml)
+- [Workflow](../../.github/workflows/reviewer-scorecard.yml)
+
+## FAQ
+
+**Q: What does "UNKNOWN" status mean on the first run?**
+
+A: On the first workflow execution, there is no previous status to compare against. The system shows "UNKNOWN" as the previous status and establishes the current status as the baseline. No notification is sent on the first run since there is no regression to detect.
+
+**Q: How do I manually trigger the scorecard?**
+
+A: Go to Actions → "Reviewer Stability Scorecard" → "Run workflow". You can optionally enable "Force notification" to receive a @mention regardless of regression status.
+
+**Q: Where are the JSON artifacts stored?**
+
+A: JSON reports are stored as GitHub Actions artifacts with 90-day retention. Navigate to the workflow run and download the `scorecard-{run_id}` artifact. These are NOT committed to the repository.
+
+**Q: Why didn't I receive a notification?**
+
+A: Notifications are only sent on regression (status downgrade) or execution failure. If the status improved or stayed the same, no notification is sent. Use `force_notify` to test the notification mechanism.
 
 ## Changelog
 

--- a/tools/reviewer_stability_scorecard.py
+++ b/tools/reviewer_stability_scorecard.py
@@ -505,6 +505,18 @@ def main():
         default=None,
         help=f"Repository in owner/repo format (default: {DEFAULT_REPO})",
     )
+    parser.add_argument(
+        "--json-out",
+        type=str,
+        default=None,
+        help="Write JSON output to file (optional, for CI workflows)",
+    )
+    parser.add_argument(
+        "--md-out",
+        type=str,
+        default=None,
+        help="Write Markdown output to file (optional, for CI workflows)",
+    )
     args = parser.parse_args()
 
     token = os.environ.get("GITHUB_TOKEN")
@@ -528,17 +540,30 @@ def main():
     # Also remove raw latency list
     output_metrics.pop("review_latencies_seconds", None)
 
+    json_content = json.dumps(output_metrics, indent=2)
+    md_content = format_markdown(output_metrics)
+
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            f.write(json_content)
+        print(f"JSON output written to: {args.json_out}")
+
+    if args.md_out:
+        with open(args.md_out, "w") as f:
+            f.write(md_content)
+        print(f"Markdown output written to: {args.md_out}")
+
     if args.output in ("json", "both"):
         print("\n" + "=" * 60)
         print("JSON Output:")
         print("=" * 60)
-        print(json.dumps(output_metrics, indent=2))
+        print(json_content)
 
     if args.output in ("markdown", "both"):
         print("\n" + "=" * 60)
         print("Markdown Output:")
         print("=" * 60)
-        print(format_markdown(output_metrics))
+        print(md_content)
 
     # Exit with non-zero if status is bad
     if metrics["status"] == "NEEDS ATTENTION":


### PR DESCRIPTION
# feat(governance): Phase 0 - Reviewer Stability Dashboard

## Summary

Implements Phase 0 of the reviewer stability monitoring plan for EPIC B governance. This adds automated daily scorecard execution with GitHub Issue comment reporting and regression-only notifications.

**Key components:**

1. **GitHub Actions workflow** (`reviewer-scorecard.yml`): Runs daily at 00:00 UTC, executes the scorecard tool with a 7-day analysis window, posts Markdown reports to tracking issue #2859, and stores JSON as artifacts (not committed to repo).

2. **Regression detection**: Uses GitHub Actions cache with `restore-keys` pattern to track previous status. Only notifies via @mention when status degrades (e.g., GOOD → FAIR) or on execution failure.

3. **Governance documentation** (`docs/governance/reviewer-stability.md`): Defines KPIs, health status thresholds, notification policy, and EPIC C progression criteria.

**Tracking Issue:** https://github.com/RC918/morningai/issues/2859

## Updates since last revision

- **Robust file outputs**: Added `--json-out` and `--md-out` CLI arguments to scorecard tool, replacing fragile `sed` parsing in workflow
- **Concurrency control**: Added `concurrency` group to prevent parallel workflow runs
- **Documentation improvements**: Added FAQ section (UNKNOWN baseline, manual trigger, artifacts), fixed relative link to workflow, clarified score clamping at 0
- **Follow-up issues created**:
  - #2861: Unit tests for regression detection logic
  - #2862: Use repo variable for tracking issue ID
  - #2863: Improve status persistence durability

## Review & Testing Checklist for Human

- [ ] **Manually trigger the workflow** via Actions UI (`workflow_dispatch`) and verify it completes successfully - this is the most important test since the workflow hasn't been run yet
- [ ] **Verify file outputs work**: Check that `scorecard.json` and `scorecard.md` are created correctly (the new `--json-out`/`--md-out` flags replace the old sed parsing)
- [ ] **Confirm tracking issue #2859 exists** and receives the comment

**Recommended test plan:**
1. Merge PR
2. Go to Actions → "Reviewer Stability Scorecard" → "Run workflow"
3. Verify workflow completes and posts a comment to issue #2859
4. Run again to verify regression detection works (should show "No regression detected")

### Notes

- JSON reports are stored as artifacts (90-day retention), not committed to repo per user request
- First run will show "UNKNOWN" previous status and won't trigger notification (establishing baseline)
- The `force_notify` input allows manual notification override for testing
- All 31 existing scorecard tests pass

**Requested by:** Ryan Chen (@RC918)
**Devin run:** https://app.devin.ai/sessions/d8d3848f706f435b8bc1d12f46adecd2