### PR TITLE
docs(runbooks): add checkpoint degradation response runbook

### DIFF
--- a/docs/runbooks/CHECKPOINT_DEGRADATION_RUNBOOK.md
+++ b/docs/runbooks/CHECKPOINT_DEGRADATION_RUNBOOK.md
@@ -289,6 +289,70 @@ all retries exhausted
 
 ---
 
+## False Positives and Edge Cases
+
+### Common False Positives
+
+| Symptom | Why It's Not Degradation | How to Confirm |
+|---------|--------------------------|----------------|
+| Single `checkpoint_degraded` event | Isolated transient error, workflow recovered | Check if subsequent workflows show `persistence_degraded=False` |
+| Low degradation ratio (< 1%) | Normal transient errors, system self-healed | Monitor for 15 minutes, ratio should stay low |
+| `circuit_breaker="opened"` but ratio low | Circuit breaker opened for one workflow, others healthy | Check if new workflows are succeeding |
+
+### Edge Cases
+
+**Q: What happens if I toggle `ENABLE_CHECKPOINT_FAILOVER` while workflows are running?**
+
+A: The flag is read at workflow start time, not per-operation. Changing the environment variable requires a **redeploy/restart** to take effect. In-flight workflows will continue with their original setting.
+
+**Q: Can a degraded workflow "recover" mid-execution if PostgreSQL comes back?**
+
+A: No. Sticky degradation is intentional. Once a workflow enters degraded mode, it stays degraded until completion. This prevents state inconsistency (e.g., Step 1 writes to DB, Step 2 writes to RAM, Step 3 reads from DB and misses Step 2's data).
+
+**Q: What are the side effects of temporarily disabling failover (`ENABLE_CHECKPOINT_FAILOVER=false`)?**
+
+A: Workflows will fail-fast on any checkpoint error instead of degrading. This means:
+- More task failures during DB issues
+- No "soft landing" - workflows crash instead of completing with degraded persistence
+- Use only if degraded mode is causing worse problems (e.g., worker OOM)
+
+**Q: How much memory does MemorySaver use per degraded workflow?**
+
+A: Depends on workflow state size. Monitor worker memory usage during degradation incidents. If memory pressure is high, consider using the kill switch.
+
+---
+
+## Runbook Drift Prevention
+
+This runbook references code artifacts that may change over time. To prevent drift:
+
+**When to Update This Runbook:**
+- When `DegradedPersistenceCheckpointer` class is modified
+- When `TRANSIENT_ERROR_PATTERNS` is updated
+- When event names or log formats change
+- When `ENABLE_CHECKPOINT_FAILOVER` behavior changes
+- When new error patterns are added to failover logic
+
+**Verification Checklist:**
+- [ ] Event names in runbook match code (`checkpoint_degraded`, `persistence_degraded`)
+- [ ] Error patterns in runbook match `TRANSIENT_ERROR_PATTERNS` frozenset
+- [ ] Log message prefixes match code (`CHECKPOINT DEGRADED:`, `ResilientPostgresSaver:`)
+- [ ] Feature flag name matches settings (`ENABLE_CHECKPOINT_FAILOVER`)
+
+**Quick Verification Commands:**
+```bash
+# Verify event name exists in code
+grep -r "checkpoint_degraded" handoff/20250928/40_App/orchestrator/
+
+# Verify error patterns match
+grep -A 15 "TRANSIENT_ERROR_PATTERNS = frozenset" handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+
+# Verify feature flag exists
+grep -r "enable_checkpoint_failover" common/config/settings.py
+```
+
+---
+
 ## Post-Incident Review
 
 After resolving a degradation incident:
@@ -326,6 +390,9 @@ If you cannot resolve the issue:
 
 ### Log Search Queries
 
+> **Note**: Different log platforms (Render, Sentry, ELK) may index `extra` fields differently. Use both structured field queries AND message text searches as fallback.
+
+**Structured Field Queries** (if your log platform indexes `extra` fields):
 ```bash
 # Find degradation events
 event="checkpoint_degraded"
@@ -340,6 +407,21 @@ circuit_breaker="opened"
 operation="resilient_postgres_saver" AND level=ERROR
 ```
 
+**Message Text Searches** (fallback for platforms that don't index `extra`):
+```bash
+# Find degradation events (fixed message prefix)
+"CHECKPOINT DEGRADED:"
+
+# Find degraded completions
+"persistence_degraded=True"
+
+# Find circuit breaker events
+"Circuit breaker OPENED"
+
+# Find ResilientPostgresSaver errors
+"ResilientPostgresSaver:" AND "error"
+```
+
 ### Key URLs
 
 - **Render Dashboard**: https://dashboard.render.com
@@ -349,9 +431,27 @@ operation="resilient_postgres_saver" AND level=ERROR
 
 ### Related Code
 
-- `DegradedPersistenceCheckpointer`: `langgraph_orchestrator.py:989-1203`
-- `ResilientPostgresSaver`: `langgraph_orchestrator.py:594-986`
-- Feature flag: `ENABLE_CHECKPOINT_FAILOVER` in `settings.py`
+> **Note**: Line numbers are approximate and may drift as code evolves. Use class/function names for searching.
+
+| Component | Location | Search Term |
+|-----------|----------|-------------|
+| `DegradedPersistenceCheckpointer` | `langgraph_orchestrator.py` | `class DegradedPersistenceCheckpointer` |
+| `ResilientPostgresSaver` | `langgraph_orchestrator.py` | `class ResilientPostgresSaver` |
+| `_maybe_failover()` | `langgraph_orchestrator.py` | `def _maybe_failover` |
+| `TRANSIENT_ERROR_PATTERNS` | `langgraph_orchestrator.py` | `TRANSIENT_ERROR_PATTERNS = frozenset` |
+| Feature flag | `common/config/settings.py` | `enable_checkpoint_failover` |
+
+**Quick Code Search:**
+```bash
+# Find DegradedPersistenceCheckpointer class
+grep -n "class DegradedPersistenceCheckpointer" handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+
+# Find failover logic
+grep -n "def _maybe_failover" handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+
+# Find transient error patterns
+grep -n "TRANSIENT_ERROR_PATTERNS" handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+```
 
 ---
 
@@ -378,4 +478,5 @@ After executing this runbook, record the results below:
 
 | Version | Date | Change | Author |
 |---------|------|--------|--------|
+| v1.1 | 2025-12-26 | Address code review feedback: replace line numbers with class/function names, add fallback message searches, add false positives/edge cases section, add drift prevention section | Engineering Team |
 | v1.0 | 2025-12-26 | Initial runbook created for DegradedPersistenceCheckpointer | Engineering Team |


### PR DESCRIPTION
# docs(runbooks): add checkpoint degradation response runbook

## Summary

Adds a comprehensive runbook for detecting, triaging, and resolving checkpoint degradation incidents in the LangGraph orchestrator. This documents the operational procedures for the `DegradedPersistenceCheckpointer` feature introduced in PR #3018.

Closes #3026

**Key sections:**
- Detection signals (`checkpoint_degraded`, `persistence_degraded` events)
- Triage matrix based on degradation ratio and PostgreSQL status
- Step-by-step response procedures with checkboxes
- Emergency kill switch documentation (`ENABLE_CHECKPOINT_FAILOVER`)
- Configuration reference and transient error patterns

**Blueprint Alignment:**
- Flow Controller v3: Fail-Fast Recovery (Section 3.2)
- Telemetry v2: Observable degradation events (Section 5.2)

## Updates Since Last Revision (v1.1)

Addressed code review feedback from Gemini Code Assist and MorningAI Reviewer Agent:

1. **Replaced line number references with class/function names** - Added a table with component names, locations, and grep search terms to prevent drift
2. **Added fallback message text searches** - Log queries now include both structured field queries AND message text searches (e.g., `"CHECKPOINT DEGRADED:"`) for platforms that don't index `extra` fields
3. **Added False Positives and Edge Cases section** - Documents common false positives and FAQ-style edge cases (flag toggle timing, sticky degradation behavior, kill switch side effects)
4. **Added Runbook Drift Prevention section** - Documents when to update the runbook and provides verification commands

**Follow-up issues created:**
- #3037: ci(runbooks): add meta-check to verify runbook event names match code
- #3038: docs(runbooks): add drill exercise process for checkpoint degradation runbook

## Review & Testing Checklist for Human

- [ ] **Verify fallback message searches match actual log format**: Check that `"CHECKPOINT DEGRADED:"` prefix matches the log output in `langgraph_orchestrator.py` (search for `def _maybe_failover`)
- [ ] **Verify edge cases section is accurate**: Confirm that `ENABLE_CHECKPOINT_FAILOVER` is read at workflow start (not per-operation) by checking `run_orchestrator` function
- [ ] **Verify drift prevention commands work**: Run the verification commands in the "Runbook Drift Prevention" section to confirm they find the expected code artifacts

**Recommended test plan:**
1. Run the drift prevention verification commands to confirm they work
2. Trigger a checkpoint degradation in staging (e.g., temporarily block DB connection)
3. Follow the runbook detection steps using both structured queries AND fallback message searches
4. Verify the recovery steps restore normal operation

### Notes

- This is documentation-only, no code changes
- Line number references have been replaced with class/function names and grep search terms
- The runbook follows the same format as existing runbooks (`canary_rollback.md`, `TOLGEE_CORRUPTION_RUNBOOK.md`)

**Link to Devin run**: https://app.devin.ai/sessions/4609907defbd48af8dd21f9b27b8dbb0
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918