### PR TITLE
test(D-1.3): add automated schema/prompt drift detection tests (#3214)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/coder/tests/test_schema_drift.py
+++ b/handoff/20250928/40_App/orchestrator/coder/tests/test_schema_drift.py
@@ -16,7 +16,6 @@ The tests verify:
 - schema_version is present and valid in all outputs
 """
 import json
-import re
 
 from typing import Set
 
@@ -24,6 +23,7 @@ from coder.simple_coder import (
     CoderOutput,
     CoderStatus,
     CODER_OUTPUT_SCHEMA_VERSION,
+    CODER_PROMPT_TEMPLATE,
     CODER_SYSTEM_PROMPT,
 )
 
@@ -69,17 +69,26 @@ class TestLLMResponseSchemaConsistency:
         The LLM should only output {status, reason, patch}.
         System-added fields (schema_version, file_path, syntax_valid)
         should NOT be in the prompt's JSON schema.
+
+        Uses anchor-based extraction to find the JSON schema section
+        in the prompt, which is more robust than regex matching braces.
         """
-        json_block_match = re.search(
-            r'\{[^}]*"status"[^}]*\}',
-            CODER_SYSTEM_PROMPT,
-            re.DOTALL
+        anchor = "You MUST respond with ONLY a JSON object"
+        anchor_pos = CODER_SYSTEM_PROMPT.find(anchor)
+        assert anchor_pos != -1, (
+            f"Anchor text '{anchor}' not found in CODER_SYSTEM_PROMPT. "
+            "Update this test if the prompt structure changed."
         )
-        if json_block_match:
-            json_block = json_block_match.group()
-            assert "schema_version" not in json_block
-            assert "file_path" not in json_block
-            assert "syntax_valid" not in json_block
+        json_section = CODER_SYSTEM_PROMPT[anchor_pos:]
+        assert "schema_version" not in json_section, (
+            "CODER_SYSTEM_PROMPT should not ask LLM to output schema_version"
+        )
+        assert "file_path" not in json_section, (
+            "CODER_SYSTEM_PROMPT should not ask LLM to output file_path"
+        )
+        assert "syntax_valid" not in json_section, (
+            "CODER_SYSTEM_PROMPT should not ask LLM to output syntax_valid"
+        )
 
 
 class TestFinalOutputSchemaConsistency:
@@ -270,14 +279,11 @@ class TestPromptTemplateConsistency:
 
     def test_prompt_template_exists(self):
         """Verify CODER_PROMPT_TEMPLATE is defined."""
-        from coder.simple_coder import CODER_PROMPT_TEMPLATE
         assert CODER_PROMPT_TEMPLATE is not None
         assert len(CODER_PROMPT_TEMPLATE) > 0
 
     def test_prompt_template_has_placeholders(self):
         """Verify prompt template has required placeholders."""
-        from coder.simple_coder import CODER_PROMPT_TEMPLATE
-
         assert "{file_path}" in CODER_PROMPT_TEMPLATE
         assert "{file_content}" in CODER_PROMPT_TEMPLATE
         assert "{review_comment}" in CODER_PROMPT_TEMPLATE
@@ -285,8 +291,6 @@ class TestPromptTemplateConsistency:
 
     def test_prompt_template_mentions_status_values(self):
         """Verify prompt template mentions valid status values."""
-        from coder.simple_coder import CODER_PROMPT_TEMPLATE
-
         template_lower = CODER_PROMPT_TEMPLATE.lower()
         assert "skipped" in template_lower
         assert "patch" in template_lower


### PR DESCRIPTION
## Summary

Adds 27 automated CI tests to prevent drift between SimpleCoder's prompt, documentation, and implementation. These tests will fail if someone modifies the schema in one place but forgets to update the others.

**Test classes added:**
- `TestLLMResponseSchemaConsistency` - Verifies CODER_SYSTEM_PROMPT matches documented LLM Response Schema
- `TestFinalOutputSchemaConsistency` - Verifies `to_dict()` output matches Final CoderOutput Schema
- `TestSchemaVersionEvolution` - Verifies schema versioning is properly implemented
- `TestDocstringSchemaAlignment` - Verifies docstrings accurately describe schemas
- `TestSchemaFieldCompleteness` - Verifies all documented fields are implemented
- `TestPromptTemplateConsistency` - Verifies CODER_PROMPT_TEMPLATE is consistent

## Updates since last revision

Addressed code review feedback from Gemini Code Assist:
- **Replaced brittle regex with anchor-based extraction** in `test_prompt_does_not_mention_system_fields` - now uses string slicing from anchor text "You MUST respond with ONLY a JSON object" instead of `r'\{[^}]*"status"[^}]*\}'`
- **Consolidated imports** - moved `CODER_PROMPT_TEMPLATE` to top-level imports, removed redundant imports from test methods
- **Added descriptive assertion messages** for better debugging when tests fail
- **Removed unused `re` import**

**Follow-up issues created:**
- #3248: Auto-sync schema field sets from source of truth
- #3249: Refactor schema drift tests with helper abstractions
- #3250: Enhance test failure messages for schema drift tests
- #3251: Add schema version bump validation to CI

## Review & Testing Checklist for Human

- [ ] Confirm the hardcoded field sets (`DOCUMENTED_LLM_FIELDS`, `DOCUMENTED_SYSTEM_FIELDS`) match the actual schema documentation in `simple_coder.py`
- [ ] Verify the anchor text "You MUST respond with ONLY a JSON object" exists in `CODER_SYSTEM_PROMPT` (test will fail with clear message if not)

**Test plan:** Run `pytest handoff/20250928/40_App/orchestrator/coder/tests/test_schema_drift.py -v` and verify all 27 tests pass.

### Notes
- Closes #3214
- Parent: #2760 (D-1 General Coder Agent MVP)
- Link to Devin run: https://app.devin.ai/sessions/4c624f57c50e499f98859c62908c800d
- Requested by: Ryan Chen (@RC918)