### PR TITLE
docs: Phase 1 Canary verification test

### DIFF
--- a/docs/PHASE1_CANARY_VERIFICATION.md
+++ b/docs/PHASE1_CANARY_VERIFICATION.md
@@ -1,0 +1,20 @@
+# Phase 1 Canary Verification
+
+This file was created to trigger MorningAI Reviewer for Phase 1 Canary verification.
+
+## Purpose
+
+Verify that the idempotency fixes are working correctly:
+- PR #2880: Webhook delivery idempotency
+- PR #2916: Atomic PR lease
+- PR #2940: PostgreSQL connection pooling
+
+## Test Date
+
+2025-12-25
+
+## Expected Behavior
+
+1. MorningAI Reviewer should post exactly ONE review
+2. If webhook is redelivered, it should be detected and skipped
+3. No duplicate reviews should be created


### PR DESCRIPTION
## Summary

Adds a test documentation file to trigger MorningAI Reviewer for Phase 1 Canary verification. This PR is intentionally minimal - its purpose is to generate a webhook event that can be used to verify the idempotency fixes from PR #2880, #2916, and #2940 are working correctly.

## Review & Testing Checklist for Human

- [ ] After MorningAI Reviewer posts a review, go to GitHub Webhooks settings and use "Redeliver" on the `pull_request` webhook to verify duplicate detection works
- [ ] Confirm only ONE MorningAI review is posted (not duplicates)

### Test Plan

1. Wait for MorningAI Reviewer to post a review on this PR
2. Go to: Settings → Webhooks → Recent Deliveries
3. Find the `pull_request` event for this PR and click "Redeliver"
4. Verify the redelivered webhook is detected and skipped (no second review posted)

### Notes

This is a test PR for Phase 1 Canary verification. Can be closed/merged after verification is complete.

---
Link to Devin run: https://app.devin.ai/sessions/199f2f07612d42fd88f6b030768a3247
Requested by: Ryan Chen (@RC918)