### PR TITLE
feat(#3495): add RouterMetrics dashboard and alerting configuration

### DIFF
--- a/config/monitoring_foundation_schema.yaml
+++ b/config/monitoring_foundation_schema.yaml
@@ -110,14 +110,44 @@ metrics:
       type: gauge
       unit: percentage
       description: "Percentage of routing decisions that fell back to deterministic path"
+      labels: []
+      
+    - name: router_fallback_count
+      type: counter
+      unit: count
+      description: "Count of fallback routing decisions by reason"
       labels: [fallback_reason]
       
-    - name: router_latency
-      type: histogram
+    - name: router_latency_avg
+      type: gauge
       unit: milliseconds
-      description: "Routing decision latency"
-      labels: [decision_mode]
-      buckets: [10, 50, 100, 250, 500, 1000, 2500, 5000]
+      description: "Average routing decision latency"
+      labels: []
+      
+    - name: router_latency_p50
+      type: gauge
+      unit: milliseconds
+      description: "50th percentile routing decision latency"
+      labels: []
+      
+    - name: router_latency_p90
+      type: gauge
+      unit: milliseconds
+      description: "90th percentile routing decision latency"
+      labels: []
+      
+    - name: router_latency_p95
+      type: gauge
+      unit: milliseconds
+      description: "95th percentile routing decision latency"
+      labels: []
+      
+    - name: router_latency_p99
+      type: gauge
+      unit: milliseconds
+      description: "99th percentile routing decision latency"
+      labels: []
+      slo_target: 5000
       
     - name: router_decision_mode_distribution
       type: gauge
@@ -266,7 +296,7 @@ slas:
     unit: milliseconds
     measurement_window: 24h
     metrics:
-      - router_latency
+      - router_latency_p99
 
 
 alerts:
@@ -347,7 +377,7 @@ alerts:
   - name: router_latency_p99_high
     severity: critical
     description: "Flow Controller v3 routing P99 latency exceeds 5 seconds"
-    condition: "router_latency{quantile='0.99'} > 5000"
+    condition: "router_latency_p99 > 5000"
     duration: 5m
     notification_channels: [pagerduty, slack]
     
@@ -361,7 +391,7 @@ alerts:
   - name: router_slow_path_dominant
     severity: warning
     description: "Flow Controller v3 slow path usage exceeds 50%"
-    condition: "router_decision_mode_distribution{decision_mode='slow_path'} / router_decisions_total > 0.50"
+    condition: "sum(rate(router_decisions_total{decision_mode='slow_path'}[15m])) / sum(rate(router_decisions_total[15m])) > 0.50"
     duration: 15m
     notification_channels: [slack]
 
@@ -476,10 +506,9 @@ dashboards:
         thresholds: [0.05, 0.10, 0.20]
         
       - title: "Latency Percentiles"
-        metric: router_latency
+        metrics: [router_latency_p50, router_latency_p90, router_latency_p95, router_latency_p99]
         visualization: graph
         time_range: 1h
-        percentiles: [p50, p90, p95, p99]
         
       - title: "Decision Mode Distribution"
         metric: router_decision_mode_distribution
@@ -492,15 +521,14 @@ dashboards:
         labels: [fixer, publisher, executor, decision]
         
       - title: "Fallback Reasons"
-        metric: router_fallback_rate
+        metric: router_fallback_count
         visualization: table
         labels: [llm_fallback, router_exception, llm_error, timeout]
         
       - title: "Latency Trend"
-        metric: router_latency
+        metric: router_latency_avg
         visualization: graph
         time_range: 6h
-        aggregation: avg
 
 
 sentry:

--- a/docs/runbooks/FLOW_ROUTER_V3_ROLLOUT.md
+++ b/docs/runbooks/FLOW_ROUTER_V3_ROLLOUT.md
@@ -466,11 +466,11 @@ curl -s https://api.morning-ai.com/api/governance/router-metrics | jq
 | Total Routing Decisions | `router_decisions_total` | Stat |
 | Success Rate | `router_success_rate` | Gauge (thresholds: 90%, 95%, 99%) |
 | Fallback Rate | `router_fallback_rate` | Gauge (thresholds: 5%, 10%, 20%) |
-| Latency Percentiles | `router_latency` | Graph (p50, p90, p95, p99) |
+| Latency Percentiles | `router_latency_p50/p90/p95/p99` | Graph |
 | Decision Mode Distribution | `router_decision_mode_distribution` | Pie Chart |
 | Target Node Distribution | `router_node_distribution` | Bar Chart |
-| Fallback Reasons | `router_fallback_rate` | Table |
-| Latency Trend | `router_latency` | Graph (6h) |
+| Fallback Reasons | `router_fallback_count` | Table (by fallback_reason) |
+| Latency Trend | `router_latency_avg` | Graph (6h) |
 
 ### Alerting Rules
 
@@ -488,7 +488,7 @@ The following alerts are configured in `monitoring_foundation_schema.yaml`:
 | SLA | Target | Window | Metric |
 |-----|--------|--------|--------|
 | Router Success Rate | 95% | 24h | `router_success_rate` |
-| Router Latency P99 | 5000ms | 24h | `router_latency` |
+| Router Latency P99 | 5000ms | 24h | `router_latency_p99` |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds monitoring configuration for Flow Controller v3 RouterMetrics to `monitoring_foundation_schema.yaml` and updates the rollout runbook to document the dashboard and alerting setup.

**Changes:**
- Added 10 router metrics definitions:
  - `router_decisions_total` (counter with decision_mode, next_node labels)
  - `router_success_rate`, `router_fallback_rate` (gauges)
  - `router_fallback_count` (counter with fallback_reason label for dimensional analysis)
  - `router_latency_avg`, `router_latency_p50/p90/p95/p99` (explicit percentile gauges)
  - `router_decision_mode_distribution`, `router_node_distribution` (gauges)
- Added 2 SLA targets (95% success rate, 5000ms p99 latency over 24h)
- Added 4 alerting rules with severity levels and notification channels
- Added `router_metrics` dashboard with 8 panels
- Updated runbook to reflect PR #3494 completion and document new monitoring configuration

Closes #3495

### Updates since last revision

Addressed review feedback from gemini-code-assist and RC918:
1. **Replaced histogram with explicit percentile gauges** - RouterMetrics API provides pre-computed percentiles, so using explicit `router_latency_p50/p90/p95/p99` gauges instead of histogram with quantile selectors
2. **Added `router_fallback_count` counter** - Enables per-reason breakdown in Fallback Reasons table panel (gauges can't do dimensional analysis)
3. **Fixed `router_latency_p99_high` alert** - Now uses `router_latency_p99 > 5000` instead of histogram quantile selector
4. **Fixed `router_slow_path_dominant` alert** - Now uses `sum(rate(router_decisions_total{decision_mode='slow_path'}[15m])) / sum(rate(router_decisions_total[15m]))` for correct ratio calculation

## Review & Testing Checklist for Human

- [ ] **Verify metric names match PR #3494 implementation** - Check that `router_decisions_total`, `router_success_rate`, `router_fallback_rate`, `router_latency_p99`, etc. match the actual metric names exposed by the RouterMetrics API
- [ ] **Verify alert thresholds are appropriate** - Current thresholds: success rate < 95% (critical), p99 latency > 5000ms (critical), fallback rate > 20% (warning), slow path > 50% (warning)
- [ ] **Confirm API endpoint path** - Dashboard references `/api/governance/router-metrics` - verify this matches the actual endpoint from PR #3494

**Test Plan:**
1. After PR #3494 is merged, call the router-metrics API endpoint and verify the response structure matches what the dashboard expects
2. If using a monitoring system that consumes this schema, verify the dashboard renders correctly

### Notes

This is a configuration-only PR (YAML + markdown). No runtime code changes.

**Dependency**: Requires PR #3494 to be merged first for the RouterMetrics API to exist.

---
Link to Devin run: https://app.devin.ai/sessions/65f10e3c82a74b78bd0a6580035bc0a9
Requested by: Ryan Chen (@RC918)