### PR TITLE
fix(cost-tracking): correct Qwen pricing and add follow-up issues

### DIFF
--- a/config/policies.yaml
+++ b/config/policies.yaml
@@ -30,14 +30,14 @@ resource_sandbox:
 
 cost_budget:
   daily:
-    max_usd: 5.0
-    max_tokens: 100000
+    max_usd: 50.0
+    max_tokens: 500000
   hourly:
-    max_usd: 1.0
-    max_tokens: 20000
+    max_usd: 10.0
+    max_tokens: 100000
   per_task:
-    max_usd: 0.5
-    max_tokens: 10000
+    max_usd: 5.0
+    max_tokens: 50000
   
   alert_thresholds:
     warning_percent: 80  # Alert at 80% of budget

--- a/docs/issues/COST_TRACKING_IMPROVEMENTS.md
+++ b/docs/issues/COST_TRACKING_IMPROVEMENTS.md
@@ -1,0 +1,182 @@
+# Cost Tracking System Improvements
+
+Based on deep evaluation of gemini-code-assist review and MorningAI Reviewer Agent analysis for PR #3009.
+
+## Critical Finding: Incorrect Qwen Pricing in PR #3009
+
+**The pricing values in PR #3009 are INCORRECT and need immediate correction.**
+
+### Current (Wrong) Pricing in `cost_tracker.py`:
+```python
+'qwen-plus': 0.0016,      # $0.0016/1K tokens
+'qwen-turbo': 0.0003,     # $0.0003/1K tokens
+'qwen-max': 0.016,        # $0.016/1K tokens
+```
+
+### Correct Alibaba Cloud Official Pricing (Singapore Region):
+| Model | Input Price | Output Price |
+|-------|-------------|--------------|
+| qwen-plus | $0.4/M tokens ($0.0004/1K) | $1.2/M tokens ($0.0012/1K) |
+| qwen-turbo | $0.05/M tokens ($0.00005/1K) | $0.2/M tokens ($0.0002/1K) |
+| qwen-max | $1.6/M tokens ($0.0016/1K) | $6.4/M tokens ($0.0064/1K) |
+
+**Source:** https://www.alibabacloud.com/help/doc-detail/2987148.html
+
+---
+
+## Follow-up Issues
+
+### Issue A: Fix Qwen Pricing Values (P0 - Critical)
+
+**Title:** `fix(cost-tracking): correct Qwen pricing values to match Alibaba Cloud official rates`
+
+**Problem:**
+PR #3009 introduced incorrect Qwen pricing values. The current values are approximately 4x higher than actual rates, which will cause:
+1. Budget enforcement to be too lenient (allowing more usage than intended)
+2. Cost reports to be inaccurate
+
+**Acceptance Criteria:**
+- [ ] Update `cost_tracker.py` with correct Alibaba Cloud pricing
+- [ ] Separate input/output pricing (Qwen charges differently)
+- [ ] Add unit tests for all Qwen model pricing lookups
+- [ ] Verify against official Alibaba Cloud documentation
+
+**Technical Details:**
+```python
+# Correct pricing (per 1K tokens)
+'qwen-plus': 0.0004,           # Input: $0.4/M = $0.0004/1K
+'qwen-plus-output': 0.0012,    # Output: $1.2/M = $0.0012/1K
+'qwen-turbo': 0.00005,         # Input: $0.05/M = $0.00005/1K
+'qwen-turbo-output': 0.0002,   # Output: $0.2/M = $0.0002/1K
+'qwen-max': 0.0016,            # Input: $1.6/M = $0.0016/1K
+'qwen-max-output': 0.0064,     # Output: $6.4/M = $0.0064/1K
+```
+
+---
+
+### Issue B: Make Pricing Table Configurable (P1 - High)
+
+**Title:** `feat(cost-tracking): make pricing table configurable and add version tracking`
+
+**Problem:**
+Pricing is hardcoded in `cost_tracker.py`, making updates difficult and untrackable.
+
+**Acceptance Criteria:**
+- [ ] Move pricing table to `config/pricing.yaml` or add to `policies.yaml`
+- [ ] Add `pricing_version` or `pricing_source` field to Redis cost records
+- [ ] Load pricing dynamically in `CostTracker.__init__()`
+- [ ] Document pricing update process in README
+
+**Benefits:**
+- Easy to update pricing without code changes
+- Audit trail for which pricing version was used
+- Enables A/B testing of pricing models
+
+---
+
+### Issue C: Fix All Hardcoded `model='gpt-4'` References (P1 - High)
+
+**Title:** `fix(cost-tracking): replace all hardcoded gpt-4 model references with actual model`
+
+**Problem:**
+Multiple files still use `model='gpt-4'` for cost tracking, even though the actual LLM is Qwen:
+
+```
+agents/ops_agent/worker.py:281:                        model='gpt-4',
+orchestrator/redis_queue/worker.py:1179:                model="gpt-4",
+orchestrator/redis_queue/worker.py:1586:                model="gpt-4",
+orchestrator/langgraph_orchestrator.py:1892:            model="gpt-4"
+```
+
+**Acceptance Criteria:**
+- [ ] Replace all `model='gpt-4'` with actual model from settings/LLM provider
+- [ ] Create a centralized `get_current_model()` function
+- [ ] Add lint rule to prevent hardcoded model strings in `track_usage()` calls
+- [ ] Update tests to use correct model names
+
+---
+
+### Issue D: Add Cost Tracking Unit Tests (P2 - Medium)
+
+**Title:** `test(cost-tracking): add comprehensive unit tests for cost estimation`
+
+**Problem:**
+Current tests only cover GPT-4 and GPT-3.5-turbo models. No tests for:
+- Qwen model pricing
+- Unknown model fallback behavior
+- Input vs output pricing separation
+- Budget boundary cases with mixed pricing data
+
+**Acceptance Criteria:**
+- [ ] Add tests for all Qwen models (qwen-plus, qwen-turbo, qwen-max)
+- [ ] Add tests for unknown model fallback
+- [ ] Add tests for input/output pricing separation
+- [ ] Add tests for `check_budget()` with mixed old/new pricing data
+- [ ] Update `test_estimate_cost()` in `tests/test_governance.py`
+
+---
+
+### Issue E: Handle Redis Historical Data Inconsistency (P2 - Medium)
+
+**Title:** `fix(cost-tracking): handle mixed pricing data in Redis gracefully`
+
+**Problem:**
+Historical Redis data was recorded with GPT-4 pricing. After PR #3009, new data uses Qwen pricing. This causes:
+1. Inconsistent cost reports
+2. Potential budget enforcement issues during transition
+
+**Acceptance Criteria:**
+- [ ] Add `pricing_version` field to Redis cost records
+- [ ] Log warning when mixed pricing versions detected
+- [ ] Consider using tokens-only for budget enforcement (usd as soft signal)
+- [ ] Optional: Create migration script to recalculate historical usd values
+
+**Technical Notes:**
+- Redis keys have TTL (daily: 7 days, hourly: 24h, task: 30 days)
+- Data will naturally age out, but transition period needs handling
+
+---
+
+### Issue F: Add Cost Monitoring and Alerting (P3 - Low)
+
+**Title:** `feat(cost-tracking): add cost monitoring metrics and drift alerting`
+
+**Problem:**
+No visibility into cost trends or anomalies. Silent drift can occur when pricing changes.
+
+**Acceptance Criteria:**
+- [ ] Add "budget usage rate" metrics (tokens/usd per hour)
+- [ ] Alert when mixed `pricing_version` detected in same period
+- [ ] Alert when cost-per-token deviates significantly from expected
+- [ ] Dashboard widget for cost trends
+
+---
+
+## Comparison: gemini-code-assist vs MorningAI Reviewer
+
+| Aspect | gemini-code-assist | MorningAI Reviewer |
+|--------|-------------------|-------------------|
+| Pricing verification | Correctly identified need for verification | Did not flag pricing accuracy |
+| Test coverage | Identified missing tests | Did not flag test gaps |
+| Redis compatibility | Identified data inconsistency risk | Did not flag migration needs |
+| Actionability | Provided general suggestions | N/A (not reviewed) |
+| False positives | Some suggestions overly cautious (migration script) | N/A |
+
+**Recommendation:** gemini-code-assist provided valuable review feedback. The suggestions about pricing verification and test coverage are particularly important and should be prioritized.
+
+---
+
+## Priority Order
+
+1. **P0 (Immediate):** Issue A - Fix incorrect Qwen pricing values
+2. **P1 (This Sprint):** Issue B - Make pricing configurable, Issue C - Fix hardcoded gpt-4 references
+3. **P2 (Next Sprint):** Issue D - Add tests, Issue E - Handle Redis inconsistency
+4. **P3 (Backlog):** Issue F - Add monitoring
+
+---
+
+## References
+
+- PR #3009: https://github.com/RC918/morningai/pull/3009
+- Alibaba Cloud Pricing: https://www.alibabacloud.com/help/doc-detail/2987148.html
+- Devin Session: https://app.devin.ai/sessions/199f2f07612d42fd88f6b030768a3247

