### PR TITLE
feat(D-1.5): add protected branch safety documentation and tests (#3217)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_simple_coder_wiring.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_simple_coder_wiring.py
@@ -545,7 +545,8 @@ class TestProtectedBranchSafety:
             success, message = _attempt_simple_coder_fix(state, "test-trace")
 
             assert success is False
-            assert "failed to apply patch" in message.lower() or "permission" in message.lower()
+            assert "failed to apply patch" in message.lower()
+            assert "branch protection" in message.lower()
             mock_commit.assert_called_once()
 
     @patch("coder.autofix_gate.is_autofix_allowed", return_value=True)

--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -359,7 +359,10 @@ def commit_file(repo, branch, path, content, message, max_retries: int = 3) -> C
     - SimpleCoder is designed to only operate on PR branches, not main/protected branches
     - If a commit is attempted on a protected branch, GitHub returns 403 with
       "protected branch" in the error message
-    - This function detects protected branch errors and returns PERMISSION_DENIED status
+    - This function detects protected branch errors via substring matching on the
+      GitHub error message (case-insensitive). If GitHub changes their error wording,
+      the detection may need to be updated in _classify_github_error()
+    - Returns PERMISSION_DENIED status for protected branch errors
     - The caller (SimpleCoder wiring in fixer_node) handles this gracefully by
       falling back to AutoFixer when commit_file returns a non-success status
     - Log event: [COMMIT_FILE_PERMISSION_DENIED] with branch protection context


### PR DESCRIPTION
# feat(D-1.5): add protected branch safety documentation and tests (#3217)

## Summary

Adds documentation and tests for protected branch safety checks in SimpleCoder. This PR addresses issue #3217 by:

1. **Documentation**: Added "Protected Branch Behavior (D-1.5)" section to `commit_file()` docstring explaining:
   - SimpleCoder only operates on PR branches, not main/protected branches
   - How 403 errors from protected branches are detected and handled
   - The graceful fallback to AutoFixer when commit fails
   - Detection relies on substring matching (case-insensitive) on GitHub's error message

2. **Tests**: Added `TestProtectedBranchSafety` class with 2 tests:
   - `test_protected_branch_error_triggers_fallback`: Verifies 403 protected branch error returns `False` to trigger AutoFixer fallback
   - `test_permission_denied_logs_clear_message`: Verifies `[SIMPLE_CODER_PATCH_FAILED]` event is logged for debugging

No functional code changes - this PR only adds documentation and tests for existing behavior.

## Updates since last revision

- Tightened test assertion to check for both "failed to apply patch" AND "branch protection" (more specific than previous OR condition)
- Added clarifying note in docstring that detection uses substring matching and may need updates if GitHub changes error wording
- Created follow-up issue #3232 for edge-case tests on 403 message variants

## Review & Testing Checklist for Human

- [ ] Verify the docstring accurately describes the substring-based detection mechanism in `_classify_github_error()`
- [ ] Confirm test assertions match actual error messages returned by `_attempt_simple_coder_fix()` (format: "Failed to apply patch: {CommitResult.message}")

### Notes

- The existing code already handles protected branch errors correctly (403 → PERMISSION_DENIED → fallback to AutoFixer)
- This PR documents that behavior and adds explicit tests for it
- Tests use mocks since we can't test against real GitHub protected branches in CI
- Follow-up issue #3232 tracks edge-case tests for different 403 message variants

Link to Devin run: https://app.devin.ai/sessions/4c624f57c50e499f98859c62908c800d
Requested by: Ryan Chen (@RC918)