### PR TITLE
refactor(observability): convert print() to logger for searchable Render logs

### DIFF
--- a/handoff/20250928/40_App/orchestrator/graph.py
+++ b/handoff/20250928/40_App/orchestrator/graph.py
@@ -421,6 +421,8 @@ def execute(goal:str, repo_full: str, trace_id: Optional[str] = None):
     
     if quality_issues:
         issue_summary = ", ".join([f"{i.code}:{i.level.value}" for i in quality_issues[:5]])
+        if len(quality_issues) > 5:
+            issue_summary += f" ...(+{len(quality_issues) - 5} more)"
         logger.info(
             f"[GraphExecute] Quality issues found trace_id={trace_id} count={len(quality_issues)} issues=[{issue_summary}]",
             extra={"operation": "quality_issues", "trace_id": trace_id, "issue_count": len(quality_issues)}


### PR DESCRIPTION
# refactor(observability): convert print() to logger for searchable Render logs

## Summary

Fixes the issue where ValueGate and PRDedup logs were not appearing in Render's log search. The root cause was that `print()` statements and `extra={"operation": "..."}` fields are not indexed by Render's search - only the message field is searchable.

**Changes:**
- Added `[GraphExecute]` entry point log with trace_id and repo for tracking execution flow
- Converted all governance-related `print()` statements to `logger.info()` or `logger.warning()` calls
- Placed key information (trace_id, scores, types, similarity, etc.) in the message field for searchability
- **Most important**: ValueGate and PRDedup now log their evaluation results with `logger.info()` before any blocking decisions

**No functional changes** - this is purely observability. The actual governance logic (blocking/allowing PRs) is completely unchanged.

### Updates since last revision
- Added truncation indicator for quality issues log: shows `...(+N more)` when there are more than 5 issues to prevent log bloat

## Review & Testing Checklist for Human

- [ ] **Deploy to staging and verify logs are searchable**: Search for `[ValueGate]`, `[PRDedup]`, `[GraphExecute]` in Render staging worker logs
- [ ] **Trigger an orchestrator task and confirm logs appear**: Should see evaluation logs even if PR is not blocked
- [ ] **Verify governance behavior unchanged**: ValueGate should still block low-value PRs, PRDedup should still detect duplicates

### Test Plan
1. Deploy this PR to staging
2. Trigger an E2E test via `agent-mvp-e2e` workflow
3. Search Render staging worker logs for:
   - `[GraphExecute] Starting execution` - should appear at start of every task
   - `[ValueGate] Evaluated` - should show score, type, and decision
   - `[PRDedup] Checked` - should show duplicate detection result
4. Verify the logs contain the trace_id and are searchable

### Notes
- This PR does not fix pre-existing lint issues (whitespace, import order) to keep the diff focused
- Log prefix convention: `[GraphExecute]` for general flow, `[ValueGate]` and `[PRDedup]` for governance-specific logs (these are the search terms users will use)
- All logs include `trace_id` in both the message and extra fields for correlation

---

[Link to Devin run](https://app.devin.ai/sessions/f3733955ec6d4f35b4b2021e59e4afe1)  
Requested by: Ryan Chen (@RC918)