### PR TITLE
feat(scorecard): add check_regression helper with comprehensive tests

### DIFF
--- a/tools/reviewer_stability_scorecard.py
+++ b/tools/reviewer_stability_scorecard.py
@@ -72,7 +72,7 @@ STATUS_SEVERITY = {
 
 def check_regression(
     prev_status: str, curr_status: str, force_notify: bool = False
-) -> tuple:
+) -> tuple[bool, str]:
     """
     Determine if a status change represents a regression requiring notification.
 
@@ -82,7 +82,9 @@ def check_regression(
         force_notify: If True, always notify regardless of regression
 
     Returns:
-        Tuple of (should_notify: bool, reason: str)
+        tuple[bool, str]: A tuple containing:
+            - should_notify (bool): True if notification should be sent
+            - reason (str): Human-readable explanation of the decision
 
     Examples:
         >>> check_regression("GOOD", "FAIR", False)

--- a/tools/tests/test_reviewer_stability_scorecard.py
+++ b/tools/tests/test_reviewer_stability_scorecard.py
@@ -516,8 +516,8 @@ class TestCheckRegression:
         assert reason == "No regression detected (NEEDS ATTENTION -> NEEDS ATTENTION)"
 
     # --- Unknown status handling ---
-    def test_unknown_current_status_treated_as_worst(self):
-        """Unknown current status should be treated as worst severity."""
+    def test_invalid_current_status_triggers_regression(self):
+        """Invalid/unknown current status triggers regression notification."""
         notify, reason = check_regression("GOOD", "INVALID_STATUS", force_notify=False)
         assert notify is True
         assert "regressed" in reason


### PR DESCRIPTION
# feat(scorecard): add check_regression helper with comprehensive tests

## Summary

Closes #2861

Extracts the regression detection logic from the workflow shell script into a testable Python function. This enables systematic testing of all status transition scenarios without needing to run the full GitHub Actions workflow.

**Changes:**
- Add `STATUS_SEVERITY` constant mapping status to severity level (lower = better)
- Add `check_regression(prev_status, curr_status, force_notify)` function
- Add 26 unit tests covering all status transitions

**Note:** The workflow still uses the shell script implementation. This PR adds the testable Python equivalent for future integration.

## Review & Testing Checklist for Human

- [ ] Verify the Python logic matches the shell script in `.github/workflows/reviewer-scorecard.yml` lines 107-146 (the `get_severity` function and comparison logic)
- [ ] Confirm severity ordering is correct: EXCELLENT(0) < GOOD(1) < FAIR(2) < NEEDS ATTENTION(3) < ERROR(4)
- [ ] Note: Unknown statuses default to severity 5 (worst) - this means typos in status names will trigger notifications

**Test plan:**
```bash
cd ~/repos/morningai && source .venv/bin/activate
cd tools && python -m pytest tests/test_reviewer_stability_scorecard.py::TestCheckRegression -v
```

### Notes

All 57 tests pass (31 existing + 26 new).

**Requested by:** Ryan Chen (@RC918)
**Devin run:** https://app.devin.ai/sessions/d8d3848f706f435b8bc1d12f46adecd2