### PR TITLE
fix(orchestrator): prevent self-trigger loop with label filter

### DIFF
--- a/handoff/20250928/40_App/orchestrator/graph.py
+++ b/handoff/20250928/40_App/orchestrator/graph.py
@@ -80,10 +80,13 @@ CORE_DOCS_PROTECTED = ["docs/FAQ.md", "docs/README.md", "README.md"]
 GENERATED_DOCS_PATH = "docs/generated"
 MAX_SLUG_LENGTH = 60
 
-# Labels for documentation PRs
-LABEL_ORCHESTRATOR_DOCS = "orchestrator-docs"
-LABEL_ORCHESTRATOR_DOCS_TEST = "orchestrator-docs-test"
-LABEL_ORCHESTRATOR_APPROVED = "orchestrator-approved"
+# Labels for documentation PRs - imported from shared constants
+# to ensure single source of truth (used by both graph.py and normalizer.py)
+from utils.constants import (
+    LABEL_ORCHESTRATOR_DOCS,
+    LABEL_ORCHESTRATOR_DOCS_TEST,
+    LABEL_ORCHESTRATOR_APPROVED,
+)
 
 
 class DocIssueLevel(Enum):

--- a/handoff/20250928/40_App/orchestrator/tests/test_orchestrator_pr_filtering.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_orchestrator_pr_filtering.py
@@ -627,3 +627,150 @@ class TestFullWebhookFlowOrchestratorFiltering:
         # Orchestrator PRs should NOT be actionable even when merged
         is_actionable = normalizer.is_actionable(event)
         assert is_actionable is False
+
+    def test_label_filter_with_real_github_webhook_payload(self):
+        """
+        Integration test: Verify label filter works with real GitHub webhook payload.
+
+        Issue: Self-Trigger Loop Prevention (Dec 2025)
+        This test simulates the exact scenario that caused the self-trigger loop:
+        1. Orchestrator creates a docs PR with 'orchestrator-docs' label
+        2. GitHub sends PR_OPENED webhook with labels in the payload
+        3. GitHubWebhookHandler.parse_event() extracts labels from payload
+        4. EventNormalizer.is_actionable() should detect the label and skip
+
+        This test verifies the FULL webhook flow, not just the filter function.
+        """
+        # Real GitHub webhook payload structure with labels
+        # This matches the actual payload format from GitHub
+        github_webhook_payload = {
+            "action": "opened",
+            "pull_request": {
+                "number": 3005,
+                "title": "docs: update FAQ for feature X",
+                "body": "Auto-generated documentation update.",
+                "html_url": "https://github.com/RC918/morningai/pull/3005",
+                "state": "open",
+                "head": {
+                    "ref": "devin/1234567890-docs-update",  # NOT orchestrator/* branch
+                    "sha": "abc123def456",
+                },
+                "base": {
+                    "ref": "main",
+                },
+                "user": {"login": "RC918"},
+                # Labels are nested objects with "name" field in GitHub payload
+                "labels": [
+                    {"id": 1, "name": "orchestrator-docs", "color": "0366d6"},
+                    {"id": 2, "name": "documentation", "color": "0075ca"},
+                ],
+                "assignees": [],
+            },
+            "repository": {
+                "id": 123456,
+                "name": "morningai",
+                "full_name": "RC918/morningai",
+                "owner": {"login": "RC918"},
+            },
+            "sender": {
+                "login": "RC918",
+                "id": 67890,
+                "type": "User",
+            },
+        }
+
+        github_webhook_headers = {
+            "X-GitHub-Event": "pull_request",
+            "X-GitHub-Delivery": "test-delivery-label-filter",
+            "X-Hub-Signature-256": "sha256=fake_signature",
+        }
+
+        # Parse the webhook using the normalizer
+        normalizer = EventNormalizer()
+        event = normalizer.parse_event(
+            source=WebhookSource.GITHUB,
+            headers=github_webhook_headers,
+            payload=github_webhook_payload,
+        )
+
+        # Verify the event was parsed correctly
+        assert event is not None
+        assert event.event_type == WebhookEventType.PR_OPENED
+        assert event.actor_name == "RC918"
+        assert event.repo_owner == "RC918"
+        assert event.repo_name == "morningai"
+
+        # CRITICAL: Verify labels were extracted from payload
+        # GitHubWebhookHandler.parse_event() extracts labels as:
+        # labels = [label.get("name") for label in pr.get("labels", [])]
+        assert "orchestrator-docs" in event.labels, (
+            "Label 'orchestrator-docs' should be extracted from GitHub payload. "
+            f"Actual labels: {event.labels}"
+        )
+
+        # THE KEY ASSERTION: The event should NOT be actionable
+        # because it has the 'orchestrator-docs' label
+        is_actionable = normalizer.is_actionable(event)
+        assert is_actionable is False, (
+            "PR with 'orchestrator-docs' label should NOT be actionable! "
+            "This would cause a self-trigger loop."
+        )
+
+    def test_label_filter_with_none_label_name_in_payload(self):
+        """
+        Edge case: Verify label filter handles None label names gracefully.
+
+        GitHub handler extracts labels as: [label.get("name") for label in ...]
+        If a label object doesn't have a "name" field, this produces None.
+        The filter should handle this without crashing.
+        """
+        github_webhook_payload = {
+            "action": "opened",
+            "pull_request": {
+                "number": 3006,
+                "title": "Test PR with malformed labels",
+                "body": "Test body",
+                "html_url": "https://github.com/RC918/morningai/pull/3006",
+                "state": "open",
+                "head": {"ref": "feature/test-branch", "sha": "xyz789"},
+                "base": {"ref": "main"},
+                "user": {"login": "developer"},
+                # Malformed labels - one without "name" field
+                "labels": [
+                    {"id": 1, "name": "bug"},
+                    {"id": 2, "color": "ff0000"},  # Missing "name" field -> None
+                    {"id": 3, "name": "enhancement"},
+                ],
+                "assignees": [],
+            },
+            "repository": {
+                "name": "morningai",
+                "owner": {"login": "RC918"},
+            },
+            "sender": {"login": "developer", "id": 11111},
+        }
+
+        github_webhook_headers = {
+            "X-GitHub-Event": "pull_request",
+            "X-GitHub-Delivery": "test-delivery-malformed-labels",
+        }
+
+        normalizer = EventNormalizer()
+        event = normalizer.parse_event(
+            source=WebhookSource.GITHUB,
+            headers=github_webhook_headers,
+            payload=github_webhook_payload,
+        )
+
+        assert event is not None
+        # Labels should include None for the malformed label
+        # The filter should handle this gracefully
+        assert "bug" in event.labels
+        assert "enhancement" in event.labels
+
+        # Should NOT crash and should be actionable (no orchestrator-docs label)
+        is_actionable = normalizer.is_actionable(event)
+        assert is_actionable is True, (
+            "PR without orchestrator-docs label should be actionable, "
+            "even with malformed labels in payload."
+        )

