### PR TITLE
docs(governance): add disaster recovery playbook with v2.0.0-2025-final baseline

### DIFF
--- a/docs/governance/RECOVERY.md
+++ b/docs/governance/RECOVERY.md
@@ -33,15 +33,20 @@
 如果系統在 2026 年初發生重大故障，請執行以下步驟：
 
 ```bash
-# 1. 切換至黃金基準線
-git fetch origin
-git checkout v2.0.0-2025-final
+# 1. 取得最新 tags
+git fetch origin --tags
 
-# 2. 驗證版本
-git log -1 --oneline
-# 預期輸出: 19408e97 feat(governance): implement EPIC I-3b provider health snapshot API (#3359)
+# 2. 建立 hotfix 分支（推薦，允許後續緊急修復）
+git checkout -b hotfix/rollback-v2.0.0-2025-final v2.0.0-2025-final
 
-# 3. 重新部署
+# 或者：如果只需要部署精確基準線，可直接 checkout tag（detached HEAD）
+# git checkout v2.0.0-2025-final
+
+# 3. 驗證版本
+git rev-parse v2.0.0-2025-final
+# 預期輸出: 19408e97...（完整 commit hash）
+
+# 4. 重新部署
 # (依照您的部署流程執行)
 ```
 
@@ -49,22 +54,24 @@ git log -1 --oneline
 
 - [ ] 確認問題無法透過 hotfix 解決
 - [ ] 通知相關團隊成員
+- [ ] **備份資料庫**（建立 snapshot 或 point-in-time restore point）
 - [ ] 備份當前狀態的 logs 和 metrics
-- [ ] 確認回滾版本的相容性（資料庫 migrations 等）
+- [ ] 確認回滾版本的相容性。**警告：資料庫 schema 回滾需特別謹慎，請參考 [Database Migrations Guide](../database/MIGRATIONS.md) 了解 downgrade 程序。**
 
 ### 回滾後驗證
 
-1. 執行 smoke tests
-2. 檢查 Orchestrator 健康狀態
-3. 驗證 Provider Health 監控正常
-4. 確認 RLS 安全門禁運作
+依照 [Post-Deploy Smoke Test Checklist](../runbooks/POST_DEPLOY_SMOKE_TEST_CHECKLIST.md) 執行 **MUST-PASS** sections：
+
+1. **Section 1: Backend Health Verification** - 驗證 `/healthz` 和核心 API
+2. **Section 2: RLS Verification** - 確認 RLS 安全門禁正常（如適用）
+3. **Section 3: Application Smoke Tests** - 執行應用程式功能測試
 
 ---
 
 ## 聯絡資訊
 
 - 專案負責人: Ryan Chen (@RC918)
-- 緊急聯絡: [依照組織政策填寫]
+- 緊急聯絡: [依照組織政策填寫，例如 PagerDuty/Slack #incidents]
 
 ---
 
@@ -72,4 +79,5 @@ git log -1 --oneline
 
 | 日期 | 版本 | 變更 |
 |------|------|------|
+| 2025-12-31 | 1.1 | 改進回滾程序（建立 hotfix 分支）、新增資料庫備份步驟、連結至現有 runbooks |
 | 2025-12-31 | 1.0 | 初始版本，建立 v2.0.0-2025-final 黃金基準線 |


### PR DESCRIPTION
## Summary

Adds a disaster recovery playbook (`docs/governance/RECOVERY.md`) that documents the emergency rollback procedure to the v2.0.0-2025-final golden baseline. This document provides quick recovery guidance if system failures occur in 2026.

The playbook includes:
- Golden baseline reference table with version tag and date
- Feature list for v2.0.0-2025-final (Orchestrator coverage, GeneralCoder, Drift Detection, Provider Health, RLS, etc.)
- Step-by-step emergency rollback commands
- Pre-rollback checklist (including database backup)
- Post-rollback verification steps (linked to existing runbooks)

**Note**: The version tag `v2.0.0-2025-final` was also created and pushed as part of this work.

### Updates since last revision

Based on gemini-code-assist review feedback:
- Changed rollback command to create a hotfix branch (`git checkout -b hotfix/...`) instead of detached HEAD, allowing emergency fixes on top of the baseline
- Added database backup step to pre-rollback checklist with warning about schema rollback
- Linked to existing `docs/database/MIGRATIONS.md` for downgrade guidance
- Linked to existing `docs/runbooks/POST_DEPLOY_SMOKE_TEST_CHECKLIST.md` for verification steps
- Created follow-up issue #3365 for a dedicated production database rollback runbook

## Review & Testing Checklist for Human

- [ ] Verify the tag `v2.0.0-2025-final` exists on remote: `git tag -l v2.0.0-2025-final`
- [ ] Verify the commit hash matches: `git rev-parse v2.0.0-2025-final` should return `19408e97...`
- [ ] Verify relative links work: check that `../database/MIGRATIONS.md` and `../runbooks/POST_DEPLOY_SMOKE_TEST_CHECKLIST.md` resolve correctly from `docs/governance/`
- [ ] Review if the feature list accurately reflects what's included in the tagged version

**Test Plan**: Run `git checkout -b test-rollback v2.0.0-2025-final` locally to verify the rollback procedure works as documented.

### Notes

- Requested by: Ryan Chen (@RC918)
- Link to Devin run: https://app.devin.ai/sessions/4c624f57c50e499f98859c62908c800d
- Emergency contact information is placeholder text and should be filled in per organization policy
- Follow-up issue #3365 created for dedicated DB rollback runbook