### PR TITLE
fix(orchestrator): prevent IndexError in executor_node exception handler

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -3833,6 +3833,8 @@ def executor_node(state: AgentState) -> AgentState:
 
     metrics.record_node_start("executor", trace_id)
 
+    # Defensive bounds check: Extract step name before try block to prevent secondary
+    # IndexError in exception handler if current_step is out of bounds
     current_step_name = plan[current_step] if current_step < len(plan) else "unknown"
     logger.info(f"[Executor] Executing step {current_step + 1}/{len(plan)} source_pr_number={source_pr_number}", extra={
         "operation": "executor",


### PR DESCRIPTION
## Summary

Fixes a potential secondary `IndexError` in the `executor_node` exception handler by extracting `current_step_name` before the try block. Also adds `exc_info=True` to the error logger for better Sentry stack trace capture.

**Root cause:** When processing test webhooks with non-existent PRs (e.g., PR #9999), the original error would trigger the except block, which then tried to access `plan[current_step]` - potentially causing a secondary IndexError that masked the original error.

**Changes:**
- Extract `current_step_name` with bounds check before try block
- Reuse this variable in both success and error message paths
- Add `exc_info=True` to `logger.error` for full stack traces in Sentry
- Add clarifying comment explaining the defensive coding pattern

## Review & Testing Checklist for Human

- [ ] Verify the bounds check logic: `plan[current_step] if current_step < len(plan) else "unknown"` handles edge cases correctly
- [ ] Confirm that `exc_info=True` won't cause excessive log volume in production (standard pattern, but worth verifying)

### Test Plan
1. Deploy to staging
2. Trigger a test webhook with a non-existent PR number
3. Verify the error is logged gracefully without secondary IndexError
4. Check Sentry to confirm stack traces are now captured

### Notes
- This was discovered during investigation of a test webhook with PR #9999
- The test webhook was triggered by GitHub's "Test" button, not a real PR event

### Updates since last revision
- Added clarifying comment per review feedback to explain the defensive bounds check pattern

Link to Devin run: https://app.devin.ai/sessions/704acc3d97124d00a7e98394ff2203e1
Requested by: Ryan Chen (@RC918)