### PR TITLE
feat(orchestrator): add fail-open monitoring for PR lease mechanism (#2919)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/governance/pr_deduplication.py
+++ b/handoff/20250928/40_App/orchestrator/governance/pr_deduplication.py
@@ -31,7 +31,7 @@ import logging
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional  # Any used for redis_client type hint
 
 logger = logging.getLogger(__name__)
 
@@ -658,7 +658,7 @@ def _record_fail_open_event(
     dedup_key: str,
     reason: str,
     error: Optional[str] = None,
-    redis_client=None
+    redis_client: Optional[Any] = None
 ) -> None:
     """
     Record a fail-open event for monitoring and alerting (Issue #2919).
@@ -670,7 +670,7 @@ def _record_fail_open_event(
     This function:
     1. Adds a Sentry breadcrumb for debugging
     2. Increments a metrics counter for Prometheus/Grafana
-    3. Checks if alert threshold is exceeded
+    3. Logs structured warning for observability
 
     Args:
         trace_id: Trace ID for correlation
@@ -700,6 +700,7 @@ def _record_fail_open_event(
         logger.debug(f"[PRDedup] Failed to add Sentry breadcrumb: {e}")
 
     # 2. Increment metrics counter (if Redis available)
+    # Use INCR + EXPIRE pattern for robustness (ensures TTL is always refreshed)
     if redis_client:
         try:
             from datetime import datetime
@@ -707,8 +708,8 @@ def _record_fail_open_event(
             metric_key = f"metrics:orchestrator:{FAIL_OPEN_METRIC_NAME}:{minute_str}"
 
             with redis_client.pipeline(transaction=True) as pipe:
-                pipe.set(metric_key, 0, ex=7200, nx=True)  # 2 hour TTL
-                pipe.incr(metric_key)
+                pipe.incr(metric_key)  # INCR creates key with value 1 if not exists
+                pipe.expire(metric_key, 7200)  # Always refresh TTL to 2 hours
                 pipe.execute()
 
             logger.debug(f"[PRDedup] Recorded fail-open metric: {metric_key}")

--- a/handoff/20250928/40_App/orchestrator/governance/tests/test_pr_deduplication_lease.py
+++ b/handoff/20250928/40_App/orchestrator/governance/tests/test_pr_deduplication_lease.py
@@ -267,7 +267,7 @@ class TestFailOpenMonitoring:
         assert call_kwargs["data"]["fail_open"] is True
 
     def test_record_fail_open_event_increments_metric(self, mock_redis):
-        """Fail-open event should increment metrics counter"""
+        """Fail-open event should increment metrics counter with INCR+EXPIRE pattern"""
         mock_pipeline = MagicMock()
         mock_redis.pipeline.return_value.__enter__ = MagicMock(return_value=mock_pipeline)
         mock_redis.pipeline.return_value.__exit__ = MagicMock(return_value=False)
@@ -282,6 +282,7 @@ class TestFailOpenMonitoring:
 
         mock_redis.pipeline.assert_called_once()
         mock_pipeline.incr.assert_called_once()
+        mock_pipeline.expire.assert_called_once()  # Verify TTL is refreshed
 
     def test_redis_unavailable_triggers_fail_open_monitoring(self):
         """Redis unavailable should trigger fail-open monitoring"""
@@ -368,3 +369,48 @@ class TestFailOpenMonitoring:
         assert FAIL_OPEN_METRIC_NAME == "pr_lease.fail_open"
         assert FAIL_OPEN_ALERT_THRESHOLD == 5
         assert FAIL_OPEN_ALERT_WINDOW_MINUTES == 5
+
+    def test_record_fail_open_event_graceful_when_sentry_and_redis_unavailable(self):
+        """Fail-open monitoring should fail gracefully when both Sentry and Redis unavailable"""
+        # Simulate Sentry import failure by not mocking it
+        # and Redis unavailable by passing None
+
+        # This should not raise any exception
+        _record_fail_open_event(
+            trace_id="trace-123",
+            dedup_key="test-dedup-key",
+            reason="redis_unavailable",
+            error=None,
+            redis_client=None  # Redis unavailable
+        )
+        # Test passes if no exception is raised
+
+    def test_record_fail_open_event_graceful_when_sentry_raises_exception(self):
+        """Fail-open monitoring should continue when Sentry add_breadcrumb raises"""
+        mock_sentry = MagicMock()
+        mock_sentry.add_breadcrumb.side_effect = Exception("Sentry error")
+
+        with patch.dict('sys.modules', {'sentry_sdk': mock_sentry}):
+            # This should not raise any exception
+            _record_fail_open_event(
+                trace_id="trace-123",
+                dedup_key="test-dedup-key",
+                reason="connection_error",
+                error="Connection refused",
+                redis_client=None
+            )
+        # Test passes if no exception is raised
+
+    def test_record_fail_open_event_graceful_when_redis_pipeline_fails(self, mock_redis):
+        """Fail-open monitoring should continue when Redis pipeline fails"""
+        mock_redis.pipeline.side_effect = Exception("Redis pipeline error")
+
+        # This should not raise any exception
+        _record_fail_open_event(
+            trace_id="trace-123",
+            dedup_key="test-dedup-key",
+            reason="connection_error",
+            error="Connection refused",
+            redis_client=mock_redis
+        )
+        # Test passes if no exception is raised


### PR DESCRIPTION
## Summary

Implements observability for Redis fail-open events in the PR lease mechanism. When Redis is unavailable or errors occur during lease acquisition, the system intentionally allows PR creation (fail-open behavior). This PR adds monitoring to track these degraded states.

**Changes:**
- Add `_record_fail_open_event()` helper that records Sentry breadcrumbs and increments Redis-based metrics counters
- Add `get_fail_open_count()` to query fail-open events within a configurable time window
- Add `check_fail_open_alert_threshold()` for SLO monitoring - sends Sentry alert when threshold exceeded (>5 events in 5 minutes)
- Update `acquire_pr_lease()` to call fail-open monitoring at both fail-open paths (Redis unavailable and connection errors)
- Add 13 unit tests covering Sentry breadcrumbs, metrics increment, alert threshold logic, and graceful failure scenarios

## Updates since last revision

Addressed code review feedback:
- Added type hint `Optional[Any]` for `redis_client` parameter
- Fixed misleading docstring (removed claim about checking alert threshold)
- Changed metrics from `SET(nx=True)+INCR` to `INCR+EXPIRE` pattern for TTL robustness (ensures TTL is always refreshed, preventing storage bloat from orphaned keys)
- Added 3 tests for graceful failure when Sentry/Redis are unavailable or raise exceptions

**Follow-up issues created:**
- [#2933](https://github.com/RC918/morningai/issues/2933) - Make fail-open alert threshold configurable via settings
- [#2934](https://github.com/RC918/morningai/issues/2934) - Add E2E/behavioral tests for fail-open monitoring

## Review & Testing Checklist for Human

- [ ] **Verify alert threshold values are appropriate**: Currently hardcoded as >5 events in 5 minutes (`FAIL_OPEN_ALERT_THRESHOLD=5`, `FAIL_OPEN_ALERT_WINDOW_MINUTES=5`). Consider if these need to be configurable via settings (see #2933).
- [ ] **Verify Sentry integration patterns**: Check that `sentry_sdk.add_breadcrumb()` and `sentry_sdk.capture_message()` calls match your existing Sentry usage patterns
- [ ] **Verify metrics key format**: Metrics use `metrics:orchestrator:pr_lease.fail_open:{minute}` - confirm this aligns with your Grafana/alerting setup (different from CanaryMetrics which uses `metrics:canary:...`)
- [ ] **Test in staging with Redis unavailable**: Temporarily disable Redis connectivity and verify:
  - Sentry breadcrumbs appear in error traces
  - Metrics are NOT recorded (expected, since Redis is down)
  - PR creation still succeeds (fail-open behavior preserved)

### Notes

The monitoring itself is designed to fail gracefully - if Sentry or Redis metrics recording fails, it won't break the fail-open behavior. The metrics use minute-bucket keys with 2-hour TTL for lightweight storage.

Most whitespace changes in the diff are trailing whitespace cleanup, not logic changes.

---
**Requested by:** Ryan Chen (@RC918)
**Link to Devin run:** https://app.devin.ai/sessions/2bbb68331f3d4f87b9c2155be158ca48