### PR TITLE
feat(webhooks): add smart PR filtering to reduce docs PR noise

### DIFF
--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -368,7 +368,8 @@ SKIP_FILE_PATTERNS = {
         ".flake8",
         "pyproject.toml",
         "setup.cfg",
-        "setup.py",
+        # NOTE: setup.py intentionally NOT included - it can contain significant
+        # executable logic (custom build commands, entry points, etc.)
         "makefile",
         "dockerfile",
         "docker-compose.yml",
@@ -420,7 +421,9 @@ def _path_is_non_code(path: str) -> bool:
     if not path:
         return True  # Empty/invalid path treated as non-code for safety (fail-open)
 
-    path_lower = path.lower()
+    # Normalize path separators for cross-platform robustness
+    # GitHub API always uses forward slashes, but this makes the helper reusable
+    path_lower = path.lower().replace("\\", "/")
     filename = path_lower.split("/")[-1]
 
     # Check exact filename matches
@@ -1033,7 +1036,7 @@ class EventNormalizer:
         # - Test files (tests/*, *_test.py, *.spec.ts)
         # - CI/CD files (.github/*)
         # Or PRs with non-actionable title prefixes (chore:, ci:, test:, docs:, style:)
-        should_skip, skip_reason, skip_details = should_skip_pr_by_smart_filters(event)
+        should_skip, _, _ = should_skip_pr_by_smart_filters(event)
         if should_skip:
             return False
 

--- a/handoff/20250928/40_App/orchestrator/webhooks/tests/test_garbage_pr_fix.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/tests/test_garbage_pr_fix.py
@@ -758,6 +758,21 @@ class TestPathIsNonCode:
         assert _path_is_non_code("") is True
         assert _path_is_non_code(None) is True
 
+    def test_setup_py_is_code(self):
+        """Test that setup.py is treated as code (can contain executable logic)"""
+        # setup.py can contain significant executable logic like custom build commands,
+        # dynamic dependency resolution, or registration of entry points
+        assert _path_is_non_code("setup.py") is False
+        assert _path_is_non_code("src/setup.py") is False
+
+    def test_backslash_paths_normalized(self):
+        """Test that Windows-style backslash paths are normalized correctly"""
+        # GitHub API always uses forward slashes, but this makes the helper reusable
+        assert _path_is_non_code("docs\\readme.md") is True
+        assert _path_is_non_code("tests\\test_main.py") is True
+        assert _path_is_non_code("src\\main.py") is False
+        assert _path_is_non_code("path\\to\\component.tsx") is False
+
 
 class TestShouldSkipByPaths:
     """Tests for _should_skip_by_paths() aggregate path filter"""


### PR DESCRIPTION
## Summary

Adds a content-based filtering layer to prevent docs PR generation for PRs that don't warrant documentation updates. This addresses the recurring "garbage PR" issue where the orchestrator creates docs PRs for every PR event, including trivial changes like dependency updates or CI fixes.

**Filter Pipeline:**
1. **Semantic title filter** (cheap, runs first) - Skips PRs with `chore:`, `ci:`, `test:`, `docs:`, `style:`, `build:` prefixes
2. **File path filter** (requires API call) - Skips PRs that only modify config/docs/tests/CI files

The filter is integrated into `is_actionable()` after the existing orchestrator self-loop prevention checks. It only applies to `PR_OPENED` and `PR_MERGED` events.

**Key design decisions:**
- Fails open on API errors (doesn't skip if we can't fetch file list)
- Early exit optimization: stops checking files as soon as one code file is found
- Returns full file list on early exit for debugging context
- Comprehensive file pattern matching for config, docs, tests, and CI files

## Updates since last revision

Addressed gemini-code-assist review suggestions:
- **Removed `setup.py` from SKIP_FILE_PATTERNS** - setup.py can contain significant executable logic (custom build commands, entry points, etc.) and should be treated as code
- **Added path normalization** for backslash paths in `_path_is_non_code()` for cross-platform robustness
- **Replaced unused variables** `skip_reason`/`skip_details` with `_` placeholders for clarity
- Added 2 new tests for setup.py and backslash path handling (85 tests total)

Created follow-up issues for deferred suggestions:
- #3063 - Expand SKIP_TITLE_PREFIXES and SKIP_FILE_PATTERNS based on observed patterns
- #3064 - Add monitoring/alerting for smart filter API errors
- #3065 - Create periodic audit runbook for smart PR filtering

## Review & Testing Checklist for Human

- [ ] **Verify setup.py behavior change**: PRs that only modify `setup.py` will now trigger docs PR generation. Confirm this is desired behavior.
- [ ] **Verify file pattern completeness**: Review `SKIP_FILE_PATTERNS` dict - are there important file types being incorrectly classified as "non-code"?
- [ ] **Test in staging**: After merge, monitor staging logs for `pr_event_skip_semantic_title` and `pr_event_skip_file_paths_only` operations to verify the filter is working correctly and not causing false positives.

**Recommended test plan:**
1. Create a test PR with title `chore: test filtering` → should NOT trigger docs PR
2. Create a test PR with title `feat: test feature` that only modifies `.md` files → should NOT trigger docs PR  
3. Create a test PR with title `feat: test feature` that modifies `.py` files → SHOULD trigger docs PR
4. Create a test PR that only modifies `setup.py` → SHOULD trigger docs PR (new behavior)

### Notes
- 85 tests pass (45 new tests for smart filtering)
- Pre-existing C901 complexity warnings in `normalizer.py` are not addressed (out of scope)
- Link to Devin run: https://app.devin.ai/sessions/e22677f2b88a41dfa29369d3836536f8
- Requested by: Ryan Chen (@RC918)