--- a/handoff/20250928/40_App/orchestrator/governance/cost_tracker.py
+++ b/handoff/20250928/40_App/orchestrator/governance/cost_tracker.py
@@ -228,16 +228,29 @@ class CostTracker:
             'daily': self.get_budget_status(trace_id, 'daily')
         }
 
-    def estimate_cost(self, tokens: int, model: str = "gpt-4") -> float:
-        """Estimate cost in USD for given tokens"""
+    def estimate_cost(self, tokens: int, model: str = "qwen-plus") -> float:
+        """Estimate cost in USD for given tokens
+        
+        Pricing source: https://www.alibabacloud.com/help/doc-detail/2987148.html
+        Last updated: 2025-12-26
+        """
         pricing = {
-            'gpt-4': 0.03,  # Input
-            'gpt-4-output': 0.06,  # Output
-            'gpt-3.5-turbo': 0.0015,  # Input
-            'gpt-3.5-turbo-output': 0.002,  # Output
+            # OpenAI models (per 1K tokens)
+            'gpt-4': 0.03,
+            'gpt-4-output': 0.06,
+            'gpt-3.5-turbo': 0.0015,
+            'gpt-3.5-turbo-output': 0.002,
+            # Qwen models - Alibaba Cloud official pricing (Singapore region)
+            # Per 1K tokens = Per 1M tokens / 1000
+            'qwen-plus': 0.0004,           # Input: $0.4/M = $0.0004/1K
+            'qwen-plus-output': 0.0012,    # Output: $1.2/M = $0.0012/1K
+            'qwen-turbo': 0.00005,         # Input: $0.05/M = $0.00005/1K
+            'qwen-turbo-output': 0.0002,   # Output: $0.2/M = $0.0002/1K
+            'qwen-max': 0.0016,            # Input: $1.6/M = $0.0016/1K
+            'qwen-max-output': 0.0064,     # Output: $6.4/M = $0.0064/1K
         }
 
