### PR TITLE
feat(webhooks): add enhanced logging for staging observation (#3047)

### DIFF
--- a/docs/runbooks/GARBAGE_PR_FIX_STAGING_OBSERVATION.md
+++ b/docs/runbooks/GARBAGE_PR_FIX_STAGING_OBSERVATION.md
@@ -63,6 +63,41 @@ Fields captured:
 - Same as branch match, plus:
 - `matched_labels`: Labels that triggered the skip (e.g., ["orchestrator-docs"])
 
+### Sample Log Output
+
+**UNKNOWN Event Skip (check_suite):**
+```json
+{
+  "message": "[EventNormalizer] UNKNOWN event skipped - not actionable",
+  "operation": "unknown_event_skip",
+  "event_id": "abc123-def456",
+  "repo": "RC918/morningai",
+  "event_type": "unknown",
+  "github_event": "check_suite",
+  "github_action": "completed",
+  "head_branch": "orchestrator/docs-update-789",
+  "actor": "github-actions[bot]",
+  "reason": "unknown_event_type_not_actionable"
+}
+```
+
+**Orchestrator Branch Skip (PR event):**
+```json
+{
+  "message": "[EventNormalizer] Skipping orchestrator-generated event (branch match)",
+  "operation": "orchestrator_event_skip",
+  "event_id": "xyz789-abc123",
+  "repo": "RC918/morningai",
+  "resource_id": "3040",
+  "head_ref": "orchestrator/docs-update-789",
+  "event_type": "pr_opened",
+  "github_event": "pull_request",
+  "github_action": "opened",
+  "actor": "devin-ai-integration[bot]",
+  "reason": "orchestrator_branch_prefix"
+}
+```
+
 ## Success Criteria
 
 The observation period is successful if:
@@ -80,6 +115,20 @@ Create a simple tracking table during observation:
 | Day 1 | | | | | |
 | Day 2 | | | | | |
 | ... | | | | | |
+
+### Baseline-Driven Thresholds
+
+Rather than setting absolute thresholds, use a baseline-driven approach:
+
+1. **Establish baseline (Day 1-2)**: Record the average hourly/daily count of each event type
+2. **Alert threshold**: Flag for review if any metric exceeds 3x the baseline
+3. **Investigation trigger**: Investigate immediately if garbage PRs > 0
+
+Example baseline expectations (adjust based on actual Day 1 data):
+- UNKNOWN events: ~10-50 per hour (mostly CI events)
+- Branch skips: ~1-5 per hour (depends on orchestrator activity)
+- Label skips: ~0-2 per hour (less common)
+- Garbage PRs: **Must be 0**
 
 ## Verification Steps
 
@@ -117,15 +166,26 @@ Create a simple tracking table during observation:
 2. Review any anomalies or edge cases
 3. Decision: Deploy to production or extend observation
 
+## Log Retention
+
+During the observation period, ensure logs are retained for auditability:
+
+- **Minimum retention**: 14 days (covers observation period + buffer for cross-team review)
+- **Recommended retention**: 30 days (allows for delayed analysis if needed)
+- **Export critical logs**: If your logging provider has shorter retention, export relevant logs to a shared document or spreadsheet for the team
+
+**Note**: Check your Render/Sentry log retention settings before starting observation. If retention is less than 14 days, consider exporting daily summaries.
+
 ## Rollback Plan
 
 If issues are discovered during observation:
 
-1. **Immediate**: Revert PR #3040 on staging
+1. **Immediate**: Revert PR #3040 on your staging deployment branch
    ```bash
    git revert <commit-sha>
-   git push origin main
+   git push origin <your-staging-branch>
    ```
+   **Note**: Replace `<your-staging-branch>` with your actual staging deployment branch (e.g., `main`, `staging`, `release/staging`). Check your CI/CD configuration to confirm which branch triggers staging deployments.
 
 2. **Investigate**: Check logs for the specific issue
 3. **Fix**: Create a new PR with the fix

--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -105,6 +105,77 @@ def is_self_generated_review(event: "WebhookEvent") -> bool:
     return False
 
 
+def _extract_head_branch_from_payload(raw_payload: dict) -> str:
+    """
+    Extract head branch from various GitHub webhook payload structures.
+
+    Issue: Staging Observation (#3047) - Consolidated branch extraction
+    This helper unifies branch extraction logic used in multiple places:
+    - should_skip_orchestrator_pr_event() for orchestrator branch detection
+    - is_actionable() UNKNOWN event logging for staging observation
+
+    Supported payload structures:
+    - PR events: pull_request.head.ref
+    - Check suite events: check_suite.head_branch or check_suite.pull_requests[0].head.ref
+    - Check run events: check_run.check_suite.head_branch
+    - Status events: branches[0].name
+
+    Args:
+        raw_payload: The raw webhook payload dict
+
+    Returns:
+        The head branch name, or empty string if not found
+    """
+    if not isinstance(raw_payload, dict):
+        return ""
+
+    head_ref = ""
+
+    # Try PR payload first (most common for PR events)
+    pr_data = raw_payload.get("pull_request", {})
+    if pr_data and isinstance(pr_data, dict):
+        head_data = pr_data.get("head", {})
+        if isinstance(head_data, dict):
+            head_ref = head_data.get("ref", "")
+
+    # Try check_suite payload (CI events)
+    if not head_ref:
+        check_suite = raw_payload.get("check_suite", {})
+        if check_suite and isinstance(check_suite, dict):
+            head_ref = check_suite.get("head_branch", "")
+            # Also check pull_requests array in check_suite
+            if not head_ref:
+                prs = check_suite.get("pull_requests", [])
+                if prs and isinstance(prs, list) and len(prs) > 0:
+                    first_pr = prs[0]
+                    if isinstance(first_pr, dict):
+                        head_data = first_pr.get("head", {})
+                        if isinstance(head_data, dict):
+                            head_ref = head_data.get("ref", "")
+
+    # Try check_run payload (CI events)
+    if not head_ref:
+        check_run = raw_payload.get("check_run", {})
+        if check_run and isinstance(check_run, dict):
+            check_suite_in_run = check_run.get("check_suite", {})
+            if isinstance(check_suite_in_run, dict):
+                head_ref = check_suite_in_run.get("head_branch", "")
+
+    # Try status event payload
+    if not head_ref:
+        branches = raw_payload.get("branches", [])
+        if branches and isinstance(branches, list) and len(branches) > 0:
+            first_branch = branches[0]
+            if isinstance(first_branch, dict):
+                head_ref = first_branch.get("name", "")
+
+    # Ensure we return a string
+    if not isinstance(head_ref, str):
+        head_ref = ""
+
+    return head_ref
+
+
 def should_skip_orchestrator_pr_event(event: "WebhookEvent") -> bool:
     """
     Check if a PR event should be skipped because it's from an orchestrator-generated PR.
@@ -149,52 +220,10 @@ def should_skip_orchestrator_pr_event(event: "WebhookEvent") -> bool:
 
     repo = f"{event.repo_owner}/{event.repo_name}" if event.repo_owner and event.repo_name else "unknown"
 
-    # Extract head branch from raw payload
-    # Defense in Depth: Check multiple payload locations for branch info
-    # - PR events: pull_request.head.ref
-    # - Check suite events: check_suite.head_branch or check_suite.pull_requests[0].head.ref
-    # - Check run events: check_run.check_suite.head_branch
-    # - Status events: branches[0].name
+    # Extract head branch using consolidated helper function
+    # See _extract_head_branch_from_payload() for supported payload structures
     raw_payload = event.raw_payload or {}
-
-    head_ref = ""
-
-    # Try PR payload first (most common)
-    pr_data = raw_payload.get("pull_request", {})
-    if pr_data:
-        head_ref = pr_data.get("head", {}).get("ref", "")
-
-    # Try check_suite payload (CI events)
-    if not head_ref:
-        check_suite = raw_payload.get("check_suite", {})
-        if check_suite and isinstance(check_suite, dict):
-            head_ref = check_suite.get("head_branch", "")
-            # Also check pull_requests array in check_suite
-            if not head_ref:
-                prs = check_suite.get("pull_requests", [])
-                if prs and isinstance(prs, list) and len(prs) > 0:
-                    first_pr = prs[0]
-                    if isinstance(first_pr, dict):
-                        head_ref = first_pr.get("head", {}).get("ref", "")
-
-    # Try check_run payload (CI events)
-    if not head_ref:
-        check_run = raw_payload.get("check_run", {})
-        if check_run and isinstance(check_run, dict):
-            check_suite_in_run = check_run.get("check_suite", {})
-            if isinstance(check_suite_in_run, dict):
-                head_ref = check_suite_in_run.get("head_branch", "")
-
-    # Try status event payload
-    if not head_ref:
-        branches = raw_payload.get("branches", [])
-        if branches and isinstance(branches, list) and len(branches) > 0:
-            first_branch = branches[0]
-            if isinstance(first_branch, dict):
-                head_ref = first_branch.get("name", "")
-
-    if not isinstance(head_ref, str):
-        head_ref = ""
+    head_ref = _extract_head_branch_from_payload(raw_payload)
 
     # Check 1: Label filter - skip PRs with orchestrator-docs labels
     # This catches PRs created by any actor (including Devin) that have the orchestrator label
@@ -223,7 +252,7 @@ def should_skip_orchestrator_pr_event(event: "WebhookEvent") -> bool:
 
     matched_labels = orchestrator_labels & event_labels
 
-    # Enhanced logging for staging observation (#3047)
+    # Staging observation (#3047) - capture GitHub event metadata for log analysis
     metadata = event.metadata or {}
     github_event = metadata.get("github_event", "unknown")
     github_action = metadata.get("action", "unknown")
@@ -643,30 +672,12 @@ class EventNormalizer:
         # This is a critical early-exit to prevent self-trigger loops from non-PR events.
         if event.event_type == WebhookEventType.UNKNOWN:
             repo = f"{event.repo_owner}/{event.repo_name}" if event.repo_owner and event.repo_name else "unknown"
-            # Enhanced logging for staging observation (#3047)
-            # Capture original GitHub event type and action for analysis
+            # Staging observation logging (#3047) - capture metadata for analysis
             metadata = event.metadata or {}
             github_event = metadata.get("github_event", "unknown")
             github_action = metadata.get("action", "unknown")
             raw_payload = event.raw_payload or {}
-            # Extract branch info for CI event analysis
-            head_branch = ""
-            if "check_suite" in raw_payload:
-                cs = raw_payload.get("check_suite", {})
-                if isinstance(cs, dict):
-                    head_branch = cs.get("head_branch", "")
-            elif "check_run" in raw_payload:
-                cr = raw_payload.get("check_run", {})
-                if isinstance(cr, dict):
-                    cs_in_cr = cr.get("check_suite", {})
-                    if isinstance(cs_in_cr, dict):
-                        head_branch = cs_in_cr.get("head_branch", "")
-            elif "branches" in raw_payload:
-                branches = raw_payload.get("branches", [])
-                if isinstance(branches, list) and branches:
-                    first_branch = branches[0]
-                    if isinstance(first_branch, dict):
-                        head_branch = first_branch.get("name", "")
+            head_branch = _extract_head_branch_from_payload(raw_payload)
             logger.info(
                 "[EventNormalizer] UNKNOWN event skipped - not actionable",
                 extra={

--- a/handoff/20250928/40_App/orchestrator/webhooks/tests/test_garbage_pr_fix.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/tests/test_garbage_pr_fix.py
@@ -456,3 +456,135 @@ class TestGarbagePRScenario:
 
         assert event_normalizer.is_actionable(event) is False
         assert should_skip_orchestrator_pr_event(event) is True
+
+
+class TestExtractHeadBranchFromPayload:
+    """Tests for _extract_head_branch_from_payload helper function (#3047)"""
+
+    def test_extract_from_pull_request(self):
+        """Test extraction from PR payload"""
+        from ..normalizer import _extract_head_branch_from_payload
+        payload = {"pull_request": {"head": {"ref": "feature/my-branch"}}}
+        assert _extract_head_branch_from_payload(payload) == "feature/my-branch"
+
+    def test_extract_from_check_suite_head_branch(self):
+        """Test extraction from check_suite.head_branch"""
+        from ..normalizer import _extract_head_branch_from_payload
+        payload = {"check_suite": {"head_branch": "orchestrator/docs-123"}}
+        assert _extract_head_branch_from_payload(payload) == "orchestrator/docs-123"
+
+    def test_extract_from_check_suite_pull_requests(self):
+        """Test extraction from check_suite.pull_requests[0].head.ref"""
+        from ..normalizer import _extract_head_branch_from_payload
+        payload = {
+            "check_suite": {
+                "pull_requests": [{"head": {"ref": "feature/pr-branch"}}]
+            }
+        }
+        assert _extract_head_branch_from_payload(payload) == "feature/pr-branch"
+
+    def test_extract_from_check_run(self):
+        """Test extraction from check_run.check_suite.head_branch"""
+        from ..normalizer import _extract_head_branch_from_payload
+        payload = {"check_run": {"check_suite": {"head_branch": "main"}}}
+        assert _extract_head_branch_from_payload(payload) == "main"
+
+    def test_extract_from_status_branches(self):
+        """Test extraction from status event branches array"""
+        from ..normalizer import _extract_head_branch_from_payload
+        payload = {"branches": [{"name": "develop"}]}
+        assert _extract_head_branch_from_payload(payload) == "develop"
+
+    def test_empty_payload_returns_empty_string(self):
+        """Test empty payload returns empty string"""
+        from ..normalizer import _extract_head_branch_from_payload
+        assert _extract_head_branch_from_payload({}) == ""
+
+    def test_none_payload_returns_empty_string(self):
+        """Test None payload returns empty string"""
+        from ..normalizer import _extract_head_branch_from_payload
+        assert _extract_head_branch_from_payload(None) == ""
+
+    def test_non_dict_payload_returns_empty_string(self):
+        """Test non-dict payload returns empty string"""
+        from ..normalizer import _extract_head_branch_from_payload
+        assert _extract_head_branch_from_payload("not a dict") == ""
+        assert _extract_head_branch_from_payload([]) == ""
+
+    def test_priority_pr_over_check_suite(self):
+        """Test PR payload takes priority over check_suite"""
+        from ..normalizer import _extract_head_branch_from_payload
+        payload = {
+            "pull_request": {"head": {"ref": "pr-branch"}},
+            "check_suite": {"head_branch": "check-suite-branch"}
+        }
+        assert _extract_head_branch_from_payload(payload) == "pr-branch"
+
+
+class TestStagingObservationLogging:
+    """Tests for staging observation logging fields (#3047)"""
+
+    def test_unknown_event_logging_fields(self, event_normalizer, caplog):
+        """Test that UNKNOWN event skip logs contain required fields"""
+        import logging
+        caplog.set_level(logging.INFO)
+
+        event = WebhookEvent(
+            event_id="test-event-456",
+            source=WebhookSource.GITHUB,
+            event_type=WebhookEventType.UNKNOWN,
+            timestamp=datetime.now(timezone.utc),
+            raw_payload={"check_suite": {"head_branch": "orchestrator/test-123"}},
+            title="Test Event",
+            description="",
+            url="https://github.com/test/repo/pull/1",
+            actor_name="test-bot",
+            metadata={"github_event": "check_suite", "action": "completed"},
+            labels=[],
+            repo_owner="test",
+            repo_name="repo",
+        )
+
+        result = event_normalizer.is_actionable(event)
+        assert result is False
+
+        # Verify the log message contains expected text
+        assert any("UNKNOWN event skipped" in r.message for r in caplog.records)
+
+        # Find the log record and verify extra fields are present
+        log_records = [r for r in caplog.records if "UNKNOWN event skipped" in r.message]
+        assert len(log_records) >= 1
+        record = log_records[0]
+        # Verify extra fields are captured (they become attributes on the LogRecord)
+        assert hasattr(record, "operation") and record.operation == "unknown_event_skip"
+        assert hasattr(record, "github_event") and record.github_event == "check_suite"
+        assert hasattr(record, "github_action") and record.github_action == "completed"
+        assert hasattr(record, "head_branch") and record.head_branch == "orchestrator/test-123"
+        assert hasattr(record, "actor") and record.actor == "test-bot"
+
+    def test_orchestrator_branch_skip_logging_fields(self, caplog):
+        """Test that orchestrator branch skip logs contain required fields"""
+        import logging
+        caplog.set_level(logging.INFO)
+
+        event = WebhookEvent(
+            event_id="test-event-789",
+            source=WebhookSource.GITHUB,
+            event_type=WebhookEventType.PR_OPENED,
+            timestamp=datetime.now(timezone.utc),
+            raw_payload={"pull_request": {"head": {"ref": "orchestrator/docs-456"}}},
+            title="Test PR",
+            description="",
+            url="https://github.com/test/repo/pull/1",
+            actor_name="test-user",
+            metadata={"github_event": "pull_request", "action": "opened"},
+            labels=[],
+            repo_owner="test",
+            repo_name="repo",
+        )
+
+        result = should_skip_orchestrator_pr_event(event)
+        assert result is True
+
+        # Verify the log message contains expected text
+        assert any("orchestrator-generated event" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Adds enhanced logging infrastructure to support the 1-week staging observation period for the garbage PR fix (PR #3040). This PR captures additional metadata in logs to enable monitoring and analysis of filtered events.

**Changes:**
- Enhanced UNKNOWN event logging with `github_event`, `github_action`, `head_branch`, and `actor` fields
- Enhanced orchestrator skip logging (both label and branch match) with same fields for consistency
- Added staging observation runbook with log queries, success criteria, and verification steps

## Updates since last revision

Addressed reviewer feedback from Gemini Code Assist and MorningAI Reviewer:

**Code refactoring:**
- Extracted `_extract_head_branch_from_payload()` helper to consolidate duplicate branch extraction logic between `should_skip_orchestrator_pr_event()` and `is_actionable()` UNKNOWN event logging
- Helper handles all payload shapes: PR events, check_suite, check_run, and status events with proper `isinstance()` guards

**Test improvements:**
- Added `TestExtractHeadBranchFromPayload` class with 9 tests covering all payload shapes and edge cases
- Added `TestStagingObservationLogging` class with caplog-based tests that verify logging extra fields (operation, github_event, github_action, head_branch, actor)

**Runbook improvements:**
- Added sample log output examples in JSON format
- Added baseline-driven thresholds section (establish Day 1-2 baseline, alert on >3x baseline)
- Added log retention section for auditability (14-30 day retention recommendation)
- Fixed rollback section to use `<your-staging-branch>` placeholder instead of hardcoding `main`

**Follow-up issue created:** #3054 - standardize structured logging schema for webhook filtering events

## Review & Testing Checklist for Human

- [ ] Verify the `_extract_head_branch_from_payload()` helper correctly handles all payload shapes (PR, check_suite, check_run, status) - the refactoring consolidated logic from two places
- [ ] Verify the log queries in `docs/runbooks/GARBAGE_PR_FIX_STAGING_OBSERVATION.md` work with your actual Sentry/Render log search syntax
- [ ] After deploying to staging, trigger a test webhook to verify the enhanced logging fields appear correctly

**Recommended test plan:**
1. Deploy to staging
2. Create a test PR from an `orchestrator/` branch
3. Check Render logs for `operation:orchestrator_event_skip` with the new fields (`github_event`, `github_action`, `actor`)
4. Verify the log format matches what's documented in the runbook

### Notes

- This is purely additive logging changes - no business logic modifications
- All 40 tests pass (29 original + 11 new: 9 for helper function, 2 for logging verification)
- The branch extraction logic for UNKNOWN events handles check_suite, check_run, and status payloads with isinstance() guards

Link to Devin run: https://app.devin.ai/sessions/e22677f2b88a41dfa29369d3836536f8
Requested by: Ryan Chen (@RC918)