### PR TITLE
feat(orchestrator): add enhanced filtering for orchestrator PR events

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_orchestrator_pr_filtering.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_orchestrator_pr_filtering.py
@@ -256,6 +256,31 @@ class TestOrchestratorBranchDetection:
         event.raw_payload = None
         assert should_skip_orchestrator_pr_event(event) is False
 
+    def test_non_string_head_ref_is_handled(self):
+        """
+        Test that events with non-string head_ref values are handled gracefully.
+
+        Malformed payloads might have None, int, dict, list, etc. as head_ref.
+        The function should not raise AttributeError and should return False.
+        """
+        non_string_values = [
+            None,
+            123,
+            {"ref": "orchestrator/docs-test"},
+            ["orchestrator/docs-test"],
+            True,
+            12.34,
+        ]
+        for value in non_string_values:
+            event = self._create_pr_event(
+                event_type=WebhookEventType.PR_OPENED,
+                head_ref="",  # Will be overwritten
+            )
+            event.raw_payload["pull_request"]["head"]["ref"] = value
+            # Should not raise and should return False (not skip)
+            result = should_skip_orchestrator_pr_event(event)
+            assert result is False, f"Non-string head_ref {type(value).__name__} should not cause skip"
+
 
 class TestEventNormalizerOrchestratorFiltering:
     """

--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -138,6 +138,11 @@ def should_skip_orchestrator_pr_event(event: "WebhookEvent") -> bool:
     pr_data = raw_payload.get("pull_request", {})
     head_ref = pr_data.get("head", {}).get("ref", "")
 
+    # Type guard: ensure head_ref is a string to prevent AttributeError
+    # Malformed payloads might have None, int, dict, etc.
+    if not isinstance(head_ref, str):
+        head_ref = ""
+
     # Check if branch starts with orchestrator/ prefix
     if head_ref.startswith("orchestrator/"):
         repo = f"{event.repo_owner}/{event.repo_name}" if event.repo_owner and event.repo_name else "unknown"


### PR DESCRIPTION
## Summary

Adds filtering to prevent the orchestrator from processing its own PR events, reducing docs PR noise. When the orchestrator creates a docs PR (branch: `orchestrator/*`), GitHub sends PR webhooks back. Without this filter, the orchestrator would process these events and potentially create more docs PRs.

**Changes:**
- Add `should_skip_orchestrator_pr_event()` function that checks if a PR's head branch starts with `orchestrator/`
- Integrate the check into `is_actionable()` as P2 priority (after self-review detection)
- Add 16 unit tests covering branch detection, edge cases, and E2E webhook flow

## Updates since last revision

- Added type guard for `head_ref` to handle malformed payloads (None, int, dict, list, etc.) - prevents `AttributeError` on unexpected payload shapes
- Added test for non-string `head_ref` values

## Review & Testing Checklist for Human

- [ ] **Verify no false positives**: Confirm that legitimate PRs from branches like `feature/...`, `devin/...`, `fix/...` are NOT filtered (tests cover this but worth manual verification)
- [ ] **Check logging output**: After deployment, monitor logs for `operation=orchestrator_pr_skip` to confirm filtering is working as expected
- [ ] **E2E verification**: Create a test orchestrator PR (branch `orchestrator/test-*`) and verify it's not processed by the orchestrator

**Recommended test plan:**
1. Deploy to staging
2. Trigger a docs PR generation (or manually create a PR from an `orchestrator/*` branch)
3. Check worker logs for `orchestrator_pr_skip` operation
4. Verify no new docs PR is created in response to the orchestrator PR

### Notes

This implements "Plan A (加強版)" - enhanced filtering rules to prevent self-triggering loops. The filter uses a zero-cost check (branch prefix from webhook payload) with no API calls required.

Pre-existing C901 complexity warning on `is_actionable` (complexity 18) is unrelated to this change.

**Follow-up issues created:**
- #2961 - Refactor `is_actionable()` to reduce complexity
- #2962 - Add configurable whitelist for orchestrator PR filtering
- #2963 - Add staging webhook validation checklist

---
Link to Devin run: https://app.devin.ai/sessions/2bbb68331f3d4f87b9c2155be158ca48
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918