### PR TITLE
test(orchestrator): add concurrent worker integration tests for PR lease mechanism

### DIFF
--- a/handoff/20250928/40_App/orchestrator/redis_queue/tests/test_pr_lease_integration.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/tests/test_pr_lease_integration.py
@@ -20,6 +20,16 @@ Blueprint Alignment:
 - Memory v2 (Layer 1): Atomic short-term reservation
 - Safety Governor v2: Prevents race condition duplicates
 - Telemetry v2: Structured logging for lease decisions
+
+Running Tests:
+- Local: Requires REDIS_URL environment variable (default: redis://localhost:6379/0)
+  ```
+  export REDIS_URL="redis://localhost:6379/0"
+  pytest handoff/20250928/40_App/orchestrator/redis_queue/tests/test_pr_lease_integration.py -v
+  ```
+- CI: Uses Redis service container defined in orchestrator-integration-tests.yml
+- Note: In CI environment (CI=true), Redis connection failure will fail the test
+  rather than skip, to prevent silent CI misconfigurations.
 """
 
 import pytest
@@ -41,8 +51,13 @@ class TestPRLeaseIntegration:
 
     @pytest.fixture
     def redis_client(self):
-        """Create a real Redis client for integration tests."""
+        """Create a real Redis client for integration tests.
+
+        In CI environment (CI=true), Redis connection failure will fail the test
+        rather than skip, to prevent silent CI misconfigurations.
+        """
         redis_url = os.environ.get("REDIS_URL", "redis://localhost:6379/0")
+        is_ci = os.environ.get("CI", "").lower() == "true"
         try:
             client = redis.from_url(redis_url, decode_responses=True)
             client.ping()
@@ -52,8 +67,11 @@ class TestPRLeaseIntegration:
                 client.delete(key)
             for key in client.keys("test:pr_lease:*"):
                 client.delete(key)
-        except redis.ConnectionError:
-            pytest.skip("Redis not available for integration tests")
+        except redis.ConnectionError as e:
+            if is_ci:
+                pytest.fail(f"Redis not available in CI environment: {e}")
+            else:
+                pytest.skip("Redis not available for integration tests")
 
     @pytest.fixture
     def unique_dedup_key(self):
@@ -116,7 +134,8 @@ class TestPRLeaseIntegration:
     def test_ttl_expiry_allows_reacquire(self, redis_client, unique_dedup_key):
         """Test that lease can be re-acquired after TTL expires.
 
-        Uses a short TTL (1 second) to verify expiry behavior.
+        Uses polling instead of fixed sleep to avoid CI flakiness under load.
+        Polls Redis TTL/existence with a generous deadline (5 seconds).
         """
         from governance.pr_deduplication import (
             acquire_pr_lease,
@@ -143,8 +162,14 @@ class TestPRLeaseIntegration:
         assert result1.acquired is False, "Should not acquire lease while held"
         assert result1.holder == "worker-1", "Should report correct holder"
 
-        # Wait for TTL to expire
-        time.sleep(1.5)
+        # Poll for TTL expiry instead of fixed sleep (avoids CI flakiness)
+        deadline = time.time() + 5.0  # 5 second deadline
+        while time.time() < deadline:
+            if not redis_client.exists(lease_key):
+                break
+            time.sleep(0.1)  # Poll every 100ms
+        else:
+            pytest.fail("Lease key did not expire within 5 second deadline")
 
         # Second attempt should succeed (lease expired)
         result2 = acquire_pr_lease(


### PR DESCRIPTION
# test(orchestrator): add concurrent worker integration tests for PR lease mechanism

## Summary

Adds integration tests for the atomic SETNX lease mechanism introduced in PR #2916. These tests verify the PR deduplication lease works correctly under concurrent access patterns with real Redis.

**Tests added (10 total):**
- Concurrent lease acquisition (only one winner among 10 workers)
- TTL expiry allows re-acquire
- Complete blocks with PR metadata
- Release allows re-acquire  
- Concurrent acquire-release cycles
- Deterministic dedup key generation
- Deterministic branch generation
- Fail-open behavior when Redis unavailable (3 tests)

Closes #2917

## Updates Since Last Revision

Based on code review feedback, the following improvements were made:

1. **Fixed TTL flakiness**: Replaced `time.sleep(1.5)` with polling approach that checks Redis key existence with a 5-second deadline. This avoids CI flakiness under load.

2. **CI fail-fast behavior**: Redis connection failure now calls `pytest.fail()` in CI environment (detected via `CI=true`) instead of `pytest.skip()`. This prevents silent CI misconfigurations.

3. **Added test execution documentation**: Module docstring now includes instructions for running tests locally and notes about CI environment.

**Follow-up issues created:**
- #2923: Chaos/fault injection tests (Redis restart, reconnection, long-running race conditions)
- #2924: Data corruption/anomaly defense tests (JSON decode errors, missing fields)

## Review & Testing Checklist for Human

- [ ] **Verify concurrent test isn't flaky**: Run `pytest handoff/20250928/40_App/orchestrator/redis_queue/tests/test_pr_lease_integration.py::TestPRLeaseIntegration::test_concurrent_lease_acquisition_only_one_winner -v` multiple times (5-10x) to check for flakiness
- [ ] **Confirm CI workflow runs these tests**: Verify `orchestrator-integration-tests.yml` picks up the new test file and Redis service container is available
- [ ] **Verify CI fail-fast behavior**: If Redis service container fails to start in CI, tests should now fail (not skip) - confirm this is desired behavior

**Recommended test plan:**
1. Wait for CI to pass on this PR
2. Check the `Orchestrator Integration Tests` workflow specifically for these new tests
3. If any tests fail intermittently, consider increasing the polling deadline or adding retry logic

### Notes

- Tests are marked with `@pytest.mark.integration` and `@pytest.mark.concurrency` for selective execution and flake monitoring
- All 10 tests passed locally with real Redis
- The concurrent tests use barrier-style synchronization to ensure threads start simultaneously
- TTL expiry test now uses polling (100ms intervals, 5s deadline) instead of fixed sleep

---
Link to Devin run: https://app.devin.ai/sessions/2bbb68331f3d4f87b9c2155be158ca48
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918