### PR TITLE
feat(publisher): pass commit_id to Summary Report for Redis dedup idempotency (#3253)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -5728,7 +5728,9 @@ def publisher_node(state: AgentState) -> AgentState:
     diff_truncated = state.get("diff_truncated", False)
     # Phase 2: Get stored head_sha for commit pinning
     # Fix: This should now always be set by reviewer_node (moved outside if diff_content: block)
-    stored_head_sha = state.get("diff_head_sha")
+    # Issue #3253: Normalize to None if not a valid non-empty string (defensive)
+    _raw_head_sha = state.get("diff_head_sha")
+    stored_head_sha = _raw_head_sha if isinstance(_raw_head_sha, str) and _raw_head_sha else None
     downgraded_count = 0
     line_drift_detected = False
 

--- a/handoff/20250928/40_App/orchestrator/tests/test_publisher_node.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_publisher_node.py
@@ -827,6 +827,44 @@ class TestPublisherNodeNoOp:
 
                             mock_post.reset_mock()
 
+    def test_file_level_fallback_passes_commit_id_for_dedup(self):
+        """Issue #3253: File-level fallback path should pass commit_id for Redis dedup"""
+        mock_settings = MagicMock()
+        mock_settings.enable_github_review_posting = True
+
+        mock_metrics = MagicMock()
+        mock_repo = MagicMock()
+
+        mock_post_result = {
+            "success": True,
+            "posted_count": 0,
+            "dry_run": False,
+            "error": None
+        }
+
+        test_commit_id = "abc123def456789012345678901234567890abcd"
+        state = {
+            "trace_id": "test-trace",
+            "pr_number": 123,
+            "review_comments": [{"message": "General comment", "file": "test.py", "severity": "warning"}],
+            "messages": [],
+            "diff_head_sha": test_commit_id
+        }
+
+        with patch("langgraph_orchestrator.settings", mock_settings):
+            with patch("langgraph_orchestrator._get_metrics", return_value=mock_metrics):
+                with patch("review_comment_schema.is_inline_comment", return_value=False):
+                    with patch("tools.github_api.get_repo", return_value=mock_repo):
+                        with patch("tools.github_api.post_pr_review", return_value=mock_post_result) as mock_post:
+                            from langgraph_orchestrator import publisher_node
+
+                            result = publisher_node(state)
+
+                            # Issue #3253: Verify commit_id is passed for Redis dedup in file-level fallback
+                            mock_post.assert_called_once()
+                            call_args = mock_post.call_args
+                            assert call_args.kwargs.get("commit_id") == test_commit_id
+
 
 @pytest.mark.skipif(not LANGGRAPH_AVAILABLE, reason="langgraph not installed")
 class TestPublisherNodeIntegration:


### PR DESCRIPTION
# feat(publisher): pass commit_id to Summary Report for Redis dedup idempotency (#3253)

## Summary
Fixes issue #3253 where Summary Report and file-level fallback paths in `publisher_node` were not passing `commit_id` to `post_pr_review()`, causing the Redis dedup mechanism to be bypassed. This could result in duplicate Summary Reports when the Reviewer Agent is re-run on the same PR.

**Changes:**
- Pass `commit_id=stored_head_sha` to `post_pr_review()` in Summary Report path
- Pass `commit_id=stored_head_sha` to `post_pr_review()` in file-level fallback path  
- Add defensive validation to normalize `diff_head_sha` to `None` if not a valid non-empty string (applied consistently to both Summary Report path and inline comments path)
- Add tests to verify `commit_id` is passed for Redis dedup and edge cases are handled

## Updates since last revision
- **Unified defensive validation**: Per gemini-code-assist feedback, added the same defensive validation to the inline comments path (line 5731) that was already in the Summary Report path. Both paths now use:
  ```python
  _raw_head_sha = state.get("diff_head_sha")
  stored_head_sha = _raw_head_sha if isinstance(_raw_head_sha, str) and _raw_head_sha else None
  ```

- **Added file-level fallback test**: Added `test_file_level_fallback_passes_commit_id_for_dedup` to verify `commit_id` is correctly passed in the file-level fallback path (when comments exist but none are inline-eligible).

- **Created follow-up issues** for suggestions that were out of scope:
  - #3258: Integration test for Redis dedup verification
  - #3259: Define `diff_head_sha` contract and ensure availability
  - #3260: Add observability for Redis dedup failures

## Review & Testing Checklist for Human
- [ ] **Verify defensive validation consistency**: Both paths (Summary Report at line ~5633 and inline comments at line ~5733) should have identical validation logic
- [ ] **Test idempotency**: Re-run the Reviewer Agent on the same PR twice and verify only one Summary Report is posted (requires Redis and `GITHUB_REVIEW_POSTING_DRY_RUN=false`)
- [ ] **Test graceful degradation**: Verify behavior when `diff_head_sha` is missing from state (should proceed without dedup, not crash)

### Notes
- The regular inline comments path already passes `commit_id` correctly (line ~5996), so this PR aligns the Summary Report and file-level fallback paths with that pattern
- When `stored_head_sha` is `None`, `post_pr_review()` handles it gracefully (dedup is skipped but review still posts)
- Strict SHA format validation (40-hex regex) was intentionally not added to avoid churn with existing test fixtures; tracked in follow-up issue #3259

---
Requested by: Ryan Chen (@RC918)
Link to Devin run: https://app.devin.ai/sessions/4c624f57c50e499f98859c62908c800d