### PR TITLE
fix(#3081): Deprecate 'style' category in CommentCategory

### DIFF
--- a/handoff/20250928/40_App/orchestrator/review_comment_schema.py
+++ b/handoff/20250928/40_App/orchestrator/review_comment_schema.py
@@ -54,8 +54,17 @@ CISeverity = Literal["low", "medium", "high", "critical"]
 # Comment categories
 # Major Brain Upgrade (2025-12): Added "contract" for API/schema/timestamp changes
 # Removed "style" from prompt (but kept here for backward compatibility)
+#
+# DEPRECATION NOTICE (Issue #3081):
+# The "style" category is DEPRECATED and will be removed in a future version.
+# - Deprecated since: 2025-12 (Major Brain Upgrade)
+# - Reason: Senior Architect policy prohibits style nitpicks to reduce noise
+# - Migration: Use "maintainability" for code quality issues, or "other" for misc
+# - Timeline: Will be removed after 2026-Q1 (3-month deprecation window)
+# When "style" is used, a deprecation warning will be logged.
 CommentCategory = Literal[
-    "style", "bug", "performance", "security",
+    "style",  # DEPRECATED - see notice above
+    "bug", "performance", "security",
     "maintainability", "documentation", "contract", "other"
 ]
 
@@ -157,6 +166,10 @@ def _normalize_category(category: Optional[str]) -> CommentCategory:
 
     Returns:
         Valid category or "other"
+
+    Note:
+        The "style" category is DEPRECATED (Issue #3081). A warning will be
+        logged when it is used. Migrate to "maintainability" or "other".
     """
     if not category:
         return DEFAULT_CATEGORY
@@ -165,9 +178,18 @@ def _normalize_category(category: Optional[str]) -> CommentCategory:
 
     # Use module-level VALID_CATEGORIES frozenset for efficient lookup
     if category_lower in VALID_CATEGORIES:
+        # Issue #3081: Log deprecation warning for 'style' category
+        if category_lower == "style":
+            logger.warning(
+                "[ReviewCommentSchema] DEPRECATION WARNING: 'style' category is "
+                "deprecated and will be removed after 2026-Q1. "
+                "Use 'maintainability' for code quality issues or 'other' for misc. "
+                "See Issue #3081 for migration guidance."
+            )
         return category_lower  # type: ignore
 
     # Map common variations
+    # Note: Aliases that map to "style" will also trigger deprecation warning
     category_aliases = {
         "formatting": "style",
         "code style": "style",
@@ -184,7 +206,19 @@ def _normalize_category(category: Optional[str]) -> CommentCategory:
         "comment": "documentation",
     }
 
-    return category_aliases.get(category_lower, DEFAULT_CATEGORY)
+    result = category_aliases.get(category_lower, DEFAULT_CATEGORY)
+
+    # Issue #3081: Log deprecation warning for aliases that map to 'style'
+    if result == "style":
+        logger.warning(
+            "[ReviewCommentSchema] DEPRECATION WARNING: '%s' maps to 'style' category "
+            "which is deprecated and will be removed after 2026-Q1. "
+            "Use 'maintainability' for code quality issues or 'other' for misc. "
+            "See Issue #3081 for migration guidance.",
+            category_lower
+        )
+
+    return result
 
 
 def _parse_line_number(value: Any) -> Optional[int]:

--- a/handoff/20250928/40_App/orchestrator/tests/test_review_comment_schema.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_review_comment_schema.py
@@ -129,6 +129,27 @@ class TestNormalizeCategory:
     def test_none_defaults_to_other(self):
         assert _normalize_category(None) == "other"
 
+    def test_style_category_logs_deprecation_warning(self, caplog):
+        """Issue #3081: 'style' category should log deprecation warning"""
+        import logging
+        with caplog.at_level(logging.WARNING):
+            result = _normalize_category("style")
+        assert result == "style"
+        assert "DEPRECATION WARNING" in caplog.text
+        assert "style" in caplog.text
+        assert "#3081" in caplog.text
+
+    def test_style_alias_logs_deprecation_warning(self, caplog):
+        """Issue #3081: Aliases mapping to 'style' should log deprecation warning"""
+        import logging
+        for alias in ["formatting", "code style", "lint"]:
+            caplog.clear()
+            with caplog.at_level(logging.WARNING):
+                result = _normalize_category(alias)
+            assert result == "style"
+            assert "DEPRECATION WARNING" in caplog.text
+            assert "#3081" in caplog.text
+
 
 class TestValidateLineRange:
     """Tests for line range validation"""


### PR DESCRIPTION
## Summary

Deprecates the `style` category in `CommentCategory` as part of the Senior Architect policy to reduce noise from style nitpicks. The category still works for backward compatibility but now logs a deprecation warning when used.

**Changes:**
- Added deprecation notice comment to `CommentCategory` definition with migration guidance
- Added warning log in `_normalize_category()` when 'style' is used directly
- Added warning log for aliases that map to 'style' (formatting, lint, code style)
- Added 2 tests to verify deprecation warnings are logged correctly
- Documented migration path: use `maintainability` for code quality issues or `other` for misc
- Timeline: removal after 2026-Q1 (3-month deprecation window)

## Review & Testing Checklist for Human

- [ ] Verify the deprecation warning message is appropriate and won't be too noisy in production logs
- [ ] Confirm the migration path (`maintainability` or `other`) aligns with team conventions

**Test Plan:** Run `pytest handoff/20250928/40_App/orchestrator/tests/test_review_comment_schema.py::TestNormalizeCategory -v` to verify all category normalization tests pass including the new deprecation warning tests.

### Notes

Closes #3081

This PR was created with assistance from Devin.
- Link to Devin run: https://app.devin.ai/sessions/56997061d38a42258df4b91215cc8ae3
- Requested by: Ryan Chen (@RC918)