### PR TITLE
docs: add Render manual deployment SOP (#2901)

### DIFF
--- a/docs/deployment/RENDER_MANUAL_DEPLOY_SOP.md
+++ b/docs/deployment/RENDER_MANUAL_DEPLOY_SOP.md
@@ -1,8 +1,10 @@
 # Render Manual Deployment SOP
 
-> **Version**: v0.1 (2025-12-24)
+> **Version**: v0.2 (2025-12-24)
 > **Status**: Active - All Render deployments are now manual
+> **Owner**: @RC918 (Ryan Chen)
 > **Related**: PR #2897, Issue #2901
+> **Review Cadence**: Quarterly or after major infrastructure changes
 
 ## Overview
 
@@ -17,7 +19,7 @@ As of 2025-12-24, automatic deployments (autoDeploy) have been disabled for all 
 | morningai-worker-dashboard | [Dashboard](https://dashboard.render.com/web/srv-xxx) | Worker dashboard UI |
 | morningai-ops-agent-worker | [Dashboard](https://dashboard.render.com/web/srv-xxx) | Ops agent worker |
 
-> Note: Replace `srv-xxx` with actual service IDs from Render Dashboard
+> **IMPORTANT**: The `srv-xxx` values are placeholders. You MUST replace them with actual service IDs from Render Dashboard before using these links. Navigate via: Render Dashboard → Services → Select service name.
 
 ## Pre-Deployment Checklist
 
@@ -27,6 +29,7 @@ Before triggering a deployment:
 - [ ] No blocking issues or incidents in progress
 - [ ] Team notified in Slack/Discord (if applicable)
 - [ ] Confirm which services need deployment (not all changes affect all services)
+- [ ] Verify Render Dashboard links in this document are correct (or navigate manually)
 
 ## Deployment Steps
 
@@ -56,12 +59,17 @@ After deployment completes:
 ### Health Check
 
 ```bash
-# Check service health endpoint
+# Quick liveness check (lightweight)
+curl -s https://morningai-backend-v2.onrender.com/healthz | jq .
+
+# Full diagnostic check (includes all service status)
 curl -s https://morningai-backend-v2.onrender.com/health | jq .
 
-# Expected response:
-# {"status": "healthy", "timestamp": "..."}
+# Expected response (both endpoints return same format):
+# {"status": "healthy", "phase": "Phase 8", "database": "connected", "redis": {...}, ...}
 ```
+
+> **Note**: Both `/health` and `/healthz` endpoints are available. Use `/healthz` for quick liveness checks, `/health` for detailed diagnostics.
 
 ### Smoke Test
 
@@ -122,8 +130,9 @@ If issues are detected after deployment:
 
 | Date | Version | Changes |
 |------|---------|---------|
+| 2025-12-24 | v0.2 | Added owner/review cadence, improved placeholder warnings, documented both health endpoints, added link verification checklist item |
 | 2025-12-24 | v0.1 | Initial SOP created after disabling autoDeploy |
 
 ---
 
-*This document should be updated as deployment procedures evolve.*
+*This document should be updated as deployment procedures evolve. Report issues or suggest improvements to @RC918.*


### PR DESCRIPTION
## Summary

Adds a v0.2 Standard Operating Procedure (SOP) document for manual Render deployments. This documentation is needed because PR #2897 disabled `autoDeploy` for all Render services to address the bandwidth/pipeline cost crisis.

The SOP includes:
- Pre-deployment checklist
- Step-by-step deployment instructions
- Post-deployment verification procedures
- Rollback procedure
- Troubleshooting guide

## Updates since last revision

Per Gemini Code Assist and manual review feedback:
- Added document owner (@RC918) and quarterly review cadence metadata
- Strengthened placeholder warning with explicit "IMPORTANT" note about `srv-xxx` values
- Added checklist item to verify Render Dashboard links before deployment
- Documented both `/health` and `/healthz` endpoints with usage guidance (consistent with VERCEL_DEPLOYMENT_STRATEGY.md)
- Updated expected response format to include `phase` field
- Added feedback contact in document footer

## Review & Testing Checklist for Human

- [ ] **Verify placeholder decision**: Confirm that keeping `srv-xxx` placeholders (with warning note) is acceptable, or replace with actual Render service IDs
- [ ] **Walk through the SOP**: Have a team member follow the deployment steps on one service to verify accuracy and completeness

**Recommended Test Plan:**
1. Follow the deployment steps on one service to verify accuracy
2. Test the rollback procedure documentation against actual Render UI
3. Verify both health endpoints work as documented: `curl https://morningai-backend-v2.onrender.com/healthz`

### Notes

- This is a documentation-only change with no functional impact
- Health endpoints verified: both `/health` and `/healthz` return 200 OK with full status including `phase: "Phase 8"`
- Emergency contact (@RC918) verified via CODEOWNERS
- Related to Issue #2901 and PR #2897 (which disabled autoDeploy)

---
Link to Devin run: https://app.devin.ai/sessions/a283a2018c5848009f1f008f51ae3429
Requested by: Ryan Chen (@RC918)