### PR TITLE
feat(telemetry): add RESOURCE_TELEMETRY_ENABLED kill-switch (#3205)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/resource_telemetry.py
+++ b/handoff/20250928/40_App/orchestrator/resource_telemetry.py
@@ -28,10 +28,14 @@ def _is_telemetry_enabled() -> bool:
     """
     Check if resource telemetry is enabled via environment variable.
 
+    Accepts common falsey values: "false", "0", "no", "off", "" (empty string).
+    Default is enabled (true).
+
     Returns:
         True if telemetry is enabled (default), False if explicitly disabled.
     """
-    return os.environ.get("RESOURCE_TELEMETRY_ENABLED", "true").lower() != "false"
+    value = os.environ.get("RESOURCE_TELEMETRY_ENABLED", "true").strip().lower()
+    return value not in ("false", "0", "no", "off", "")
 
 
 def _get_timestamp_ms() -> int:


### PR DESCRIPTION
# feat(telemetry): add RESOURCE_TELEMETRY_ENABLED kill-switch (#3205)

## Summary

Adds a kill-switch environment variable to disable all resource telemetry logging. This provides a Self-Governed mechanism (per Blueprint) to quickly disable telemetry in production if log volume becomes problematic.

**Changes:**
- New `_is_telemetry_enabled()` function checks `RESOURCE_TELEMETRY_ENABLED` env var
- All 5 log functions early-return when telemetry is disabled
- Default is `true` (enabled) to preserve Phase 0 baseline collection
- Accepts common falsey values: `"false"`, `"0"`, `"no"`, `"off"`, `""` (empty string)

## Updates since last revision

**Commit f15e5d26** - Address Gemini Code Assist feedback:
- Accept common falsey values (`0`, `no`, `off`, empty string) in addition to `false`
- Add `.strip()` to handle whitespace in env var value
- Update docstring to document accepted values

This improves usability by matching common conventions for boolean environment variables.

## Review & Testing Checklist for Human

- [ ] **Verify `log_resource_peak` return value**: When disabled, returns `0.0` instead of actual RSS. Confirmed only one call site (`langgraph_orchestrator.py:221`) which does not use the return value.
- [ ] **Environment variable behavior**: The check reads `os.environ` on every call (no caching). Note: runtime toggling typically requires worker restart since env vars are set at process start.
- [ ] **No unit tests included**: Consider whether tests for the enable/disable behavior should be added (tracked in #3204).

**Recommended test plan:**
1. Deploy to staging with `RESOURCE_TELEMETRY_ENABLED=true` (default)
2. Trigger a PR review workflow and verify telemetry events appear in logs
3. Set `RESOURCE_TELEMETRY_ENABLED=false` (or `0`, `no`, `off`) and restart worker
4. Trigger another workflow and verify NO telemetry events appear
5. Confirm workflow completes successfully with telemetry disabled

### Notes

Closes #3205

Part of P1 瘦身計畫 EPIC (#3196). This kill-switch should be in place before deploying Phase 0 telemetry to production.

**Deferred to follow-up**: Gemini suggested using a decorator to reduce code duplication across the 5 log functions. This was deferred as the current explicit early-return pattern is more readable and the duplication is minimal.

---
Link to Devin run: https://app.devin.ai/sessions/e98a8311ee5746a49c1983b86cb982bd
Requested by: Ryan Chen (@RC918)