### PR TITLE
docs: add Phase 6 (B-6 Router Interface) to EPIC B roadmap

### DIFF
--- a/docs/EPIC_B_DIFF_AWARE_REVIEW_ROADMAP.md
+++ b/docs/EPIC_B_DIFF_AWARE_REVIEW_ROADMAP.md
@@ -217,6 +217,8 @@ P6 is "Governance Interface for 2026 Full-Auto PR Lifecycle" - should be on road
 > **Issue**: [#3130](https://github.com/RC918/morningai/issues/3130)
 > **Target**: EPIC C Stage 1 (C-5 Review Routing Pilot)
 
+> **Note**: This is a **design document**. The actual schema and logic implementation will be delivered in the B-6 implementation PR. Until that PR is merged, this document defines the contract; the implementation PR will be the source of truth.
+
 ### Overview
 
 Phase 6 defines the stable interface contract between Reviewer and Router, enabling Flow Controller v3 to make routing decisions based on review results.
@@ -271,17 +273,37 @@ The Router MUST apply the following precedence rules when reading `ReviewOutcome
 
 2. **`blocked` verdict forces escalation**: If `verdict == "blocked"`, Router MUST escalate regardless of other fields. This is reserved for Safety/Compliance blocks.
 
-3. **`schema_validated == False` triggers fallback**: If Pydantic validation failed but a partial object was constructed, Router MUST treat this as equivalent to `unknown`.
+3. **`schema_validated == False` triggers fallback**: If Pydantic validation failed, the producer MUST catch the exception and explicitly construct a minimal dict with `verdict="unknown"` and `schema_validated=False`. Router MUST treat this as equivalent to `unknown`.
 
 4. **Business verdicts follow normal routing**: `approve`, `request_changes`, `comment` are processed according to Router's LLM-driven or rule-based logic.
+
+### Router Behavior Examples
+
+| Scenario | ReviewOutcome | Router Action |
+|----------|---------------|---------------|
+| **Reviewer timeout** | `verdict="unknown", schema_validated=False` | Fallback to rule-based routing (ignore all other fields) |
+| **Safety block detected** | `verdict="blocked", severity="critical"` | Force escalate to human review |
+| **Clean review** | `verdict="approve", severity="low", blocker_count=0` | Proceed to publisher |
+| **Issues found** | `verdict="request_changes", severity="high", blocker_count=3` | Route to fixer or escalate based on blocker_count |
+| **Suggestions only** | `verdict="comment", severity="medium", blocker_count=0` | Proceed to publisher (attach suggestions) |
 
 ### Field Definitions
 
 | Field | Definition | Source |
 |-------|------------|--------|
 | `blocker_count` | Count of `review_comments` where `severity in {"high", "critical"}` | Computed from `state["review_comments"]` |
-| `severity` | Worst severity across all comments: `max(comment.severity for comment in review_comments)` | Computed from `state["review_comments"]` |
+| `severity` | Worst severity across all comments: `max(comment.severity for comment in review_comments)`. If no comments exist, defaults to `"low"`. | Computed from `state["review_comments"]` |
 | `diff_truncated` | Whether the PR diff was truncated due to size limits | From `state["diff_truncated"]` |
+
+**Severity Mapping Note**: The current `reviewer_node` outputs `review_severity` with possible value `"none"` when no issues are found. `ReviewOutcome.severity` does NOT include `"none"` - implementations MUST map `"none"` to `"low"` as the baseline.
+
+### Current Implementation Evidence
+
+As of `main` branch, `reviewer_node` (see `langgraph_orchestrator.py` lines 3583-3588) outputs:
+- `review_comments: List[Dict]` where each comment contains `severity` and `message` fields
+- `review_severity: "none" | "low" | "medium" | "high" | "critical"` (aggregate severity)
+
+This confirms `blocker_count` can be deterministically computed from `state["review_comments"]`.
 
 ### Schema Evolution Strategy
 


### PR DESCRIPTION
## Summary

Adds Phase 6 (B-6 Router Interface) documentation to the EPIC B roadmap. This phase defines the `ReviewOutcome` schema - the stable interface contract between Reviewer and Router that enables EPIC C (Flow Controller v3) to make routing decisions based on review results.

Key additions:
- Added B-6 to the status summary table (marked as In Progress)
- Added detailed Phase 6 section with CTO-approved `ReviewOutcome` Pydantic schema
- Documented verdict semantics (`approve`, `request_changes`, `comment`, `blocked`, `unknown`)
- Documented data quality signals (`diff_truncated`, `schema_validated`, `blocker_count`)
- Added Blueprint alignment table and dependency information

Related: Issue #3130

### Updates since last revision

**Revision 2** - Addressed additional code review feedback:

1. **Design disclaimer**: Added note clarifying this is a design document; the implementation PR will be the source of truth
2. **Router Behavior Examples**: Added table with 5 key scenarios (timeout, blocked, approve, request_changes, comment)
3. **schema_validated semantics**: Clarified that producer MUST catch Pydantic exceptions and explicitly construct minimal dict with `verdict="unknown"`
4. **Severity Mapping Note**: Documented that `reviewer_node` can output `"none"` but `ReviewOutcome.severity` MUST map it to `"low"`
5. **Current Implementation Evidence**: Added reference to `langgraph_orchestrator.py` lines 3583-3588 showing existing `review_comments` structure

**Revision 1** - Initial code review feedback:

1. **Schema versioning**: Added `schema_version: Literal[1] = 1` field and "Schema Evolution Strategy" section for backward-compatible evolution
2. **Router Decision Rules**: Added deterministic precedence rules clarifying that `unknown` verdict overrides all other fields and is ONLY for runtime failures (not LLM uncertainty)
3. **Field Definitions**: Added table explicitly defining `blocker_count = count of comments where severity in {"high", "critical"}` with computation sources

## Review & Testing Checklist for Human

- [ ] Verify severity mapping requirement (`"none"` → `"low"`) is acceptable for the schema design
- [ ] Confirm Router Decision Rules precedence logic matches intended behavior (especially `unknown` override semantics)
- [ ] Verify the evidence reference (`langgraph_orchestrator.py` lines 3583-3588) is accurate and matches current `main` branch
- [ ] Confirm issue #3130 has been updated with specific test cases (13 unit tests + 5 integration tests documented)

### Notes

This is a documentation-only change to track the B-6 phase before implementation begins. The actual implementation will follow in a separate PR.

**Potential drift risk**: The evidence reference (line numbers) may become stale if `langgraph_orchestrator.py` is modified. The implementation PR should verify these references.

Link to Devin run: https://app.devin.ai/sessions/4c624f57c50e499f98859c62908c800d
Requested by: Ryan Chen (@RC918)