### PR TITLE
test(reviewer): add contract awareness and noise budget validation tests (#3084)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_llm_reviewer_adapter.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_llm_reviewer_adapter.py
@@ -1995,6 +1995,19 @@ new mode 100755"""
         assert 'print("hello (world)")' in result
 
 
+def _get_system_prompt_for_testing() -> str:
+    """
+    Helper function to get the system prompt for testing.
+
+    This centralizes the setup logic for all prompt content tests,
+    making it easier to maintain and modify.
+    """
+    adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
+    adapter.trace_id = "test"
+    adapter.llm_client = None
+    return adapter._get_diff_aware_system_prompt()
+
+
 class TestContractAwarenessAndNoiseBudget:
     """
     Test suite for Contract Awareness and Noise Budget validation (Issue #3084).
@@ -2006,15 +2019,14 @@ class TestContractAwarenessAndNoiseBudget:
     Blueprint Alignment:
         - Telemetry v2: Observable contract changes (Section 5.2)
         - Stability First: Prevent prompt regression
+
+    Note: These tests only verify prompt content exists, not that the LLM
+    follows instructions. For LLM behavior validation, see Issue #3085.
     """
 
     def test_system_prompt_contains_contract_change_checklist(self):
         """Test that system prompt contains CONTRACT CHANGE CHECKLIST section."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert "CONTRACT CHANGE CHECKLIST" in prompt
         assert "Structured Output Fields" in prompt
@@ -2023,11 +2035,7 @@ class TestContractAwarenessAndNoiseBudget:
 
     def test_system_prompt_contains_noise_budget(self):
         """Test that system prompt contains NOISE BUDGET section."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert "NOISE BUDGET" in prompt
         assert "Maximum 5 comments" in prompt
@@ -2036,11 +2044,7 @@ class TestContractAwarenessAndNoiseBudget:
 
     def test_system_prompt_contains_strict_mode(self):
         """Test that system prompt contains STRICT MODE section."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert "STRICT MODE" in prompt
         assert 'ONLY COMMENT ON + LINES' in prompt
@@ -2048,11 +2052,7 @@ class TestContractAwarenessAndNoiseBudget:
 
     def test_system_prompt_contains_senior_architect_persona(self):
         """Test that system prompt contains SENIOR ARCHITECT persona."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert "SENIOR" in prompt
         assert "ARCHITECT" in prompt
@@ -2061,14 +2061,9 @@ class TestContractAwarenessAndNoiseBudget:
 
     def test_system_prompt_contains_quote_first_methodology(self):
         """Test that system prompt contains QUOTE-FIRST methodology."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert "QUOTE-FIRST" in prompt
-        assert "Chain of Thought" in prompt
         assert "QUOTE:" in prompt
         assert "LOCATE:" in prompt
         assert "ANALYZE:" in prompt
@@ -2076,78 +2071,47 @@ class TestContractAwarenessAndNoiseBudget:
 
     def test_system_prompt_forbids_nit_severity(self):
         """Test that system prompt explicitly forbids 'nit' severity."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert '"nit" severity is REMOVED' in prompt
 
     def test_system_prompt_forbids_style_category(self):
         """Test that system prompt explicitly forbids 'style' category."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert '"style" category is REMOVED' in prompt
 
     def test_system_prompt_includes_contract_category(self):
         """Test that system prompt includes new 'contract' category."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert '"contract" category is NEW' in prompt
         assert '"contract"' in prompt
 
     def test_system_prompt_includes_quote_field(self):
         """Test that system prompt includes new 'quote' field requirement."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert '"quote" field is NEW' in prompt
         assert '"quote":' in prompt
 
     def test_system_prompt_timestamp_validation_requirements(self):
         """Test that system prompt includes timestamp validation requirements."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert "unit" in prompt.lower()
         assert "UTC" in prompt
-        assert "milliseconds" in prompt
 
     def test_system_prompt_line_number_format_instructions(self):
         """Test that system prompt includes line number format instructions."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert "(Line N)" in prompt or "(Line 50)" in prompt
         assert "COPY the number" in prompt
 
     def test_system_prompt_scoring_guidelines(self):
         """Test that system prompt includes scoring guidelines."""
-        adapter = LLMReviewerAdapter.__new__(LLMReviewerAdapter)
-        adapter.trace_id = "test"
-        adapter.llm_client = None
-
-        prompt = adapter._get_diff_aware_system_prompt()
+        prompt = _get_system_prompt_for_testing()
 
         assert "SCORING GUIDELINES" in prompt
         assert "quality_score" in prompt
-        assert "85-95" in prompt
-        assert "Security issues" in prompt


### PR DESCRIPTION
# test(reviewer): add contract awareness and noise budget validation tests (#3084)

## Summary

Adds 12 unit tests to verify the LLM reviewer's system prompt contains required sections from the Major Brain Upgrade (PR #3076). These are regression tests that prevent accidental modification of critical prompt content.

**Tests verify presence of:**
- CONTRACT CHANGE CHECKLIST (timestamp/API schema validation)
- NOISE BUDGET (max 5 comments, IMPACT + SUGGESTED FIX requirements)
- STRICT MODE (only + lines for inline comments)
- SENIOR ARCHITECT persona (no nitpicks)
- QUOTE-FIRST methodology
- Removed severities/categories (nit, style)
- New additions (contract category, quote field)

## Updates since last revision

Addressed Gemini Code Assist feedback:
- **DRY refactoring**: Extracted `_get_system_prompt_for_testing()` helper function to eliminate duplicated adapter setup across all 12 tests
- **Reduced brittleness**: Removed overly specific assertions (`Chain of Thought`, `milliseconds`, `85-95`, `Security issues`) that could cause CI churn if prompt wording is tweaked without changing intent
- **Documentation**: Added reference to Issue #3085 for LLM behavior validation (out of scope for this PR)

## Review & Testing Checklist for Human

- [ ] Verify the helper function `_get_system_prompt_for_testing()` correctly instantiates the adapter
- [ ] Confirm remaining assertions strike the right balance - strict enough to catch regressions, flexible enough to allow minor wording changes
- [ ] Check that removed assertions were indeed too brittle and not core to #3084 acceptance criteria

**Recommended test plan:**
```bash
pytest handoff/20250928/40_App/orchestrator/tests/test_llm_reviewer_adapter.py::TestContractAwarenessAndNoiseBudget -v
```

### Notes
- These tests only verify prompt content exists, not that the LLM follows instructions (acknowledged limitation per issue #3084)
- For LLM behavior validation, see Issue #3085
- All 12 tests passed locally before PR creation
- Blueprint Alignment: Telemetry v2 (Section 5.2), Stability First

Closes #3084

---
**Link to Devin run:** https://app.devin.ai/sessions/4609907defbd48af8dd21f9b27b8dbb0
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918