### PR TITLE
refactor(#3308): Narrow xfail scope - release 19 XPASS tests

### DIFF
--- a/handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py
+++ b/handoff/20250928/40_App/orchestrator/meta_agent/tests/test_vscode_ide.py
@@ -1533,7 +1533,6 @@ class TestInitializeSession:
         assert healthz_call_count >= 1, f"Expected at least 1 healthz call, got {healthz_call_count}"
 
 
-@pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
 class TestCorsConfig:
     """Tests for CORS / iframe configuration (#2353)"""
 
@@ -1570,6 +1569,7 @@ class TestCorsConfig:
         assert config["public_url"] is None
         assert config["iframe_enabled"] is False
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     def test_get_cors_config_with_origins(self, service, monkeypatch):
         """Test get_cors_config parses comma-separated origins"""
         monkeypatch.setattr(
@@ -1604,6 +1604,7 @@ class TestCorsConfig:
         assert headers["X-Frame-Options"] == "DENY"
         assert "Content-Security-Policy" not in headers
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     def test_get_cors_headers_single_origin(self, service, monkeypatch):
         """Test get_cors_headers with single origin sets both headers"""
         monkeypatch.setattr(
@@ -1620,6 +1621,7 @@ class TestCorsConfig:
         assert headers["Content-Security-Policy"] == expected_csp
         assert headers["X-Frame-Options"] == "ALLOW-FROM https://app.morningai.com"
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     def test_get_cors_headers_multiple_origins(self, service, monkeypatch):
         """Test get_cors_headers with multiple origins only sets CSP"""
         monkeypatch.setattr(
@@ -1649,6 +1651,7 @@ class TestCorsConfig:
 
         assert config["default_extensions"] == []
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     def test_get_extension_config_with_extensions(self, service, monkeypatch):
         """Test get_extension_config parses comma-separated extension IDs"""
         monkeypatch.setattr(
@@ -1664,6 +1667,7 @@ class TestCorsConfig:
             "dbaeumer.vscode-eslint"
         ]
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     def test_get_extension_config_trims_whitespace(self, service, monkeypatch):
         """Test get_extension_config trims whitespace from extension IDs"""
         monkeypatch.setattr(
@@ -1678,6 +1682,7 @@ class TestCorsConfig:
             "esbenp.prettier-vscode"
         ]
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     def test_get_desired_extensions_defaults_only(self, service, mock_session, monkeypatch):
         """Test _get_desired_extensions returns only defaults when no extras"""
         monkeypatch.setattr(
@@ -1689,6 +1694,7 @@ class TestCorsConfig:
 
         assert desired == ["ms-python.python", "esbenp.prettier-vscode"]
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     def test_get_desired_extensions_with_extras(self, service, mock_session, monkeypatch):
         """Test _get_desired_extensions combines defaults with per-task extras"""
         monkeypatch.setattr(
@@ -1701,6 +1707,7 @@ class TestCorsConfig:
 
         assert desired == ["ms-python.python", "dbaeumer.vscode-eslint"]
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     def test_get_desired_extensions_deduplicates(self, service, mock_session, monkeypatch):
         """Test _get_desired_extensions removes duplicates preserving order"""
         monkeypatch.setattr(
@@ -1733,6 +1740,7 @@ class TestCorsConfig:
 
         assert "extensions_desired" not in mock_session.metadata
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     @pytest.mark.asyncio
     async def test_ensure_extensions_installed_all_already_installed(
         self, service, mock_session, monkeypatch
@@ -1766,6 +1774,7 @@ class TestCorsConfig:
         }
         assert mock_session.metadata["extensions_failed"] == []
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     @pytest.mark.asyncio
     async def test_ensure_extensions_installed_installs_missing(
         self, service, mock_session, monkeypatch
@@ -1804,6 +1813,7 @@ class TestCorsConfig:
         ]
         assert mock_session.metadata["extensions_failed"] == []
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     @pytest.mark.asyncio
     async def test_ensure_extensions_installed_handles_failures(
         self, service, mock_session, monkeypatch
@@ -1834,6 +1844,7 @@ class TestCorsConfig:
         assert mock_session.metadata["extensions_installed"] == ["ms-python.python"]
         assert mock_session.metadata["extensions_failed"] == ["invalid.extension"]
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - CORS/extension config env var mismatch")
     @pytest.mark.asyncio
     async def test_ensure_extensions_installed_list_failure(
         self, service, mock_session, monkeypatch
@@ -1861,7 +1872,6 @@ class TestCorsConfig:
         assert "extensions_installed" not in mock_session.metadata
 
 
-@pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - resource monitoring env var mismatch")
 class TestResourceMonitoring:
     """Tests for resource monitoring functionality (#2353)"""
 
@@ -1909,6 +1919,7 @@ class TestResourceMonitoring:
         assert limits["memory_limit_percent"] == 85
         assert limits["max_sessions"] == 10
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - resource monitoring env var mismatch")
     def test_get_resource_limits_custom_values(self, service, monkeypatch):
         """Test get_resource_limits with custom configuration"""
         monkeypatch.setattr(
@@ -2086,6 +2097,7 @@ class TestResourceMonitoring:
         assert result["can_create_session"] is False
         assert any("Memory overloaded" in r for r in result["reasons"])
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - resource monitoring env var mismatch")
     @pytest.mark.asyncio
     async def test_check_resource_overload_session_limit(
         self, service, monkeypatch
@@ -2122,6 +2134,7 @@ class TestResourceMonitoring:
         assert result["can_create_session"] is False
         assert any("Session limit reached" in r for r in result["reasons"])
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - resource monitoring env var mismatch")
     @pytest.mark.asyncio
     async def test_get_idle_sessions_returns_idle(self, service, monkeypatch):
         """Test get_idle_sessions returns sessions that exceeded idle timeout"""
@@ -2187,6 +2200,7 @@ class TestResourceMonitoring:
 
         assert len(idle_sessions) == 0
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - resource monitoring env var mismatch")
     @pytest.mark.asyncio
     async def test_get_idle_sessions_disabled(self, service, monkeypatch):
         """Test get_idle_sessions returns empty when timeout is disabled"""

--- a/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_auto_fixer.py
+++ b/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_auto_fixer.py
@@ -365,10 +365,10 @@ except ImportError:
     HAS_LANGGRAPH = False
 
 
-@pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - langgraph_orchestrator import fails")
 class TestFixerNodeIntegration:
     """Integration tests for fixer_node with AutoFixer"""
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - langgraph_orchestrator import fails")
     @pytest.mark.skipif(not HAS_LANGGRAPH, reason="langgraph not installed")
     def test_fixer_node_increments_retry_count(self):
         """Test that fixer_node increments retry_count"""
@@ -404,6 +404,7 @@ class TestFixerNodeIntegration:
 
         assert "Max retries" in (result.get("error") or "")
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - langgraph_orchestrator import fails")
     @pytest.mark.skipif(not HAS_LANGGRAPH, reason="langgraph not installed")
     def test_fixer_node_calls_auto_fixer_when_enabled(self):
         """Test that fixer_node calls AutoFixer when enabled"""

--- a/handoff/20250928/40_App/orchestrator/webhooks/tests/test_normalizer_ai_reviewer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/tests/test_normalizer_ai_reviewer.py
@@ -70,10 +70,10 @@ class TestEventNormalizerAIReviewerKeywords:
         assert "nitpick:" in keywords
 
 
-@pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
 class TestEventNormalizerIsActionable:
     """Tests for EventNormalizer.is_actionable with AI reviewers"""
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_is_actionable_for_ai_reviewer_event(self, event_normalizer):
         """Test that AI reviewer events are always actionable"""
         event = create_mock_event(
@@ -82,6 +82,7 @@ class TestEventNormalizerIsActionable:
         )
         assert event_normalizer.is_actionable(event) is True
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_is_actionable_for_ai_reviewer_with_empty_description(
         self, event_normalizer
     ):
@@ -92,6 +93,7 @@ class TestEventNormalizerIsActionable:
         )
         assert event_normalizer.is_actionable(event) is True
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_is_actionable_for_suggestion_keyword(self, event_normalizer):
         """Test that 'suggestion:' keyword triggers actionable"""
         event = create_mock_event(
@@ -99,6 +101,7 @@ class TestEventNormalizerIsActionable:
         )
         assert event_normalizer.is_actionable(event) is True
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_is_actionable_for_consider_keyword(self, event_normalizer):
         """Test that 'consider:' keyword triggers actionable"""
         event = create_mock_event(
@@ -106,6 +109,7 @@ class TestEventNormalizerIsActionable:
         )
         assert event_normalizer.is_actionable(event) is True
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_is_actionable_for_security_concern_keyword(self, event_normalizer):
         """Test that 'security concern' keyword triggers actionable"""
         event = create_mock_event(
@@ -113,6 +117,7 @@ class TestEventNormalizerIsActionable:
         )
         assert event_normalizer.is_actionable(event) is True
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_is_actionable_for_code_review_keyword(self, event_normalizer):
         """Test that 'code review' keyword triggers actionable"""
         event = create_mock_event(
@@ -120,6 +125,7 @@ class TestEventNormalizerIsActionable:
         )
         assert event_normalizer.is_actionable(event) is True
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_is_actionable_for_refactor_keyword(self, event_normalizer):
         """Test that 'refactor' keyword triggers actionable"""
         event = create_mock_event(
@@ -127,6 +133,7 @@ class TestEventNormalizerIsActionable:
         )
         assert event_normalizer.is_actionable(event) is True
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_is_actionable_for_vulnerability_keyword(self, event_normalizer):
         """Test that 'vulnerability' keyword triggers actionable"""
         event = create_mock_event(
@@ -134,6 +141,7 @@ class TestEventNormalizerIsActionable:
         )
         assert event_normalizer.is_actionable(event) is True
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_is_actionable_for_deprecated_keyword(self, event_normalizer):
         """Test that 'deprecated' keyword triggers actionable"""
         event = create_mock_event(
@@ -149,6 +157,7 @@ class TestEventNormalizerIsActionable:
         )
         assert event_normalizer.is_actionable(event) is False
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_is_actionable_case_insensitive(self, event_normalizer):
         """Test that keyword detection is case insensitive"""
         event = create_mock_event(
@@ -157,10 +166,10 @@ class TestEventNormalizerIsActionable:
         assert event_normalizer.is_actionable(event) is True
 
 
-@pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - extract_task returns None")
 class TestEventNormalizerExtractTask:
     """Tests for EventNormalizer.extract_task with AI reviewers"""
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - extract_task returns None")
     def test_extract_task_from_ai_reviewer_event(self, event_normalizer):
         """Test that tasks are extracted from AI reviewer events"""
         event = create_mock_event(
@@ -189,10 +198,10 @@ class TestEventNormalizerExtractTask:
         assert task.source_event.metadata.get("review_source") == "copilot"
 
 
-@pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
 class TestAIReviewerIntegration:
     """Integration tests for AI reviewer workflow in normalizer"""
 
+    @pytest.mark.xfail(reason="Pre-existing legacy debt #3251 - is_actionable() logic mismatch")
     def test_full_ai_reviewer_workflow(self, event_normalizer):
         """Test complete workflow: is_actionable -> extract_task"""
         # Simulate a Gemini Code Assist review comment


### PR DESCRIPTION
# refactor(#3308): Narrow xfail scope - release 19 XPASS tests

## Summary

Moves `@pytest.mark.xfail` decorators from class-level to function-level to release 19 tests that were incorrectly marked as expected-to-fail (XPASS "unexpected survivors"). These tests were passing but marked as xfail due to overly broad class-level markers.

**Changes by file:**
- `test_normalizer_ai_reviewer.py`: Removed class-level xfail from 3 classes, added function-level xfail to 10 genuinely failing tests, released 3 XPASS tests
- `test_vscode_ide.py TestCorsConfig`: Removed class-level xfail, added function-level xfail to 12 failing tests, released 4 XPASS tests  
- `test_vscode_ide.py TestResourceMonitoring`: Removed class-level xfail, added function-level xfail to 4 failing tests, released 11 XPASS tests
- `test_auto_fixer.py TestFixerNodeIntegration`: Removed class-level xfail, added function-level xfail to 2 failing tests, released 1 XPASS test

## Review & Testing Checklist for Human

- [ ] **Verify CI passes** - The test counts should change: xpassed should decrease from 19 to 0, and total passed should increase by 19
- [ ] **Spot-check xfail placement** - Verify that the function-level xfail markers are on the correct tests (the ones that genuinely fail, not the ones that pass)
- [ ] **Confirm no new failures** - Ensure no tests that were previously passing are now failing

**Recommended test plan:**
1. Wait for CI to complete
2. Check the pytest summary: expect ~4,721 passed, ~26 xfailed, 0 xpassed
3. If any tests fail unexpectedly, the xfail marker may have been removed from a test that should have kept it

### Notes

This is part of #3308 "收窄 xfail 範圍，釋放那 19 個「意外生還者」" - narrowing xfail scope to release the 19 "unexpected survivors" identified in PR #3302.

The identification of which tests are XPASS vs XFAIL was based on CI logs from the merged #3302 PR. If any tests were misidentified, CI will catch it.

---
**Link to Devin run**: https://app.devin.ai/sessions/56997061d38a42258df4b91215cc8ae3
**Requested by**: Ryan Chen (@RC918)