### PR TITLE
test(D-1): add fixer_node and _attempt_simple_coder_fix unit tests (#3239)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_fixer_node_unit.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_fixer_node_unit.py
@@ -278,7 +278,7 @@ class TestCommitFileResultHandling:
             mock_coder.return_value.execute.return_value = mock_output
 
             mock_commit.return_value = CommitResult(
-                CommitResult.ERROR,
+                CommitResult.UNKNOWN_ERROR,
                 "Network error: connection timeout"
             )
 


### PR DESCRIPTION
# test(D-1): add fixer_node and _attempt_simple_coder_fix unit tests (#3239)

## Summary

Adds 15 unit tests across 6 test classes for `fixer_node` and `_attempt_simple_coder_fix` functions. These tests complement the existing `test_simple_coder_wiring.py` by covering additional edge cases identified in #3239:

- **CommitResult handling**: Tests for SUCCESS, CONFLICT, and UNKNOWN_ERROR status codes from `commit_file()`
- **Exception handling**: Tests for RuntimeError and ValueError from SimpleCoder.execute()
- **fixer_node integration**: Tests for metrics recording, message addition, and retry_count increment
- **Review comment extraction**: Tests for extracting comments from dict and string formats
- **File content fetching**: Tests for using diff_head_sha vs branch as ref
- **Severity extraction**: Tests for passing severity to SimpleCoder and default behavior

Uses the same fake module injection pattern as `test_simple_coder_wiring.py` to handle the complex import cascade.

## Updates since last revision

- Fixed `CommitResult.ERROR` → `CommitResult.UNKNOWN_ERROR` to match actual API (the `CommitResult` class uses `UNKNOWN_ERROR`, not `ERROR`)

## Review & Testing Checklist for Human

- [ ] **Verify test assertions match implementation** - Tests check for specific strings like "successfully" and "failed to apply patch" in messages; confirm these match actual `_attempt_simple_coder_fix` output
- [ ] **Check fake module setup** - The `setup_fake_modules()` function (lines 25-73) creates fake modules; verify these match the real module structure
- [ ] **No duplication with existing tests** - Confirm these tests cover gaps not already covered by `test_simple_coder_wiring.py`

### Recommended Test Plan
1. Review the test file to ensure assertions align with actual implementation behavior
2. Run the orchestrator test suite locally if possible to verify no regressions

### Notes

- Closes #3239
- Related to #3211 (Three Don'ts Safety Guardrails - closed)
- CI: 42/42 checks passed
- Link to Devin run: https://app.devin.ai/sessions/4c624f57c50e499f98859c62908c800d
- Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918