### PR TITLE
feat(diagnostic): add format_commit_id_for_display function (test PR for commit pinning verification)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/diagnostic_helper.py
+++ b/handoff/20250928/40_App/orchestrator/diagnostic_helper.py
@@ -41,6 +41,33 @@ def _safe_serialize(obj: Any) -> Any:
     return str(obj)
 
 
+def format_commit_id_for_display(commit_id: Optional[str], max_length: int = 8) -> str:
+    """
+    Format a commit ID for display in logs and diagnostics.
+
+    This function safely truncates a commit SHA for human-readable display
+    while preserving enough characters for identification.
+
+    Args:
+        commit_id: Full 40-character commit SHA, or None
+        max_length: Maximum length to display (default: 8 chars)
+
+    Returns:
+        Truncated commit ID or "null" if commit_id is None
+
+    Example:
+        >>> format_commit_id_for_display("abc123def456...")
+        'abc123de'
+        >>> format_commit_id_for_display(None)
+        'null'
+    """
+    if commit_id is None:
+        return "null"
+    if not isinstance(commit_id, str):
+        return "invalid"
+    return commit_id[:max_length] if len(commit_id) > max_length else commit_id
+
+
 def _sample_array(arr: List, max_size: int = MAX_SAMPLE_SIZE) -> Dict:
     """
     Sample an array to reduce size while preserving diagnostic value.


### PR DESCRIPTION
## Summary

**This is a TEST PR - do not merge.** Created to verify that PR #3115's commit pinning fix is working correctly in production.

Adds a simple utility function `format_commit_id_for_display()` to safely truncate commit SHAs for human-readable display in logs. The function handles None values and non-string inputs gracefully.

**Purpose**: Trigger MorningAI Reviewer Agent to generate inline comments so we can verify in Render logs that:
1. `commit_id` is NOT null (was null before PR #3115)
2. `commit_pinning_attempted=True`

## Review & Testing Checklist for Human

- [ ] **DO NOT MERGE** - Close this PR after verification is complete
- [ ] Wait for MorningAI Reviewer Agent to post inline comments
- [ ] Search Render logs for `Final payload for PR #<this_pr_number>`
- [ ] Verify `commit_id` has a valid SHA value (not null)
- [ ] Search for `commit_pinning_attempted` and verify it's `True`

### Test Plan
1. Wait for MorningAI Reviewer Agent to process this PR
2. Check `morningai-agent-worker` logs in Render dashboard
3. Search for diagnostic payload containing this PR number
4. Confirm commit_id fix is working, then close this PR

### Notes
- Link to Devin run: https://app.devin.ai/sessions/704acc3d97124d00a7e98394ff2203e1
- Requested by: Ryan Chen (@RC918)
- Related: PR #3115 (schema fix), PR #3089 (initial commit_id fix), PR #3114 (previous test PR that confirmed root cause)