### PR TITLE
test(D-1.2): add SimpleCoder E2E integration tests with LangGraph (#3213)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_simple_coder_e2e.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_simple_coder_e2e.py
@@ -18,6 +18,7 @@ This test file covers E2E integration scenarios that verify:
 - State transitions through the full workflow
 - Error handling and fallback to AutoFixer
 """
+import logging
 from typing import Optional, Dict, Any
 
 from coder.autofix_gate import is_autofix_allowed, is_path_excluded
@@ -108,6 +109,32 @@ def create_fix_suggestion(
         confidence=confidence,
         category=category,
     )
+
+
+def create_eligible_review_outcome(**overrides) -> Dict[str, Any]:
+    """Create an eligible review_outcome dict for autofix.
+
+    Default values satisfy all autofix gate conditions:
+    - severity="low"
+    - diff_truncated=False
+    - schema_validated=True
+
+    Use overrides to customize specific fields for testing rejection cases.
+
+    Example:
+        # Eligible outcome
+        outcome = create_eligible_review_outcome()
+
+        # Rejected due to high severity
+        outcome = create_eligible_review_outcome(severity="high")
+    """
+    base = {
+        "severity": "low",
+        "diff_truncated": False,
+        "schema_validated": True,
+    }
+    base.update(overrides)
+    return base
 
 
 class TestRouterToSimpleCoderRouting:
@@ -566,7 +593,6 @@ class TestWorkflowEventCodes:
 
     def test_route_to_fixer_event_code(self, caplog):
         """Test that [ROUTE_TO_FIXER] event code is logged."""
-        import logging
         caplog.set_level(logging.INFO)
 
         review_outcome = {
@@ -589,7 +615,6 @@ class TestWorkflowEventCodes:
 
     def test_skip_fixer_event_code(self, caplog):
         """Test that [SKIP_FIXER] event code is logged."""
-        import logging
         caplog.set_level(logging.INFO)
 
         review_outcome = {
@@ -612,7 +637,6 @@ class TestWorkflowEventCodes:
 
     def test_autofix_gate_pass_event_code(self, caplog):
         """Test that [AUTOFIX_GATE_PASS] event code is logged."""
-        import logging
         caplog.set_level(logging.INFO)
 
         review_outcome = {
@@ -630,7 +654,6 @@ class TestWorkflowEventCodes:
 
     def test_autofix_gate_fail_event_code(self, caplog):
         """Test that [AUTOFIX_GATE_FAIL] event code is logged."""
-        import logging
         caplog.set_level(logging.INFO)
 
         review_outcome = {


### PR DESCRIPTION
# test(D-1.2): add SimpleCoder E2E integration tests with LangGraph (#3213)

## Summary

Adds 39 E2E integration tests for SimpleCoder that verify the routing logic, handoff schema integration, and autofix gate alignment. These tests cover the acceptance criteria from issue #3213:

1. Router → SimpleCoder routing based on `is_autofix_allowed()`
2. ReviewToFixHandoff schema integration with state
3. Autofix gate and handoff eligibility alignment
4. Event code logging verification

**Test Classes:**
- `TestRouterToSimpleCoderRouting` (9 tests): Routing decisions based on severity, diff_truncated, schema_validated, confidence
- `TestFullWorkflowE2E` (4 tests): Workflow state transitions and handoff storage
- `TestReviewToFixHandoffIntegration` (6 tests): Schema serialization, field preservation, derived metrics
- `TestAutoFixGateAndHandoffAlignment` (4 tests): Gate and handoff agreement on eligibility
- `TestWorkflowEventCodes` (4 tests): Greppable event codes [ROUTE_TO_FIXER], [SKIP_FIXER], etc.
- `TestExcludedPathsE2E` (7 tests): Config, migration, env, package, CI, Docker file exclusions
- `TestMultipleSuggestionsE2E` (5 tests): Multiple suggestions with mixed confidence/categories

## Updates since last revision

Addressed code review feedback:
- Moved `import logging` from test methods to file top (PEP 8 compliance)
- Added `create_eligible_review_outcome()` helper function to reduce duplication

Created follow-up issues for remaining suggestions:
- #3239: Add fixer_node and _attempt_simple_coder_fix unit tests
- #3240: Add exception/error path tests for SimpleCoder E2E
- #3241: Discuss .env exclusion policy expansion
- #3242: Consider splitting test file for maintainability

## Review & Testing Checklist for Human

- [ ] **Verify test coverage matches acceptance criteria** - Tests focus on routing logic and handoff schema, but don't directly test `fixer_node` or `_attempt_simple_coder_fix` due to import complexity. Confirm this level of coverage is acceptable for D-1.2.
- [ ] **Check security category severity inference test** - `test_routing_with_security_category_infers_high_severity` uses `review_outcome=None` because `_determine_max_severity()` prioritizes review_outcome.severity over suggestion categories. Verify this matches intended behavior.
- [ ] **Verify .env exclusion behavior** - `test_env_files_excluded` only checks exact `.env` match, not `.env.local` or `.env.production`. The actual `is_path_excluded()` implementation uses exact basename matching.

**Test Plan:**
```bash
cd ~/repos/morningai
source .venv/bin/activate
PYTHONPATH=".:handoff/20250928/40_App/orchestrator:$PYTHONPATH" pytest handoff/20250928/40_App/orchestrator/tests/test_simple_coder_e2e.py -v
```

### Notes

- Link to Devin run: https://app.devin.ai/sessions/4c624f57c50e499f98859c62908c800d
- Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918
- Related: Issue #3213, Parent #2760 (D-1 General Coder Agent MVP), EPIC #2759