### PR TITLE
fix(orchestrator): OOM long-term fix - pool reset and memory release

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -409,9 +409,34 @@ def _reset_postgres_pool():
 
         new_pool.wait()
 
-        # Install new pool under lock
+        # Install new pool under lock with CAS pattern
+        # This prevents race condition where another thread created a pool
+        # while we were closing the old one and creating the new one
+        pool_to_close = None
         with _postgres_pool_lock:
-            _postgres_pool = new_pool
+            if _postgres_pool is None:
+                # Normal case: no one else created a pool, install ours
+                _postgres_pool = new_pool
+                installed_pool = new_pool
+            else:
+                # Race condition: another thread already created a pool
+                # Keep the existing pool, close our newly created one
+                pool_to_close = new_pool
+                installed_pool = _postgres_pool
+                logger.info(
+                    "Pool reset: another thread already created pool, using existing",
+                    extra={"operation": "_reset_postgres_pool"}
+                )
+
+        # Close unused pool outside lock to avoid blocking
+        if pool_to_close is not None:
+            try:
+                pool_to_close.close()
+            except Exception as close_err:
+                logger.warning(
+                    f"Error closing unused pool after race: {close_err}",
+                    extra={"operation": "_reset_postgres_pool", "error": str(close_err)}
+                )
 
         logger.info(
             "PostgreSQL connection pool reset successfully",
@@ -422,7 +447,7 @@ def _reset_postgres_pool():
             }
         )
 