--- a/handoff/20250928/40_App/orchestrator/utils/constants.py
+++ b/handoff/20250928/40_App/orchestrator/utils/constants.py
@@ -27,3 +27,15 @@ REVIEW_DEDUP_TTL_SECONDS = 86400  # 24 hours
 # Increment this when review logic changes significantly to allow
 # re-reviewing PRs that were reviewed with an older version
 REVIEWER_VERSION = "v1"
+
+# Labels for documentation PRs
+# These labels are used by the orchestrator when creating docs PRs.
+# The webhook normalizer checks for these labels and skips PR events
+# that have them, preventing self-trigger loops.
+#
+# WARNING: These constants are used in both graph.py (for adding labels)
+# and normalizer.py (for detecting labels). If you change these values,
+# both files will automatically use the new values since they import from here.
+LABEL_ORCHESTRATOR_DOCS = "orchestrator-docs"
+LABEL_ORCHESTRATOR_DOCS_TEST = "orchestrator-docs-test"
+LABEL_ORCHESTRATOR_APPROVED = "orchestrator-approved"

--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -144,10 +144,38 @@ def should_skip_orchestrator_pr_event(event: "WebhookEvent") -> bool:
 
     repo = f"{event.repo_owner}/{event.repo_name}" if event.repo_owner and event.repo_name else "unknown"
 
+    # Extract head branch from raw payload (needed for logging in both checks)
+    raw_payload = event.raw_payload or {}
+    pr_data = raw_payload.get("pull_request", {})
+    head_ref = pr_data.get("head", {}).get("ref", "")
+    if not isinstance(head_ref, str):
+        head_ref = ""
+
     # Check 1: Label filter - skip PRs with orchestrator-docs labels
     # This catches PRs created by any actor (including Devin) that have the orchestrator label
