### PR TITLE
test: add CANONICAL_NODES validation tests (#3157)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_flow_controller.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_flow_controller.py
@@ -1636,6 +1636,9 @@ class TestCanonicalNodesValidation:
     - EXPECTED_CANONICAL_NODES: Expected content of CANONICAL_NODES (single source of truth)
     """
 
+    # IMPORTANT: This list must be manually kept in sync with the nodes defined
+    # in `handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py`.
+    # See workflow.add_node() calls in create_orchestrator_graph().
     ACTUAL_GRAPH_NODES = frozenset({
         "review_intake",
         "internal_review",
@@ -1742,7 +1745,21 @@ class TestCanonicalNodesValidation:
             f"Extra nodes: {CANONICAL_NODES - self.ACTUAL_GRAPH_NODES}"
         )
 
-    def test_hybrid_router_routing_targets_in_canonical_nodes(self):
+    @pytest.mark.parametrize(
+        "verdict, severity, summary, blockers",
+        [
+            ("approve", "low", "Test", 0),
+            ("blocked", "high", "Test", 1),
+            ("unknown", "medium", "Test", 0),
+            ("request_changes", "low", "Test", 0),
+            ("request_changes", "medium", "Test", 0),
+            ("request_changes", "high", "Test", 2),
+            ("comment", "low", "Test", 0),
+        ],
+    )
+    def test_hybrid_router_routing_targets_in_canonical_nodes(
+        self, verdict, severity, summary, blockers
+    ):
         """Test that all nodes HybridRoutingPolicy can route to are in CANONICAL_NODES.
 
         This validates the routing logic won't produce invalid node names.
@@ -1751,22 +1768,11 @@ class TestCanonicalNodesValidation:
 
         policy = HybridRoutingPolicy(llm_generate_fn=None)
 
-        test_cases = [
-            ("approve", "low", "Test", 0),
-            ("blocked", "high", "Test", 1),
-            ("unknown", "medium", "Test", 0),
-            ("request_changes", "low", "Test", 0),
-            ("request_changes", "medium", "Test", 0),
-            ("request_changes", "high", "Test", 2),
-            ("comment", "low", "Test", 0),
-        ]
-
-        for verdict, severity, summary, blockers in test_cases:
-            decision = policy.route(verdict, severity, summary, blockers)
-            assert decision.next_node in CANONICAL_NODES, (
-                f"HybridRoutingPolicy.route({verdict}, {severity}) returned "
-                f"'{decision.next_node}' which is not in CANONICAL_NODES"
-            )
+        decision = policy.route(verdict, severity, summary, blockers)
+        assert decision.next_node in CANONICAL_NODES, (
+            f"HybridRoutingPolicy.route({verdict}, {severity}) returned "
+            f"'{decision.next_node}' which is not in CANONICAL_NODES"
+        )
 
     def test_document_canonical_nodes_mapping(self):
         """Document the expected mapping between CANONICAL_NODES and graph nodes.


### PR DESCRIPTION
## Summary

Adds 8 tests to validate that `CANONICAL_NODES` in `hybrid_router.py` matches actual LangGraph node IDs in `langgraph_orchestrator.py`. This prevents runtime routing failures where the router could route to non-existent nodes.

**Tests added:**
1. `test_all_canonical_nodes_exist_in_graph` - Primary validation that all CANONICAL_NODES exist in graph
2. `test_canonical_nodes_contains_required_routing_targets` - Ensures publisher/fixer/executor/decision are present
3. `test_canonical_nodes_is_frozen` - Immutability check
4. `test_node_aliases_map_to_canonical_nodes` - Alias mapping validation
5. `test_canonical_nodes_count` - Guard against accidental node additions/removals
6. `test_canonical_nodes_subset_of_actual_graph` - Subset validation
7. `test_hybrid_router_routing_targets_in_canonical_nodes` - Exercises HybridRoutingPolicy to verify all outputs are valid (parametrized with 7 test cases)
8. `test_document_canonical_nodes_mapping` - Documentation test

Closes #3157

## Updates since last revision

**Addressed MorningAI Reviewer Agent feedback:**
- Added `EXPECTED_CANONICAL_NODES` class constant as single source of truth
- `test_canonical_nodes_count` now derives count from `EXPECTED_CANONICAL_NODES` instead of hardcoding `8`
- `test_document_canonical_nodes_mapping` now uses the shared constant to avoid duplication

**Addressed Gemini Code Assist feedback:**
- Added IMPORTANT comment above `ACTUAL_GRAPH_NODES` pointing to source of truth in `langgraph_orchestrator.py`
- Refactored `test_hybrid_router_routing_targets_in_canonical_nodes` to use `pytest.mark.parametrize` for cleaner test cases and better failure messages

**Follow-up issue created:** #3168 - Replace hardcoded `ACTUAL_GRAPH_NODES` with dynamic file parsing

## Review & Testing Checklist for Human

- [ ] **Verify ACTUAL_GRAPH_NODES list is accurate**: The test uses a hardcoded frozenset of 20 graph nodes. Cross-check against `langgraph_orchestrator.py` (the `workflow.add_node()` calls in `create_orchestrator_graph()`) to ensure completeness.
- [ ] **Verify EXPECTED_CANONICAL_NODES matches hybrid_router.py**: Confirm the 8 nodes in `EXPECTED_CANONICAL_NODES` match the actual `CANONICAL_NODES` definition in `hybrid_router.py`.

**Recommended test plan:**
1. Run `pytest handoff/20250928/40_App/orchestrator/tests/test_flow_controller.py::TestCanonicalNodesValidation -v`
2. Verify all 14 tests pass (8 base tests, with routing targets test expanded to 7 parametrized cases)
3. Optionally, temporarily add a fake node to CANONICAL_NODES and verify the test catches it

### Notes

The tests use hardcoded `ACTUAL_GRAPH_NODES` and `EXPECTED_CANONICAL_NODES` lists rather than dynamically importing from source. This is intentional to avoid import chain issues in CI, but means these lists must be manually updated if graph nodes change. See #3168 for planned improvement to use dynamic file parsing.

**Link to Devin run:** https://app.devin.ai/sessions/4c624f57c50e499f98859c62908c800d
**Requested by:** Ryan Chen (ryan2939z@gmail.com), @RC918