### PR TITLE
docs: PostgreSQL connection fix verification for staging test

### DIFF
--- a/docs/operations/POSTGRES_CONNECTION_FIX_VERIFICATION.md
+++ b/docs/operations/POSTGRES_CONNECTION_FIX_VERIFICATION.md
@@ -1,0 +1,62 @@
+# PostgreSQL Connection Lifecycle Fix Verification
+
+## Date: December 26, 2025
+
+## PR Reference
+- PR #2972: fix(orchestrator): decouple rate limiter + fix PostgreSQL connection lifecycle (#2969)
+
+## Problem Statement
+
+Production Sentry errors showed PostgreSQL connection failures during long workflows (~2 minutes):
+- "the connection is closed" (12 events, Escalating)
+- "SSL connection has been closed unexpectedly" (5 events)
+- "psycopg.Pipeline [BAD]" state
+- "prepared statement _pg3_1 does not exist" (4 events)
+
+## Root Cause
+
+The previous implementation held a single pooled connection for the entire `app.invoke()` duration (~2 minutes). Any network hiccup or Supabase reset killed the connection with no recovery.
+
+```python
+# OLD (Vulnerable)
+with pool.connection() as conn:
+    checkpointer = PostgresSaver(conn)
+    app.invoke(...)  # Holds connection for ~2 minutes
+```
+
+## Fix Applied
+
+Changed to per-operation connection borrowing:
+
+```python
+# NEW (Resilient)
+checkpointer = PostgresSaver(pool)  # Pass pool, not connection
+app.invoke(...)
+# Each checkpoint operation borrows connection briefly from pool
+```
+
+Key changes:
+1. `prepare_threshold=0` - Disables prepared statements to avoid "prepared statement does not exist" errors
+2. `PostgresSaver(pool)` - Each checkpoint operation borrows connection briefly
+3. New `get_postgres_checkpointer()` function replaces context manager approach
+
+## Verification Checklist
+
+- [ ] Staging deployment successful
+- [ ] Worker logs show "PostgreSQL checkpointer initialized with per-operation connection borrowing"
+- [ ] No "Pipeline [BAD]" errors in logs
+- [ ] No "SSL connection closed" errors in logs
+- [ ] Workflow completes successfully
+- [ ] Sentry error count decreases over 24 hours
+
+## Blueprint Alignment
+
+- **Design for Failure**: Connection can die without killing entire workflow
+- **Safety Governor v2**: Graceful degradation under network instability
+
+## Related Issues
+
+- Issue #2968: ResilientPostgresSaver (long-term retry/reconnect logic)
+- Issue #2969: Rate Limiter decoupling
+- Issue #2973: Concurrent webhook tests
+- Issue #2974: Fault injection tests


### PR DESCRIPTION
## Summary

Adds a verification checklist document for the PostgreSQL connection lifecycle fix deployed in PR #2972. This PR serves as a test trigger to verify the staging deployment is working correctly with the new per-operation connection borrowing approach.

The document includes:
- Problem statement with Sentry error references
- Root cause analysis (connection held for ~2 minutes during workflow)
- Fix description (per-operation connection borrowing)
- Verification checklist for staging/production validation
- Related issue references

## Review & Testing Checklist for Human

- [ ] After this PR triggers the webhook, check Render logs for `morningai-backend-v2-stg-worker` to verify:
  - "PostgreSQL checkpointer initialized with per-operation connection borrowing" message appears
  - No "Pipeline [BAD]" or "SSL connection closed" errors
- [ ] Verify the MorningAI Reviewer completes its review without PostgreSQL errors

**Test Plan:** Monitor the staging worker logs while this PR is being processed. The webhook should trigger the orchestrator, and the workflow should complete without any PostgreSQL connection errors.

### Notes

- This is a documentation-only change with no code modifications
- Primary purpose is to trigger webhook and verify PR #2972 fix in staging
- Link to Devin run: https://app.devin.ai/sessions/199f2f07612d42fd88f6b030768a3247
- Requested by: Ryan Chen (@RC918)