### PR TITLE
test(#3232): Add edge case tests for _classify_github_error 403 variants

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tools/tests/test_classify_github_error_edge_cases.py
+++ b/handoff/20250928/40_App/orchestrator/tools/tests/test_classify_github_error_edge_cases.py
@@ -65,6 +65,7 @@ class TestClassifyGithubError403EdgeCases:
         error_type, error_msg = _classify_github_error(exc)
 
         assert error_type == CommitResult.PERMISSION_DENIED
+        assert "permission" in error_msg.lower()
 
     def test_403_data_dict_without_message_key(self):
         """Test 403 error when e.data dict has other keys but no 'message'.
@@ -80,6 +81,7 @@ class TestClassifyGithubError403EdgeCases:
         error_type, error_msg = _classify_github_error(exc)
 
         assert error_type == CommitResult.PERMISSION_DENIED
+        assert "permission" in error_msg.lower()
 
     def test_403_data_is_list(self):
         """Test 403 error when e.data is a list instead of dict.
@@ -91,6 +93,7 @@ class TestClassifyGithubError403EdgeCases:
         error_type, error_msg = _classify_github_error(exc)
 
         assert error_type == CommitResult.PERMISSION_DENIED
+        assert "permission" in error_msg.lower()
 
     def test_403_data_is_integer(self):
         """Test 403 error when e.data is an unexpected type (integer).
@@ -101,6 +104,7 @@ class TestClassifyGithubError403EdgeCases:
         error_type, error_msg = _classify_github_error(exc)
 
         assert error_type == CommitResult.PERMISSION_DENIED
+        assert "permission" in error_msg.lower()
 
 
 class TestProtectedBranchMessageVariants:
@@ -289,6 +293,7 @@ class TestProtectedBranchInStringData:
         error_type, error_msg = _classify_github_error(exc)
 
         assert error_type == CommitResult.PERMISSION_DENIED
+        assert "branch protection" in error_msg.lower()
 
     def test_no_protected_branch_in_string_data(self):
         """Test that string data without protected branch is handled correctly.


### PR DESCRIPTION
# test(#3232): Add edge case tests for _classify_github_error 403 variants

## Summary

Adds 24 edge case tests for `_classify_github_error()` focusing on 403 error handling and protected branch detection. These tests complement the existing tests in `test_commit_file.py` by covering scenarios where `e.data` has unusual formats or the protected branch error message uses different wording.

**Test categories:**
- **Data format edge cases (6 tests)**: `e.data` is None, string, empty dict, dict without message key, list, or integer
- **Protected branch message variants (7 tests)**: Different GitHub wording like "protected branch hook declined", "PROTECTED BRANCH rules", "branch is protected", etc.
- **False-positive prevention (3 tests)**: Ensures generic 403s, token expiration, and permission errors don't trigger protected branch detection
- **String data format (2 tests)**: Protected branch detection when `e.data` is a string
- **Other status codes (6 tests)**: Verifies 409, 404, 500, 401, 422 handle unusual data formats gracefully

## Updates since last revision

Addressed valid Gemini Code Assist review feedback by adding `error_msg` assertions to strengthen test contracts:
- `test_403_data_is_empty_dict`: assert "permission" in error_msg
- `test_403_data_dict_without_message_key`: assert "permission" in error_msg
- `test_403_data_is_list`: assert "permission" in error_msg
- `test_403_data_is_integer`: assert "permission" in error_msg
- `test_protected_branch_in_string_data`: assert "branch protection" in error_msg

## Review & Testing Checklist for Human

- [ ] Verify the protected branch message variants (lines 117-219) are realistic GitHub API responses - these are based on documented GitHub behavior but may not cover all actual variants
- [ ] Check that `test_branch_is_protected_variant` (line 162) intentionally doesn't assert "branch protection" in the message - this tests a variant where the phrase "protected branch" doesn't appear but "is protected" does, which correctly falls through to generic 403 handling

**Test plan:**
```bash
cd ~/repos/morningai && source .venv/bin/activate
export PYTHONPATH="$PWD/handoff/20250928/40_App/orchestrator:$PYTHONPATH"
pytest handoff/20250928/40_App/orchestrator/tools/tests/test_classify_github_error_edge_cases.py -v
```

### Notes

- Part of Track C testing effort (#3218, #3240, #3246, #3232)
- Parent issue: #3217 (D-1.5: Protected Branch Safety Checks for SimpleCoder)
- All 24 tests pass locally

---
Link to Devin run: https://app.devin.ai/sessions/56997061d38a42258df4b91215cc8ae3
Requested by: Ryan Chen (@RC918)