### PR TITLE
docs: PostgreSQL connection fix production verification

### DIFF
--- a/docs/operations/POSTGRES_FIX_PRODUCTION_VERIFICATION.md
+++ b/docs/operations/POSTGRES_FIX_PRODUCTION_VERIFICATION.md
@@ -1,0 +1,33 @@
+# PostgreSQL Connection Fix - Production Verification
+
+## Date: December 26, 2025
+
+## Context
+
+This PR verifies that PR #2972 (PostgreSQL connection lifecycle fix) is properly deployed to production.
+
+## Deployment Timeline
+
+| Time (UTC+8) | Event |
+|--------------|-------|
+| Dec 25, 10:17 PM | Production worker at `f81e4a5` (without fix) |
+| Dec 26, 2:52 AM | Manual deploy triggered for `d62ec24` |
+| Dec 26, 2:54 AM | Production worker live with `d62ec24` (with fix) |
+
+## Expected Behavior
+
+After this PR triggers the webhook, the production worker logs should show:
+- `"PostgreSQL checkpointer initialized with per-operation connection borrowing"`
+
+## Verification Checklist
+
+- [ ] Worker logs show per-operation connection borrowing initialization
+- [ ] No new `Pipeline [BAD]` errors in Sentry
+- [ ] No new `SSL connection has been closed unexpectedly` errors
+- [ ] Workflow completes successfully (Job OK with success=True)
+
+## Fix Details
+
+PR #2972 changed the PostgreSQL checkpointer from holding a single connection for the entire workflow (~2 minutes) to per-operation connection borrowing, where each checkpoint operation briefly borrows a connection from the pool.
+
+This prevents connection timeout issues during long-running workflows.


### PR DESCRIPTION
## Summary

This PR adds a verification document to trigger a webhook and confirm that PR #2972 (PostgreSQL connection lifecycle fix) is properly deployed to production.

**Background:** After merging PR #2972, we discovered that the production worker (`morningai-agent-worker`) was still running an older commit (`f81e4a5`) instead of the fix (`d62ec24`). A manual deploy was triggered at Dec 26, 2:52 AM UTC+8.

This PR serves as a test trigger to verify the fix is now active in production.

## Review & Testing Checklist for Human

- [ ] After this PR is opened, check worker logs for `"PostgreSQL checkpointer initialized with per-operation connection borrowing"` message
- [ ] Monitor Sentry for any new `Pipeline [BAD]` or `SSL connection has been closed unexpectedly` errors

### Notes

This is a test/verification PR. After confirming the fix is working, this PR can be closed without merging.

**Link to Devin run:** https://app.devin.ai/sessions/199f2f07612d42fd88f6b030768a3247
**Requested by:** Ryan Chen (@RC918)