### PR TITLE
docs: add version marker for Hybrid Router production release

### DIFF
--- a/handoff/20250928/40_App/orchestrator/core/flow/hybrid_router.py
+++ b/handoff/20250928/40_App/orchestrator/core/flow/hybrid_router.py
@@ -4,6 +4,7 @@ Flow Controller v3 - Hybrid Router (C-2)
 Issue #2745: C-2 Router Node Logic
 EPIC C: Flow Controller v3 - LLM-driven Dynamic Routing
 Stage 1: Hybrid Router Implementation
+Version: 1.0.0 - Production Ready (2025-12-29)
 
 This module implements the HybridRoutingPolicy which:
 - Fast Path: Deterministic routing for clear-cut cases (approve -> publisher)


### PR DESCRIPTION
## Summary

Adds a version marker to the Hybrid Router module docstring to mark the production release (v1.0.0).

This PR also serves as a verification trigger for Phase 2 of the Hybrid Router production deployment - the webhook from this PR will exercise the routing pipeline with `ENABLE_DYNAMIC_ROUTING=true`.

## Review & Testing Checklist for Human

- [ ] Verify production logs show `[ROUTER_FAST_PATH]` after this PR triggers a webhook
- [ ] Confirm no `[ROUTER_LLM_FALLBACK]` errors appear in logs

### Notes

**Phase 2 Verification**: After this PR is created, check Render prod worker logs for router event codes to confirm Hybrid Router is functioning correctly.

Link to Devin run: https://app.devin.ai/sessions/4c624f57c50e499f98859c62908c800d
Requested by: Ryan Chen (@RC918)