### PR TITLE
test: add HITL Gate Node integration tests with checkpointer (#3164)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_hitl_integration.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_hitl_integration.py
@@ -178,29 +178,6 @@ class TestHITLInterruptResumeWithMemorySaver:
         assert result.get("requires_hitl_approval") is True
         assert result.get("hitl_approved") is False
 
-    def test_workflow_resumes_after_approval(self):
-        """Test that workflow resumes correctly after HITL approval."""
-        workflow = create_hitl_test_graph()
-        checkpointer = MemorySaver()
-        app = workflow.compile(checkpointer=checkpointer)
-
-        thread_id = str(uuid.uuid4())
-        config = {"configurable": {"thread_id": thread_id}}
-
-        initial_state = {
-            "trace_id": "test-hitl-resume",
-            "messages": [],
-            "requires_hitl_approval": False,
-            "hitl_approved": False,
-            "workflow_result": "",
-        }
-
-        result = app.invoke(initial_state, config)
-
-        assert result["workflow_result"] == "processed"
-        assert result["hitl_approved"] is False
-        assert result["requires_hitl_approval"] is False
-
 
 class TestHITLStateCheckpointing:
     """Integration tests for state checkpointing during HITL interrupt.
@@ -254,7 +231,9 @@ class TestHITLStateCheckpointing:
         assert checkpoint is not None
 
         channel_values = checkpoint.get("channel_values", {})
-        assert "trace_id" in channel_values or checkpoint is not None
+        assert "trace_id" in channel_values
+        assert "requires_hitl_approval" in channel_values
+        assert "hitl_approved" in channel_values
 
 
 class TestHITLStateReset:
@@ -265,7 +244,12 @@ class TestHITLStateReset:
     """
 
     def test_hitl_flags_reset_after_completion(self):
-        """Test that HITL flags are reset to False after workflow completion."""
+        """Test that HITL flags are reset to False after workflow completion.
+
+        This test sets initial flags to True to verify the finalize_node
+        actually resets them. Without this, the reset logic would not be
+        exercised since flags start at False.
+        """
         workflow = create_hitl_test_graph()
         checkpointer = MemorySaver()
         app = workflow.compile(checkpointer=checkpointer)
@@ -276,8 +260,8 @@ class TestHITLStateReset:
         initial_state = {
             "trace_id": "test-reset",
             "messages": [],
-            "requires_hitl_approval": False,
-            "hitl_approved": False,
+            "requires_hitl_approval": True,
+            "hitl_approved": True,
             "workflow_result": "",
         }
 


### PR DESCRIPTION
## Summary

Adds 14 integration tests for the HITL (Human-in-the-Loop) Gate Node interrupt/resume flow with MemorySaver checkpointer support. This addresses Issue #3164 as part of the C-5 Pilot (#3158).

The tests use a simplified test graph that mirrors the production HITL Gate Node behavior to verify:
- Workflow completion when HITL is not required
- Workflow interruption when HITL approval is required
- State persistence in checkpointer during workflow execution
- HITL flags reset after workflow completion
- State isolation between concurrent sessions

**Test Classes:**
- `TestHITLInterruptResumeWithMemorySaver` - Basic interrupt/resume flow
- `TestHITLStateCheckpointing` - State persistence verification
- `TestHITLStateReset` - HITL flag reset after completion
- `TestHITLMultiSessionIsolation` - Concurrent session isolation
- `TestHITLGateNodeBehavior` - Gate node logic patterns
- `TestMemorySaverCheckpointerIntegration` - MemorySaver API verification

## Updates since last revision

Based on code review feedback from gemini-code-assist and MorningAI Reviewer Agent:

1. **Removed redundant test** - `test_workflow_resumes_after_approval` was misleadingly named and redundant with `test_workflow_without_hitl_requirement_completes` (test count: 15 → 14)

2. **Strengthened assertion** - `test_checkpoint_contains_hitl_state` now explicitly asserts `trace_id`, `requires_hitl_approval`, and `hitl_approved` exist in channel_values (previously was always-true assertion)

3. **Fixed flag reset test** - `test_hitl_flags_reset_after_completion` now sets initial flags to `True` to actually exercise the reset logic in `finalize_node`

**Follow-up issues created:**
- #3173 - Full interrupt/resume flow tests with `Command(resume=...)`
- #3174 - PostgresSaver integration tests
- #3175 - Edge case and resilience tests

## Review & Testing Checklist for Human

- [ ] **Verify test graph mirrors production behavior**: The `create_hitl_test_graph()` function creates a simplified graph. Compare with production `hitl_gate_node` in `langgraph_orchestrator.py` (lines 4611-4720) to ensure the test logic accurately reflects production behavior.

- [ ] **Note: Full interrupt/resume not tested**: The tests use `interrupt_before=["hitl_gate"]` for interruption, but don't test the actual `Command(resume={"approved": True})` flow. This is tracked in follow-up issue #3173.

**Recommended Test Plan:**
1. Run `pytest handoff/20250928/40_App/orchestrator/tests/test_hitl_integration.py -v` locally
2. Verify all 14 tests pass
3. Confirm CI passes (42/42 checks expected)

### Notes

- PostgresSaver tests are deferred per issue #3164 (tracked in #3174)
- This is a test-only PR - no production code changes

Link to Devin run: https://app.devin.ai/sessions/4c624f57c50e499f98859c62908c800d
Requested by: Ryan Chen (@RC918)