### PR TITLE
docs: add EPIC C/D roadmaps and EPIC E/F/G/H placeholder issues

### DIFF
--- a/docs/EPIC_C_FLOW_CONTROLLER_V3_ROADMAP.md
+++ b/docs/EPIC_C_FLOW_CONTROLLER_V3_ROADMAP.md
@@ -1,0 +1,179 @@
+# EPIC C: Flow Controller v3 (LLM-driven Routing) - Roadmap
+
+> Last Updated: 2026-01-02
+
+## Overview
+
+EPIC C focuses on replacing deterministic `conditional_edges` routing with a `HybridRoutingPolicy` that uses LLM for ambiguous routing decisions. This enables intelligent, context-aware workflow orchestration.
+
+**GitHub Issue**: [#2743](https://github.com/RC918/morningai/issues/2743)
+
+**Blueprint Alignment**: Section 3.2 - Flow Controller v3
+
+## Status Summary
+
+| Stage | Status | Key Issues |
+|-------|--------|------------|
+| Stage 0: Foundations | **Completed** | #2744, #2745, #2746, #2747 |
+| Stage 1: Pilot | **Completed** (C-6 Graph Wiring) | #2748, #2758, #2749, #3182 |
+| C-7: Rollout Design | **Completed** | #2750 |
+| Operationalization | **Pending** | [#3486](https://github.com/RC918/morningai/issues/3486) |
+| Stage 2: Expansion | Planned | #2751, #2752, #2753 |
+
+---
+
+## Stage 0: Foundations (Completed)
+
+Framework and safety foundations for LLM-driven routing.
+
+### Implemented Items
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| [#2744](https://github.com/RC918/morningai/issues/2744) | Schema Definition (`RoutingCandidate`, `RoutingDecision`, `RoutingContext`) | Done |
+| [#2745](https://github.com/RC918/morningai/issues/2745) | Router Node Interface + Decision Validator | Done |
+| [#2746](https://github.com/RC918/morningai/issues/2746) | Feature Flag (`ENABLE_DYNAMIC_ROUTING`) | Done |
+| [#2747](https://github.com/RC918/morningai/issues/2747) | Router Observability (`RouterMetrics`) | Done |
+
+---
+
+## Stage 1: Pilot (Completed)
+
+Review segment integration and minimal viable routing.
+
+### Implemented Items
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| [#2748](https://github.com/RC918/morningai/issues/2748) | C-5: Review Segment Integration | Done |
+| [#2758](https://github.com/RC918/morningai/issues/2758) | C-5b: SimpleCoderAgent for Flow Pilot | Done |
+| [#2749](https://github.com/RC918/morningai/issues/2749) | Integration Tests / Contract Tests | Done |
+| [#3182](https://github.com/RC918/morningai/issues/3182) | C-6: Graph Wiring for Hybrid Router | Done |
+
+### C-6 Implementation Evidence
+
+- `HybridRoutingPolicy` implemented in `core/flow/hybrid_routing_policy.py`
+- `RouterNode` integrated into LangGraph orchestrator
+- Feature flag `ENABLE_DYNAMIC_ROUTING` controls activation
+- Fast path (deterministic) handles 70-80% of decisions
+- Slow path (LLM-driven) handles ambiguous cases
+
+---
+
+## C-7: Rollout Design (Completed)
+
+Canary rollout strategy and runbook documentation.
+
+### Deliverables
+
+| Item | Description | Status |
+|------|-------------|--------|
+| Rollout Runbook | `docs/runbooks/FLOW_ROUTER_V3_ROLLOUT.md` (457 lines) | Done |
+| Rollback Procedures | Immediate and gradual rollback documented | Done |
+| Monitoring Thresholds | Fallback rate, latency p99, error rate defined | Done |
+
+---
+
+## Operationalization Gap (Pending)
+
+> **Tracking Issue**: [#3486](https://github.com/RC918/morningai/issues/3486)
+
+### Current Gaps
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| `RouterMetrics` class | Implemented | 399 lines, full API |
+| Wiring to `HybridRoutingPolicy` | **Not Wired** | No calls to `record_decision()` |
+| Wiring to `RouterNode` | **Not Wired** | `metrics_callback` param exists but not passed |
+| API endpoint `/governance/router-metrics` | **Not Verified** | May not exist |
+| `router_latency_p99` | **Not Implemented** | Only `get_average_latency()` available |
+| `router_error_rate` | **Not Implemented** | No explicit method |
+
+### Action Required Before Pilot Rollout
+
+1. Wire `RouterMetrics` into `HybridRoutingPolicy` or `router_node`
+2. Add p99 latency calculation OR update runbook to use `average_latency`
+3. Verify or implement `/governance/router-metrics` API endpoint
+4. Configure Grafana dashboard with actual metric names
+5. Implement `get_error_rate()` OR rely on Sentry's `router_error_count`
+
+---
+
+## Stage 2: Expansion (Planned)
+
+Cost optimization and extended routing coverage.
+
+### Planned Items
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| [#2751](https://github.com/RC918/morningai/issues/2751) | Candidate Set Governance | Planned |
+| [#2752](https://github.com/RC918/morningai/issues/2752) | Hybrid Routing Optimization | Planned |
+| [#2753](https://github.com/RC918/morningai/issues/2753) | Extend to Next Transition | Planned |
+
+---
+
+## Dependencies
+
+```
+Stage 0: #2744 → #2745 → #2746 → #2747 (hard dependencies)
+Stage 1: #2748 → #2758 (C-5b) → #2749 → #3182 (C-6)
+Stage 2: #2751 → #2752 (safety guardrails before cost optimization)
+
+Cross-EPIC:
+- EPIC B Phase 6 (B-6): ReviewOutcome schema → consumed by Router
+- EPIC D: Depends on Flow Controller for routing decisions
+```
+
+---
+
+## Feature Flag Configuration
+
+```yaml
+ENABLE_DYNAMIC_ROUTING:
+  type: boolean
+  default: false
+  description: |
+    Enable LLM-driven dynamic routing (Flow Controller v3).
+    Default False = 100% old behavior (conditional_edges).
+    True = Hybrid Router with LLM slow path for ambiguous cases.
+```
+
+---
+
+## Verification Signals (Production Readiness)
+
+Before full production rollout, verify:
+
+- [ ] RouterMetrics wired and emitting data ([#3486](https://github.com/RC918/morningai/issues/3486))
+- [ ] Fallback rate < 10% in staging
+- [ ] Latency p99 < 15s (or average < 5s)
+- [ ] No P0/P1 incidents during canary
+- [ ] Grafana dashboard configured
+
+---
+
+## Blueprint Alignment
+
+| Blueprint Guarantee | Implementation |
+|--------------------|----------------|
+| Deterministic | `unknown` verdict triggers fallback to rule-based routing |
+| Fail-Safe | LLM timeout/error → deterministic fallback |
+| Observable | RouterMetrics + Sentry + Log event codes |
+| Reversible | Feature flag instant rollback |
+
+---
+
+## Related Documents
+
+- [Rollout Runbook](./runbooks/FLOW_ROUTER_V3_ROLLOUT.md)
+- [EPIC B Roadmap](./EPIC_B_DIFF_AWARE_REVIEW_ROADMAP.md) (ReviewOutcome schema)
+- [Wish Pool v2](./north_star/ECOSYSTEM_WISHPOOL_V2.md)
+
+---
+
+## Changelog
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-01-02 | Ryan Chen (@RC918) with Devin AI | Initial roadmap document |

--- a/docs/EPIC_D_AUTONOMOUS_CODER_ROADMAP.md
+++ b/docs/EPIC_D_AUTONOMOUS_CODER_ROADMAP.md
@@ -1,0 +1,258 @@
+# EPIC D: Autonomous Coder Agent Family - Roadmap
+
+> Last Updated: 2026-01-02
+
+## Overview
+
+EPIC D implements the complete Coder Agent family, enabling the system to autonomously complete the full cycle from "requirement understanding" to "code generation" to "self-correction". This is the main battlefield for realizing the **L2 - Execution Layer** in Wish Pool v2.
+
+**GitHub Issue**: [#2759](https://github.com/RC918/morningai/issues/2759)
+
+**Blueprint Alignment**: Section 3.3 - Agent Catalog V2 (Coder Family)
+
+## Status Summary
+
+| Stage | Status | Key Issues |
+|-------|--------|------------|
+| Stage 0: Pre-validation | **Completed** (via EPIC C) | #2758 (C-5b) |
+| Stage 1: General Coder MVP | **In Progress** | #2760, #2761 |
+| Stage 2: Intelligence & Automation | Planned | #2762, #2764 |
+| Stage 3: Advanced Capabilities | Future | D-5, D-6 |
+| HITL Gate Operationalization | **Pending** | [#3487](https://github.com/RC918/morningai/issues/3487) |
+
+---
+
+## Architecture
+
+```
+EPIC D: Coder Family
+
+  Planner ──▶ Senior Coder ──▶ Junior Coder
+  (Tier 1)     (Tier 1)        (Tier 2)
+  Task Split   Architecture    Code Impl
+      │            │               │
+      ▼            ▼               ▼
+  ┌─────────────────────────────────────┐
+  │        Self-Correction Loop         │
+  │     (npm test fail → auto-fix)      │
+  └─────────────────────────────────────┘
+```
+
+---
+
+## Stage 0: Pre-validation (Completed)
+
+Completed via EPIC C - SimpleCoder validates Flow Controller routing.
+
+### Implemented Items
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| [#2758](https://github.com/RC918/morningai/issues/2758) | C-5b: SimpleCoderAgent for Flow Pilot | Done |
+
+**SimpleCoder Specs**:
+- Model: Tier 2 (Qwen3-Next-80B)
+- Capability: Single-file create/modify only
+- Purpose: "Crash Test Dummy" for Flow Controller v3
+
+---
+
+## Stage 1: General Coder MVP (In Progress)
+
+Multi-file editing and Senior Coder reasoning capabilities.
+
+### Items
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| [#2760](https://github.com/RC918/morningai/issues/2760) | D-1: General Coder Agent (MVP) | In Progress |
+| [#2761](https://github.com/RC918/morningai/issues/2761) | D-2: Senior Coder Logic (Tier 1) | In Progress |
+
+### D-1: General Coder MVP
+
+**Acceptance Criteria**:
+- Support multi-file editing (up to 5 files)
+- Proper context window management
+- Integration with Flow Controller v3 routing
+
+### D-2: Senior Coder Logic
+
+**Acceptance Criteria**:
+- Implement reasoning step (think architecture before coding)
+- Produce architecture design document before code
+- Tier 1 model (Qwen3-235B) for complex reasoning
+
+---
+
+## HITL Gate Operationalization Gap (Pending)
+
+> **Tracking Issue**: [#3487](https://github.com/RC918/morningai/issues/3487)
+
+### Current Gap
+
+The `SeniorCoder` complexity abort mechanism currently falls back silently instead of triggering proper HITL (Human-in-the-Loop) gate.
+
+| Component | Expected Behavior | Actual Behavior |
+|-----------|-------------------|-----------------|
+| `_attempt_senior_coder_plan()` | Abort → Trigger HITL gate | Abort → Silent fallback |
+| HITL Integration Tests | Test actual abort → HITL path | Tests minimal graph only |
+
+### Action Required
+
+1. Add HITL trigger logic in `_attempt_senior_coder_plan()` abort path
+2. Update integration tests to cover SeniorCoder abort → HITL flow
+3. Add telemetry for HITL trigger events
+
+---
+
+## Stage 2: Intelligence & Automation (Planned)
+
+Spec-driven development and self-correction capabilities.
+
+### Planned Items
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| [#2762](https://github.com/RC918/morningai/issues/2762) | D-3: Spec-Driven Development | Planned |
+| [#2764](https://github.com/RC918/morningai/issues/2764) | D-4: Self-Correction Loop | Planned |
+
+### D-3: Spec-Driven Development
+
+**Acceptance Criteria**:
+- Coder can read and understand Planner's spec
+- Spec format standardized and validated
+- Traceability from spec to implementation
+
+### D-4: Self-Correction Loop
+
+**Acceptance Criteria**:
+- Detect `npm test` / `pytest` failures automatically
+- Parse error logs and identify fix targets
+- Attempt self-fix without Reviewer intervention
+- Maximum retry limit with HITL escalation
+
+---
+
+## Stage 3: Advanced Capabilities (Future)
+
+Planner v3 and cross-service coordination.
+
+### Future Items
+
+| Issue | Description | Status |
+|-------|-------------|--------|
+| D-5 | Planner v3 (Task Decomposition) | Future |
+| D-6 | Cross-Service Coordination | Future |
+
+### D-5: Planner v3
+
+**Vision**:
+- Decompose "login page" into "frontend task + backend task"
+- Generate dependency graph for parallel execution
+- Integrate with Flow Controller for orchestration
+
+> **Note**: Planner v3 may become a separate EPIC (EPIC F) due to scope.
+
+---
+
+## Model Configuration
+
+| Agent | Model Tier | Model | Purpose |
+|-------|------------|-------|---------|
+| SimpleCoder (C-5b) | Tier 2 | Qwen3-Next-80B | Flow Pilot validation |
+| Junior Coder | Tier 2 | Qwen3-Next-80B | Simple code implementation |
+| Senior Coder | Tier 1 | Qwen3-235B | Architecture design + Reasoning |
+| Planner | Tier 1 | Qwen3-235B | Task decomposition |
+
+---
+
+## Feature Flag Configuration
+
+```yaml
+ENABLE_SENIOR_CODER:
+  type: boolean
+  default: false
+  description: |
+    Enable Senior Coder Agent (Tier 1 reasoning).
+    Currently enabled in staging only for pilot testing.
+    Production enablement pending HITL gate operationalization.
+```
+
+---
+
+## Dependencies
+
+```
+EPIC C (Flow Controller v3)
+    └── C-5b (#2758): SimpleCoderAgent for Flow Pilot
+            │
+            ▼
+EPIC D (Coder Family)
+    ├── D-1 (#2760): General Coder MVP (depends on C-5b)
+    ├── D-2 (#2761): Senior Coder Logic (depends on D-1)
+    ├── D-3 (#2762): Spec-Driven Development (depends on D-2)
+    └── D-4 (#2764): Self-Correction Loop (depends on D-1)
+
+Cross-EPIC:
+- EPIC B: Reviewer validates Coder output
+- EPIC C: Flow Controller routes to appropriate Coder
+- EPIC I: Governance monitors Coder behavior
+```
+
+---
+
+## Verification Signals (Production Readiness)
+
+Before production enablement, verify:
+
+- [ ] HITL gate properly triggered on complexity abort ([#3487](https://github.com/RC918/morningai/issues/3487))
+- [ ] Multi-file editing works correctly (D-1)
+- [ ] Senior Coder reasoning produces valid architecture docs (D-2)
+- [ ] All Coders correctly routed by Flow Controller v3
+- [ ] Telemetry emitting for Coder decisions
+
+---
+
+## Acceptance Criteria (Red Lines)
+
+- [ ] D-1: Can handle multi-file editing (up to 5 files)
+- [ ] D-2: Senior Coder produces architecture design before coding
+- [ ] D-3: Coder can read and execute Planner's spec
+- [ ] D-4: Auto-fix on `npm test` failure (without Reviewer)
+- [ ] All Coders correctly routed by Flow Controller v3
+- [ ] HITL gate triggered on complexity abort
+
+---
+
+## Risk & Rollback
+
+- **Risk**: Coder output quality unstable
+- **Mitigation**: All Coder output must pass Reviewer review
+- **Rollback**: Disable Coder feature flag, fallback to manual handling
+
+---
+
+## Blueprint Alignment
+
+| Blueprint Guarantee | Implementation |
+|--------------------|----------------|
+| Tiered Models | Junior (Tier 2) vs Senior (Tier 1) |
+| Fail-Safe | Complexity abort → HITL escalation |
+| Observable | Telemetry for Coder decisions |
+| Reversible | Feature flag instant rollback |
+
+---
+
+## Related Documents
+
+- [EPIC C Roadmap](./EPIC_C_FLOW_CONTROLLER_V3_ROADMAP.md) (Flow Controller)
+- [EPIC B Roadmap](./EPIC_B_DIFF_AWARE_REVIEW_ROADMAP.md) (Reviewer)
+- [Wish Pool v2](./north_star/ECOSYSTEM_WISHPOOL_V2.md)
+
+---
+
+## Changelog
+
+| Date | Author | Changes |
+|------|--------|---------|
+| 2026-01-02 | Ryan Chen (@RC918) with Devin AI | Initial roadmap document |

--- a/docs/north_star/ECOSYSTEM_WISHPOOL_V2.md
+++ b/docs/north_star/ECOSYSTEM_WISHPOOL_V2.md
@@ -45,6 +45,15 @@
 | **Intelligence Layer** | Coding Agent Family | [EPIC D: Autonomous Coder Agent Family (#2759)](https://github.com/RC918/morningai/issues/2759) | **In Progress**; HITL Gate Pending ([#3487](https://github.com/RC918/morningai/issues/3487)) |
 | **Governance Layer** | Model Governance v2 + Autonomous Provisioning | [EPIC I: Runtime Governance & Immune System (#3342)](https://github.com/RC918/morningai/issues/3342) | Planning (after #3249) |
 
+### Future EPICs (Placeholder)
+
+| Layer | Wish Pool v2 Component | EPIC | Status |
+|-------|------------------------|------|--------|
+| **Governance Layer** | Safety Governor v2 + Compliance Radar v2 | [EPIC E: Safety Governor v2 + Compliance Radar v2 (#3489)](https://github.com/RC918/morningai/issues/3489) | Placeholder |
+| **Intelligence Layer** | Planner v3 | [EPIC F: Planner v3 (#3490)](https://github.com/RC918/morningai/issues/3490) | Placeholder (After EPIC D) |
+| **Infrastructure Layer** | Memory v2 | [EPIC G: Memory v2 (#3491)](https://github.com/RC918/morningai/issues/3491) | Placeholder |
+| **Infrastructure Layer** | Simulation Suite v1 | [EPIC H: Simulation Suite v1 (#3492)](https://github.com/RC918/morningai/issues/3492) | Placeholder |
+
 ### EPIC Dependencies
 
 ```
@@ -169,16 +178,16 @@ EPIC I 是 Blueprint 4.3 (Model Governance Framework v2) 與 4.4 (Autonomous Pro
 | Wish Pool v2 Section | Current Status | Next Action |
 |---------------------|----------------|-------------|
 | 2. Model Layer | **EPIC A Completed** | Maintenance mode |
-| 3.1 Planner v3 | Not started | After EPIC D |
+| 3.1 Planner v3 | Not started | [EPIC F (#3490)](https://github.com/RC918/morningai/issues/3490) - Placeholder (After EPIC D) |
 | 3.2 Flow Controller v3 | **EPIC C Stage 0 + C-6 Completed** (default: disabled); Operationalization Pending ([#3486](https://github.com/RC918/morningai/issues/3486)) | Wire RouterMetrics; Enable Pilot rollout |
 | 3.3 Agent Catalog V2 | **EPIC B Phase 1-3 + B-6 Completed**, EPIC D In Progress; HITL Gate Pending ([#3487](https://github.com/RC918/morningai/issues/3487)) | Continue D; Implement HITL gate for SeniorCoder |
-| 4.1 Safety Governor v2 | Not started | Future EPIC E |
-| 4.2 Compliance Radar v2 | Not started | Future EPIC E |
+| 4.1 Safety Governor v2 | Not started | [EPIC E (#3489)](https://github.com/RC918/morningai/issues/3489) - Placeholder |
+| 4.2 Compliance Radar v2 | Not started | [EPIC E (#3489)](https://github.com/RC918/morningai/issues/3489) - Placeholder |
 | 4.3 Model Governance v2 | **PR #3316 Completed** (ROUTING_ALLOWED_PROVIDERS) | **EPIC I** (#3342) |
 | 4.4 Autonomous Provisioning v2 | Planning | **EPIC I** (#3342) |
-| 5.1 Memory v2 | Not started | Future EPIC G |
+| 5.1 Memory v2 | Not started | [EPIC G (#3491)](https://github.com/RC918/morningai/issues/3491) - Placeholder |
 | 5.2 Telemetry v2 | **EPIC B Reviewer telemetry Completed**; Full trace reconstruction Pending | Future EPIC |
-| 5.3 Simulation Suite v1 | Not started | Future EPIC H |
+| 5.3 Simulation Suite v1 | Not started | [EPIC H (#3492)](https://github.com/RC918/morningai/issues/3492) - Placeholder |
 
 ---
 
@@ -222,3 +231,4 @@ This North Star document is a living summary that maps the vision to current imp
 | 1.4 | 2025-12-31 | Ryan Chen (@RC918) with Devin AI | Refined EPIC B status: Added detailed phase table (B-1 to B-6, Phase 1-4). Clarified Telemetry v2 scope: EPIC B contributes Reviewer telemetry fields; full trace reconstruction is a separate future EPIC. |
 | 1.5 | 2026-01-02 | Ryan Chen (@RC918) with Devin AI | Updated EPIC B Phase 6 (B-6) status from "In Progress" to "Completed" based on EPIC_B_DIFF_AWARE_REVIEW_ROADMAP.md evidence. Synced all references in EPIC table, phase table, and cross-reference section. |
 | 1.6 | 2026-01-02 | Ryan Chen (@RC918) with Devin AI | Added Operationalization Pending status for EPIC C ([#3486](https://github.com/RC918/morningai/issues/3486): RouterMetrics not wired) and EPIC D ([#3487](https://github.com/RC918/morningai/issues/3487): SeniorCoder HITL gate). Updated EPIC table and cross-reference section with Issue links. |
+| 1.7 | 2026-01-02 | Ryan Chen (@RC918) with Devin AI | Added Future EPICs section with placeholder issues: EPIC E (#3489 - Safety Governor + Compliance Radar), EPIC F (#3490 - Planner v3), EPIC G (#3491 - Memory v2), EPIC H (#3492 - Simulation Suite). Created dedicated roadmap documents for EPIC C and EPIC D. Updated cross-reference section with Issue links. |


### PR DESCRIPTION
## Summary

This PR establishes the complete EPIC structure for Blueprint 2025 Final coverage by:

1. **Creating dedicated roadmap documents** for EPIC C (Flow Controller v3) and EPIC D (Autonomous Coder Agent Family), following the same format as the existing EPIC B roadmap
2. **Creating placeholder GitHub issues** for future EPICs:
   - EPIC E (#3489): Safety Governor v2 + Compliance Radar v2
   - EPIC F (#3490): Planner v3
   - EPIC G (#3491): Memory v2
   - EPIC H (#3492): Simulation Suite v1
3. **Updating Wish Pool v2** with a new "Future EPICs" section and cross-references to all new issues

The roadmap documents include phase breakdowns, status summaries, operationalization gaps (linking to #3486 and #3487), dependencies, and Blueprint alignment tables.

## Review & Testing Checklist for Human

- [ ] Verify the 4 new GitHub issues (#3489, #3490, #3491, #3492) were created correctly and contain appropriate placeholder content
- [ ] Confirm the status information in EPIC C/D roadmaps matches the actual state of referenced issues (#2743, #2759, etc.)
- [ ] Check that cross-references between documents (Wish Pool v2 ↔ roadmaps ↔ issues) are consistent

### Notes

This is a documentation-only PR with no code changes. The primary goal is to provide visibility into the complete EPIC structure needed for Blueprint 2025 Final coverage and avoid future rework by establishing tracking issues early.

**Link to Devin run**: https://app.devin.ai/sessions/65f10e3c82a74b78bd0a6580035bc0a9
**Requested by**: Ryan Chen (@RC918)