-        rate = pricing.get(model, 0.03)
+        rate = pricing.get(model, 0.0004)  # Default to qwen-plus input pricing
         return (tokens / 1000) * rate
 
     def reset_budget(self, period: str = "daily") -> None:

--- a/handoff/20250928/40_App/orchestrator/graph.py
+++ b/handoff/20250928/40_App/orchestrator/graph.py
@@ -521,8 +521,8 @@ def execute(
         )
         
         estimated_tokens = len(faq_content) // 4  # Rough estimate: 4 chars per token
-        estimated_cost = cost_tracker.estimate_cost(estimated_tokens, model='gpt-4')
-        cost_tracker.track_usage(trace_id, estimated_tokens, estimated_cost, model='gpt-4', operation='faq_generation')
+        estimated_cost = cost_tracker.estimate_cost(estimated_tokens, model='qwen-plus')
+        cost_tracker.track_usage(trace_id, estimated_tokens, estimated_cost, model='qwen-plus', operation='faq_generation')
         
     except Exception as e:
         logger.warning(


### PR DESCRIPTION
## Summary

This PR fixes cost tracking to use correct Qwen model pricing instead of GPT-4 pricing, and increases budget limits 10x to accommodate actual usage patterns.

**Changes:**
1. **Budget limits increased 10x** in `policies.yaml`:
   - Daily: $5 → $50, 100K → 500K tokens
   - Hourly: $1 → $10, 20K → 100K tokens
   - Per-task: $0.5 → $5, 10K → 50K tokens

2. **Qwen pricing added** to `cost_tracker.py` using Alibaba Cloud official rates (Singapore region):
   - qwen-plus: $0.0004/1K input, $0.0012/1K output
   - qwen-turbo: $0.00005/1K input, $0.0002/1K output
   - qwen-max: $0.0016/1K input, $0.0064/1K output

3. **graph.py updated** to use `model='qwen-plus'` for FAQ generation cost tracking

4. **Follow-up issues document** added with 6 prioritized issues for remaining work

**Context:** The system was hitting budget limits because it estimated costs at GPT-4 rates (~$3.01) while actual Qwen usage was only ~$0.16. This PR supersedes PR #3009 which had incorrect Qwen pricing values (~4x higher than actual).

## Review & Testing Checklist for Human

- [ ] **Verify Qwen pricing rates** against [Alibaba Cloud official pricing](https://www.alibabacloud.com/help/doc-detail/2987148.html) - the rates I added should match Singapore region pricing
- [ ] **Confirm 10x budget increase is acceptable** - this is a significant increase; ensure it aligns with cost expectations
- [ ] **Note: Other files still use `model='gpt-4'`** - this PR only fixes `graph.py`. The following files still need updating (documented in follow-up issues):
  - `agents/ops_agent/worker.py:281`
  - `orchestrator/redis_queue/worker.py:1179, 1586`
  - `orchestrator/langgraph_orchestrator.py:1892`

**Recommended test plan:**
1. Deploy this PR to staging
2. Create a test PR to trigger the reviewer
3. Check Redis: `HGETALL cost:daily:2025-12-26` - verify new entries use qwen-plus pricing
4. Verify budget is no longer exceeded for normal operations

### Notes

- Existing Redis cost data was recorded at GPT-4 rates. Data will age out via TTL (daily: 7 days, hourly: 24h)
- No new unit tests added for Qwen pricing - documented as follow-up Issue D
- Link to Devin run: https://app.devin.ai/sessions/199f2f07612d42fd88f6b030768a3247
- Requested by: Ryan Chen (@RC918)