-    orchestrator_labels = {"orchestrator-docs", "orchestrator-docs-test"}
-    event_labels = set(label.lower() for label in (event.labels or []))
+    # Import constants from utils/constants.py to ensure single source of truth
+    from utils.constants import LABEL_ORCHESTRATOR_DOCS, LABEL_ORCHESTRATOR_DOCS_TEST
+    orchestrator_labels = {LABEL_ORCHESTRATOR_DOCS.lower(), LABEL_ORCHESTRATOR_DOCS_TEST.lower()}
+
+    # Type guard: filter out non-string labels to prevent AttributeError on .lower()
+    # GitHub handler may produce None values if label.get("name") returns None
+    event_labels_raw = event.labels if isinstance(event.labels, list) else []
+    event_labels = set()
+    for label in event_labels_raw:
+        if isinstance(label, str):
+            event_labels.add(label.lower())
+        else:
+            # Log warning for unexpected label type
+            logger.warning(
+                "[EventNormalizer] Unexpected label type in event",
+                extra={
+                    "operation": "label_type_warning",
+                    "event_id": event.event_id,
+                    "label_type": type(label).__name__,
+                    "label_value": str(label)[:100],
+                }
+            )
+
     matched_labels = orchestrator_labels & event_labels
 
     if matched_labels:
@@ -158,6 +186,7 @@ def should_skip_orchestrator_pr_event(event: "WebhookEvent") -> bool:
                 "event_id": event.event_id,
                 "repo": repo,
                 "pr_number": event.resource_id,
+                "head_ref": head_ref,
                 "matched_labels": list(matched_labels),
                 "event_type": event.event_type.value,
                 "reason": "orchestrator_label_match",
@@ -166,16 +195,7 @@ def should_skip_orchestrator_pr_event(event: "WebhookEvent") -> bool:
         return True
 
     # Check 2: Branch prefix - skip PRs from orchestrator/* branches
-    # Extract head branch from raw payload
-    raw_payload = event.raw_payload or {}
-    pr_data = raw_payload.get("pull_request", {})
-    head_ref = pr_data.get("head", {}).get("ref", "")
-
-    # Type guard: ensure head_ref is a string to prevent AttributeError
-    # Malformed payloads might have None, int, dict, etc.
-    if not isinstance(head_ref, str):
-        head_ref = ""
-
+    # (head_ref already extracted above for logging consistency)
     if head_ref.startswith("orchestrator/"):
         logger.info(
             "[EventNormalizer] Skipping orchestrator-generated PR event (branch match)",


### PR DESCRIPTION
# fix(orchestrator): prevent self-trigger loop with label filter

## Summary

Fixes an infinite self-trigger loop that occurred when `PR_DEDUP_DRY_RUN=False` was enabled. The orchestrator was creating docs PRs that triggered new webhooks, which created more docs PRs recursively.

**Root cause**: PRs created by Devin use `devin/*` branches (not `orchestrator/*`), so the existing branch prefix filter didn't catch them. However, these PRs still have the `orchestrator-docs` label applied.

**Fix**: Added a label filter to `should_skip_orchestrator_pr_event()` that checks for `orchestrator-docs` and `orchestrator-docs-test` labels before the existing branch prefix check. The filter is case-insensitive and handles None/empty labels gracefully.

Detection methods (any match triggers skip):
1. **Label filter** (new): PRs with `orchestrator-docs` or `orchestrator-docs-test` labels
2. **Branch prefix** (existing): PRs from `orchestrator/*` branches

## Updates since last revision

Based on gemini-code-assist and MorningAI Reviewer feedback:

- **Type guards**: Added protection against non-string labels (e.g., `None` from malformed payloads) to prevent `AttributeError` on `.lower()`
- **Shared constants**: Moved label constants to `utils/constants.py` to ensure single source of truth between `graph.py` and `normalizer.py`
- **Integration tests**: Added 2 new tests verifying the full webhook flow with real GitHub payload structure
- **Enhanced logging**: Added `head_ref` to label match logs and warning logs for unexpected label types

## Review & Testing Checklist for Human

- [ ] Verify that the label names (`orchestrator-docs`, `orchestrator-docs-test`) in `utils/constants.py` match exactly what the orchestrator applies when creating docs PRs
- [ ] Deploy to staging and create a test docs PR to confirm the self-trigger loop is prevented
- [ ] Verify that legitimate PRs (without orchestrator labels) are still processed normally
- [ ] Check that the lazy import `from utils.constants import ...` inside the function doesn't cause circular import issues in production

**Recommended test plan:**
1. Deploy this fix to production
2. Set `PR_DEDUP_DRY_RUN=False` 
3. Create a test PR that triggers the orchestrator to generate a docs PR
4. Confirm the docs PR is created but does NOT trigger another docs PR (check worker logs for "Skipping orchestrator-generated PR event (label match)")

### Notes

- The C901 complexity warning on `is_actionable()` is pre-existing and unrelated to this change
- 24 tests total (8 new label filter tests + 2 integration tests), all passing

---
Link to Devin run: https://app.devin.ai/sessions/199f2f07612d42fd88f6b030768a3247
Requested by: Ryan Chen (@RC918)