### PR TITLE
docs: Phase 3 Review Posting verification test

### DIFF
--- a/docs/PHASE3_REVIEW_POSTING_TEST.md
+++ b/docs/PHASE3_REVIEW_POSTING_TEST.md
@@ -1,0 +1,27 @@
+# Phase 3: GitHub Review Posting Verification
+
+## Test Purpose
+
+This PR verifies that `GITHUB_REVIEW_POSTING_DRY_RUN=false` is working correctly.
+
+## Expected Behavior
+
+When this PR is created:
+1. GitHub sends PR_OPENED webhook to orchestrator
+2. MorningAI Reviewer processes the PR
+3. Review is **actually posted** to GitHub (not dry-run)
+4. Worker logs show `"Posted review to GitHub"` instead of `"DRY_RUN: Would post review"`
+
+## Verification Steps
+
+1. Check worker logs for review posting confirmation
+2. Verify MorningAI review comment appears on this PR
+3. Confirm no self-trigger loop occurs (label filter working)
+
+## Test Date
+
+December 26, 2025 - Phase 3 Rollout
+
+---
+
+This is a test document for Phase 3 verification.


### PR DESCRIPTION
## Summary

Test PR to verify that `GITHUB_REVIEW_POSTING_DRY_RUN=false` is working correctly after Phase 3 rollout.

This PR adds a simple documentation file that will trigger the MorningAI Reviewer webhook. The purpose is to confirm that reviews are now **actually posted** to GitHub instead of being logged as dry-run.

## Review & Testing Checklist for Human

- [ ] Verify MorningAI Reviewer posts an actual review comment on this PR (not dry-run)
- [ ] Check worker logs for `"Posted review to GitHub"` message instead of `"DRY_RUN: Would post review"`
- [ ] Confirm no self-trigger loop occurs (label filter from PR #3007 working)

**Test Plan:** After this PR is created, wait 1-2 minutes and check:
1. Worker logs in Render dashboard for review posting confirmation
2. This PR's comments section for MorningAI review

### Notes

This is a test PR and can be closed after verification is complete.

- Link to Devin run: https://app.devin.ai/sessions/199f2f07612d42fd88f6b030768a3247
- Requested by: Ryan Chen (@RC918)