### PR TITLE
feat(ci): re-enable Qwen AI Code Review workflow (#2902)

### DIFF
--- a/.github/workflows/qwen-pr-review.yml
+++ b/.github/workflows/qwen-pr-review.yml
@@ -3,13 +3,12 @@
 # Qwen AI Code Review Workflow
 # 
 # ============================================================================
-# STATUS: DISABLED (2025-12-16)
+# STATUS: ENABLED (2025-12-24)
 # ============================================================================
-# This workflow is currently disabled. GitHub Copilot is used as the primary
-# AI code reviewer instead. This workflow is kept for reference and can be
-# re-enabled by uncommenting the pull_request trigger below.
+# This workflow reviews all PRs using Qwen AI (qwen-plus model).
+# Works alongside Gemini Code Assist to provide dual AI review coverage.
 #
-# To re-enable: uncomment the pull_request trigger in the 'on:' section
+# To disable: comment out the pull_request trigger in the 'on:' section
 # ============================================================================
 #
 # This workflow reviews PRs using Qwen AI.
@@ -54,12 +53,11 @@
 name: "Qwen AI Code Review"
 
 on:
-  # DISABLED: Automatic PR review is disabled. Using GitHub Copilot instead.
-  # Uncomment the following to re-enable automatic PR review:
-  # pull_request:
-  #   types: [opened, synchronize, reopened]
+  # Automatic PR review - reviews all PRs on open/sync/reopen
+  pull_request:
+    types: [opened, synchronize, reopened]
   
-  # Manual trigger only - for testing or one-off reviews
+  # Manual trigger - for testing or one-off reviews
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
## Summary

Re-enables the Qwen AI Code Review workflow to provide dual AI review coverage alongside Gemini Code Assist. The workflow was disabled on 2025-12-16 and is now being re-enabled per user decision to maximize AI review value (Gemini has fixed cost, so running both reviewers provides more coverage at minimal incremental cost).

Changes:
- Uncomment `pull_request` trigger to enable automatic reviews on all PRs
- Update status header from DISABLED to ENABLED (2025-12-24)
- Update comments to reflect current state

Existing safeguards remain in place:
- Bot/Dependabot PRs are skipped
- Fork PRs are skipped (protect secrets)
- `no-ai-review` label opt-out mechanism
- Same-commit deduplication (won't re-review same SHA)

## Review & Testing Checklist for Human

- [ ] Verify `QWEN_API_KEY` secret is still valid and has sufficient API quota
- [ ] After merge, monitor the first PR to confirm Qwen review triggers and posts successfully
- [ ] Verify both Gemini and Qwen reviews appear without conflicts on the same PR

### Test Plan
1. Merge this PR
2. Open a test PR or wait for the next PR
3. Confirm Qwen AI Code Review workflow runs and posts a review comment
4. Verify the `no-ai-review` label still skips the review if needed

### Notes

Closes #2902

---
Link to Devin run: https://app.devin.ai/sessions/a283a2018c5848009f1f008f51ae3429
Requested by: Ryan Chen (@RC918)