### PR TITLE
docs: add diagnostic test document for 422 debugging

### DIFF
--- a/docs/runbooks/DIAGNOSTIC_TEST.md
+++ b/docs/runbooks/DIAGNOSTIC_TEST.md
@@ -1,0 +1,25 @@
+# Diagnostic Test Document
+
+This document is created to trigger the MorningAI Reviewer Agent and capture diagnostic logs for 422 debugging.
+
+## Purpose
+
+Test the diagnostic logging added in PR #3056 to investigate why inline comments fail with 422 errors in production.
+
+## Expected Behavior
+
+When this PR is opened, the MorningAI Reviewer Agent should:
+1. Generate a code review using the LLM (Qwen-Plus)
+2. Log diagnostic information at 4 key points:
+   - `[Reviewer] DIAGNOSTIC: LLM raw comment output`
+   - `[Publisher] DIAGNOSTIC: Diff coverage for validation`
+   - `[Publisher] DIAGNOSTIC: Comment X validation check`
+   - `[GitHub] DIAGNOSTIC: Final payload`
+
+## Investigation
+
+We are investigating why:
+- Staging (OpenAI model) successfully posts inline comments
+- Production (Qwen model) encounters 422 "Line could not be resolved" errors
+
+Hypothesis: Model variance in line number semantics between OpenAI and Qwen.


### PR DESCRIPTION
## Summary

This PR adds a test documentation file to trigger the MorningAI Reviewer Agent and capture diagnostic logs for investigating the 422 "Line could not be resolved" error in production.

**Context**: PR #3056 added diagnostic logging at 4 key points in the review pipeline. However, previous attempts to trigger the diagnostic logs failed because:
1. PR #3056 was already merged when we tried to trigger review
2. PR #3057 used an `orchestrator/` branch prefix which is intentionally filtered by the normalizer to prevent self-trigger loops

This PR uses a `devin/` branch prefix to bypass the orchestrator filter and successfully trigger the MorningAI Reviewer Agent.

## Review & Testing Checklist for Human

- [ ] After this PR is opened, check Render logs (`morningai-agent-worker`) for diagnostic log entries:
  - `[Reviewer] DIAGNOSTIC:` - LLM raw comment output
  - `[Publisher] DIAGNOSTIC:` - Validation decisions
  - `[GitHub] DIAGNOSTIC:` - Final payload structure
- [ ] Verify the diagnostic logs capture the `llm_provider` field to confirm which model (Qwen vs OpenAI) was used

### Notes

This is a test PR specifically created to trigger diagnostic logging. The document itself explains the investigation into why staging (OpenAI) successfully posts inline comments while production (Qwen) encounters 422 errors.

**Link to Devin run**: https://app.devin.ai/sessions/704acc3d97124d00a7e98394ff2203e1
**Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918