-        return new_pool
+        return installed_pool
 
     except Exception as e:
         logger.error(
@@ -943,8 +968,13 @@ class ResilientPostgresSaver:
 
     def list(self, config, *, filter=None, before=None, limit=None):
         """List checkpoints with retry."""
+        # Use default-arg binding to capture filter/before/limit at lambda creation time
+        # This addresses reviewer concern about late-binding closure issues
         return self._retry_with_backoff(
-            "list", lambda: self._inner.list(config, filter=filter, before=before, limit=limit)
+            "list",
+            lambda _cfg=config, _filter=filter, _before=before, _limit=limit: (
+                self._inner.list(_cfg, filter=_filter, before=_before, limit=_limit)
+            )
         )
 
     def get_tuple(self, config):

--- a/handoff/20250928/40_App/orchestrator/tests/test_checkpointer.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_checkpointer.py
@@ -905,7 +905,7 @@ class TestResilientPostgresSaverOOMFix:
     @pytest.mark.skipif(not HAS_LANGGRAPH, reason="langgraph not installed")
     def test_connection_lost_error_triggers_pool_reset(self):
         """Test that connection-lost errors trigger pool reset"""
-        from unittest.mock import MagicMock, patch, call
+        from unittest.mock import MagicMock, patch
         import time
 
         from langgraph_orchestrator import ResilientPostgresSaver
@@ -1041,7 +1041,7 @@ class TestResilientPostgresSaverOOMFix:
         This test verifies the key OOM fix: time.sleep() must be called OUTSIDE
         the except block, after traceback.clear_frames() has been called.
         """
-        from unittest.mock import MagicMock, patch, call
+        from unittest.mock import MagicMock, patch
         import time
         import traceback
 
@@ -1147,3 +1147,65 @@ class TestResilientPostgresSaverOOMFix:
         assert result == {"checkpoint": "data"}
         mock_reset.assert_called_once()
         assert wrapper._inner is mock_inner
+
+    @pytest.mark.skipif(not HAS_LANGGRAPH, reason="langgraph not installed")
+    def test_consecutive_connection_lost_triggers_multiple_resets(self):
+        """Test that consecutive connection-lost errors trigger multiple pool resets
+
+        This test verifies that:
+        1. Multiple consecutive connection-lost errors each trigger a pool reset
+        2. Each reset calls inner_factory to create a new saver
+        3. Each retry uses the newly created inner saver
+        """
+        from unittest.mock import MagicMock, patch
+        import time
+
+        from langgraph_orchestrator import ResilientPostgresSaver
+
+        # Create distinct mock inners to track which one is used
+        mock_inner_1 = MagicMock(name="inner_1")
+        mock_inner_2 = MagicMock(name="inner_2")
+        mock_inner_3 = MagicMock(name="inner_3")
+
+        # First inner fails with connection-lost, second inner also fails, third succeeds
+        mock_inner_1.get.side_effect = Exception("pipeline [bad] - first failure")
+        mock_inner_2.get.side_effect = Exception("ssl connection has been closed - second failure")
+        mock_inner_3.get.return_value = {"checkpoint": "success"}
+
+        factory_calls = []
+        inner_sequence = [mock_inner_2, mock_inner_3]
+
+        def mock_factory():
+            factory_calls.append(len(factory_calls) + 1)
+            return inner_sequence.pop(0)
+
+        wrapper = ResilientPostgresSaver(
+            inner_saver=mock_inner_1,
+            max_retries=4,  # Allow enough retries for 2 failures + 1 success
+            base_delay=0.01,
+            inner_factory=mock_factory,
+        )
+
+        with patch('langgraph_orchestrator._reset_postgres_pool') as mock_reset:
+            mock_reset.return_value = MagicMock()
+            with patch('langgraph_orchestrator.logger'):
+                with patch.object(time, 'sleep'):
+                    result = wrapper.get({"config": "test"})
+
+        # Verify result
+        assert result == {"checkpoint": "success"}
+
+        # Verify pool was reset twice (once for each connection-lost error)
+        assert mock_reset.call_count == 2
+
+        # Verify factory was called twice to create new inners
+        assert len(factory_calls) == 2
+        assert factory_calls == [1, 2]
+
+        # Verify the final inner is the third one (the successful one)
+        assert wrapper._inner is mock_inner_3
+
+        # Verify each inner was called exactly once
+        mock_inner_1.get.assert_called_once()
+        mock_inner_2.get.assert_called_once()
+        mock_inner_3.get.assert_called_once()


### PR DESCRIPTION
## Summary

Implements long-term fix for OOM issues in `ResilientPostgresSaver` where workers were getting OOM killed during retry 3 of `put_writes` operations before the circuit breaker could trigger.

**Root cause:** Exception traceback was holding references to large LangGraph state objects during the 2-second sleep in the retry loop.

**Key changes:**
1. Move `time.sleep()` OUTSIDE the except block to prevent exception traceback from holding memory during sleep
2. Clear exception traceback using `traceback.clear_frames()` and `del e` before exiting except block
3. Add `_reset_postgres_pool()` to force reset the global connection pool on connection-lost errors (Pipeline [BAD], SSL closed, etc.)
4. Add `inner_factory` parameter to `ResilientPostgresSaver` to recreate inner saver after pool reset
5. Add `gc.collect()` on error path as defensive measure

## Updates since last revision

Based on review feedback from gemini-code-assist and MorningAI Reviewer Agent:

1. **Fixed lock contention in `_reset_postgres_pool()`**: Restructured to minimize lock-hold time using 3-step approach:
   - Step 1: Under lock, swap pool to None and capture old_pool
   - Step 2: Outside lock, close old_pool (may block waiting for borrowers)
   - Step 3: Under lock, install new pool
   
2. **Removed duplicate `gc.collect()` call**: Was being called in both `_reset_postgres_pool()` and `_reset_pool_and_inner()`, now only in the former.

3. **Fixed retry loop not using refreshed inner saver**: Changed delegate methods to use lambdas that resolve `self._inner` at call time:
   - Before: `self._retry_with_backoff("get", self._inner.get, config)` - captured bound method before retry loop
   - After: `self._retry_with_backoff("get", lambda: self._inner.get(config))` - resolves `self._inner` on each retry

4. **Added CAS pattern for pool installation (Step 3)**: Prevents race condition where another thread creates a pool via `_get_postgres_pool()` while we're resetting. If another pool exists when we try to install, we close our newly created pool and use the existing one.

5. **Added default-arg binding for `list()` lambda**: Changed to `lambda _cfg=config, _filter=filter, _before=before, _limit=limit: ...` to address reviewer concern about late-binding closure issues.

6. **Added unit tests** (`TestResilientPostgresSaverOOMFix`):
   - `test_connection_lost_error_triggers_pool_reset`
   - `test_ssl_closed_error_triggers_pool_reset`
   - `test_timeout_error_does_not_trigger_pool_reset`
   - `test_inner_factory_recreates_saver_after_pool_reset`
   - `test_sleep_called_after_traceback_cleared`
   - `test_connection_lost_patterns_coverage`
   - `test_no_inner_factory_still_resets_pool`
   - `test_consecutive_connection_lost_triggers_multiple_resets` (new)

## Review & Testing Checklist for Human

- [ ] **CAS pattern correctness**: Verify the new CAS logic in Step 3 of `_reset_postgres_pool()` handles all race scenarios correctly - particularly when multiple threads attempt reset simultaneously
- [ ] **3-step pool reset thread safety**: Verify closing the pool outside the lock while other operations may be borrowing connections doesn't cause issues
- [ ] **Lambda closure correctness**: Verify the default-arg binding in `list()` correctly captures parameters
- [ ] **Inner saver `setup()` idempotency**: The `create_inner_saver()` factory calls `setup()` which runs migrations - verify this is safe to call multiple times (see follow-up issue #3023)
- [ ] **Memory release verification**: Test under actual OOM conditions to verify `traceback.clear_frames()` + `del e` + `gc.collect()` actually prevents memory buildup

**Recommended test plan:**
1. Deploy to staging and trigger connection-lost errors (e.g., by temporarily blocking DB connections)
2. Monitor worker memory during retry storms to verify memory doesn't accumulate
3. Verify checkpoint operations recover successfully after pool reset
4. Confirm the new inner saver is actually used after pool reset (check logs for "Inner saver recreated after pool reset")
5. Test concurrent checkpoint operations during pool reset to verify CAS pattern works

### Notes
- Pre-existing lint warnings (C901 complexity in `reviewer_node` and `publisher_node`) are unrelated to this change
- Unit tests added for control-flow and reference-release properties; memory/OOM regression tests under fault injection are planned as follow-up work
- Follow-up issues created: #3019 (memory regression tests), #3020 (gc.collect performance), #3021 (concurrency tests), #3022 (chaos testing), #3023 (migration idempotency)

---
*This PR was created with assistance from [Devin](https://app.devin.ai/sessions/704acc3d97124d00a7e98394ff2203e1)*
*Requested by: Ryan Chen (@RC918)*