### PR TITLE
fix(config): change value_gate_dry_run default to False (Secure by Default)

### DIFF
--- a/common/config/settings.py
+++ b/common/config/settings.py
@@ -807,7 +807,7 @@ class Settings(BaseSettings):
     value_gate_dry_run: bool = Field(
         default=False,
         alias="VALUE_GATE_DRY_RUN",
-        description="Log-only mode for Value Gate. When True, logs what would be blocked but allows PR creation. Default is False (Secure by Default - gate is active in production)."
+        description="Log-only mode for Value Gate. When True, logs what would be blocked but allows PR creation. Default changed from True to False (Dec 2025) for Secure by Default. Set VALUE_GATE_DRY_RUN=true to restore old behavior."
     )
 
     # PR Deduplication Settings (Memory v2 Short-term)


### PR DESCRIPTION
## Summary

Changes the default value of `value_gate_dry_run` from `True` to `False`, implementing the "Secure by Default" principle for the Value Gate safety mechanism.

**Before:** Value Gate only logged what would be blocked but allowed all PR creation (dry-run mode)
**After:** Value Gate actively blocks low-significance PRs by default

This change was requested as part of the garbage PR prevention initiative. The Value Gate scoring system assigns DOCS-type changes a score of 20, which is below the default threshold of 30, meaning most trivial documentation PRs will now be blocked.

### Updates since last revision

Added backward compatibility documentation to the field description:
- Explicitly notes the default change date (Dec 2025)
- Provides rollback instructions: `VALUE_GATE_DRY_RUN=true` to restore old behavior

## Review & Testing Checklist for Human

- [ ] Confirm this behavioral change is acceptable: new environments will have Value Gate active by default (blocking mode, not logging mode)
- [ ] Verify production already has `VALUE_GATE_DRY_RUN=false` set in Render Environment Groups (this was set via API before this PR)
- [ ] Consider whether any staging/dev environments need explicit `VALUE_GATE_DRY_RUN=true` to maintain dry-run behavior

### Notes

**Trade-off accepted by CTO:** Documentation update frequency may temporarily decrease significantly. This is intentional - the goal is to stop garbage PR flooding. A future Batch Digest feature (P2 backlog, tracked in Issue #3087) will aggregate blocked changes.

**Production status:** The environment variable was already set to `false` in the "Commonly used" Render Environment Group before this PR was created.

**Rollback:** If issues arise, set `VALUE_GATE_DRY_RUN=true` in the environment to restore previous behavior.

---
Link to Devin run: https://app.devin.ai/sessions/199f2f07612d42fd88f6b030768a3247
Requested by: Ryan Chen (@RC918)