### PR TITLE
fix(orchestrator): increase budget limits and fix cost estimation model

### DIFF
--- a/config/policies.yaml
+++ b/config/policies.yaml
@@ -30,14 +30,14 @@ resource_sandbox:
 
 cost_budget:
   daily:
-    max_usd: 5.0
-    max_tokens: 100000
+    max_usd: 50.0
+    max_tokens: 500000
   hourly:
-    max_usd: 1.0
-    max_tokens: 20000
+    max_usd: 10.0
+    max_tokens: 100000
   per_task:
-    max_usd: 0.5
-    max_tokens: 10000
+    max_usd: 5.0
+    max_tokens: 50000
   
   alert_thresholds:
     warning_percent: 80  # Alert at 80% of budget

--- a/handoff/20250928/40_App/orchestrator/governance/cost_tracker.py
+++ b/handoff/20250928/40_App/orchestrator/governance/cost_tracker.py
@@ -228,16 +228,24 @@ class CostTracker:
             'daily': self.get_budget_status(trace_id, 'daily')
         }
 
-    def estimate_cost(self, tokens: int, model: str = "gpt-4") -> float:
+    def estimate_cost(self, tokens: int, model: str = "qwen-plus") -> float:
         """Estimate cost in USD for given tokens"""
         pricing = {
+            # OpenAI models (per 1K tokens)
             'gpt-4': 0.03,  # Input
             'gpt-4-output': 0.06,  # Output
             'gpt-3.5-turbo': 0.0015,  # Input
             'gpt-3.5-turbo-output': 0.002,  # Output
+            # Qwen models (per 1K tokens) - much cheaper
+            'qwen-plus': 0.0016,  # ~$0.0016/1K tokens
+            'qwen-plus-output': 0.0064,  # ~$0.0064/1K tokens
+            'qwen-turbo': 0.0003,  # ~$0.0003/1K tokens
+            'qwen-turbo-output': 0.0006,  # ~$0.0006/1K tokens
+            'qwen-max': 0.016,  # ~$0.016/1K tokens
+            'qwen-max-output': 0.064,  # ~$0.064/1K tokens
         }
 
-        rate = pricing.get(model, 0.03)
+        rate = pricing.get(model, 0.0016)  # Default to qwen-plus pricing
         return (tokens / 1000) * rate
 
     def reset_budget(self, period: str = "daily") -> None:

--- a/handoff/20250928/40_App/orchestrator/graph.py
+++ b/handoff/20250928/40_App/orchestrator/graph.py
@@ -521,8 +521,8 @@ def execute(
         )
         
         estimated_tokens = len(faq_content) // 4  # Rough estimate: 4 chars per token
-        estimated_cost = cost_tracker.estimate_cost(estimated_tokens, model='gpt-4')
-        cost_tracker.track_usage(trace_id, estimated_tokens, estimated_cost, model='gpt-4', operation='faq_generation')
+        estimated_cost = cost_tracker.estimate_cost(estimated_tokens, model='qwen-plus')
+        cost_tracker.track_usage(trace_id, estimated_tokens, estimated_cost, model='qwen-plus', operation='faq_generation')
         
     except Exception as e:
         logger.warning(


### PR DESCRIPTION
## Summary

This PR fixes two issues blocking Phase 3 testing:

1. **Budget limits increased 10x** to accommodate actual usage patterns:
   - Daily: $5 → $50, 100K → 500K tokens
   - Hourly: $1 → $10, 20K → 100K tokens
   - Per-task: $0.5 → $5, 10K → 50K tokens

2. **Cost estimation model corrected** from GPT-4 to Qwen pricing:
   - Added Qwen model pricing (qwen-plus, qwen-turbo, qwen-max)
   - Changed default model from `gpt-4` ($0.03/1K) to `qwen-plus` ($0.0016/1K)
   - Updated graph.py to track costs using correct model

**Context:** The system was hitting budget limits because it was estimating costs at GPT-4 rates (~$3.01) while actual Qwen usage was only ~$0.16.

## Review & Testing Checklist for Human

- [ ] **Verify Qwen pricing rates** - The rates I added (qwen-plus: $0.0016/1K, qwen-turbo: $0.0003/1K, qwen-max: $0.016/1K) should be verified against actual Alibaba Cloud pricing
- [ ] **Confirm 10x budget increase is acceptable** - This is a significant increase; ensure it aligns with your cost expectations
- [ ] **Test Phase 3 after deployment** - Create a test PR and verify review comments are posted (budget should no longer block)

**Recommended test plan:**
1. Deploy this PR
2. Check Redis budget status: `HGETALL cost:daily:2025-12-26` - existing data will still show old GPT-4 rates until daily reset
3. Create a new test PR to trigger the reviewer
4. Verify review comments appear on the PR

### Notes

- Existing cost tracking data in Redis was recorded at GPT-4 rates. The budget check will use new limits immediately, but historical data will be inconsistent until the next daily reset.
- Link to Devin run: https://app.devin.ai/sessions/199f2f07612d42fd88f6b030768a3247
- Requested by: Ryan Chen (@RC918)