### PR TITLE
fix(ci): fix YAML syntax error in backend.yml heredoc

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -166,25 +166,25 @@ jobs:
         run: |
           cd handoff/20250928/40_App/api-backend
           echo "=== DEBUG: orchestrator import resolution ==="
-          python <<'PYEOF'
-import sys
-import importlib.util
-import os
-print('PYTHONPATH env:', os.environ.get('PYTHONPATH', 'NOT SET'))
-print('sys.path[:10]:', sys.path[:10])
-spec = importlib.util.find_spec('orchestrator')
-print('orchestrator spec:', spec)
-if spec:
-    print('orchestrator origin:', spec.origin)
-    print('orchestrator submodule_search_locations:', spec.submodule_search_locations)
-import orchestrator
-print('orchestrator.__file__:', orchestrator.__file__)
-print('orchestrator has __path__:', hasattr(orchestrator, '__path__'))
-if hasattr(orchestrator, '__path__'):
-    print('orchestrator.__path__:', list(orchestrator.__path__))
-webhooks_spec = importlib.util.find_spec('orchestrator.webhooks')
-print('orchestrator.webhooks spec:', webhooks_spec)
-PYEOF
+          python -c "
+          import sys
+          import importlib.util
+          import os
+          print('PYTHONPATH env:', os.environ.get('PYTHONPATH', 'NOT SET'))
+          print('sys.path[:10]:', sys.path[:10])
+          spec = importlib.util.find_spec('orchestrator')
+          print('orchestrator spec:', spec)
+          if spec:
+              print('orchestrator origin:', spec.origin)
+              print('orchestrator submodule_search_locations:', spec.submodule_search_locations)
+          import orchestrator
+          print('orchestrator.__file__:', orchestrator.__file__)
+          print('orchestrator has __path__:', hasattr(orchestrator, '__path__'))
+          if hasattr(orchestrator, '__path__'):
+              print('orchestrator.__path__:', list(orchestrator.__path__))
+          webhooks_spec = importlib.util.find_spec('orchestrator.webhooks')
+          print('orchestrator.webhooks spec:', webhooks_spec)
+          "
           echo "=== END DEBUG ==="
           python -m pytest --rootdir=. --cov=src --cov-report=term-missing --cov-report=xml --cov-report=json --cov-fail-under=80 -v
           echo "### Coverage Summary" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Fixes the GitHub Actions workflow failure caused by YAML parser incorrectly interpreting the Python heredoc syntax (`python <<'PYEOF'`). The heredoc was causing "Invalid workflow file" error on line 170.

**Fix**: Replace heredoc with `python -c "..."` inline string which is properly handled by YAML parsers.

The Python debug code itself is unchanged - only the invocation method changed.

## Review & Testing Checklist for Human

- [ ] Verify CI workflow runs successfully after merge (the YAML parses, but the `python -c` execution should be tested in actual CI)
- [ ] Check that the debug output for orchestrator import resolution is still produced correctly in CI logs
- [ ] Confirm pytest tests still execute after the debug step

### Test Plan
1. Merge this PR
2. Check that the backend-ci workflow passes on the merge commit
3. Verify the "DEBUG: orchestrator import resolution" section appears in CI logs

### Notes
- This was a pre-existing issue from PR #2837, not caused by recent changes
- YAML syntax validated locally with `yaml.safe_load()`
- Workflow run #6865 showed the original failure

---
**Link to Devin run**: https://app.devin.ai/sessions/a283a2018c5848009f1f008f51ae3429
**Requested by**: Ryan Chen (@RC918)