### PR TITLE
fix(#3513): refine CI failure dedup to include check_suite_id

### DIFF
--- a/handoff/20250928/40_App/orchestrator/webhooks/handlers/github_handler.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/handlers/github_handler.py
@@ -403,11 +403,23 @@ class GitHubWebhookHandler(BaseWebhookHandler):
             # Issue: #3513 - Add check_suite_id for dedup refinement
             # GitHub sends multiple check_suite webhooks per SHA (different workflows)
             # Each workflow has a unique check_suite_id that we need for proper dedup
-            # Explicitly convert to int for type consistency (MorningAI review feedback)
+            # Defensive int conversion with try-except (MorningAI review feedback)
             raw_check_suite_id = check_suite.get("id")
-            metadata["ci_check_suite_id"] = (
-                int(raw_check_suite_id) if raw_check_suite_id is not None else None
-            )
+            try:
+                metadata["ci_check_suite_id"] = (
+                    int(raw_check_suite_id) if raw_check_suite_id is not None else None
+                )
+            except (ValueError, TypeError):
+                # Fallback to None if conversion fails - will use old dedup key format
+                logger.warning(
+                    "[GitHubWebhookHandler] Invalid check_suite_id, using fallback dedup",
+                    extra={
+                        "event_id": event_id,
+                        "repo": f"{repo_owner}/{repo_name}",
+                        "raw_check_suite_id": str(raw_check_suite_id)[:50],
+                    }
+                )
+                metadata["ci_check_suite_id"] = None
             # Store PR numbers for dedup and multi-PR handling
             pull_requests = check_suite.get("pull_requests", [])
             metadata["ci_pr_numbers"] = [

--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -1633,8 +1633,10 @@ class EventNormalizer:
             dedup_key = f"{repo}:{pr_number}:{head_sha}"
 
         # Try Redis-backed dedup first (cross-worker idempotency)
+        # Use keyword arg for check_suite_id to improve signature robustness
         is_duplicate, dedup_source = self._check_ci_failure_dedup_redis(
-            dedup_key, event.event_id, repo, pr_number, head_sha, check_suite_id
+            dedup_key, event.event_id, repo, pr_number, head_sha,
+            check_suite_id=check_suite_id
         )
 
         if is_duplicate:


### PR DESCRIPTION
## Summary

Fixes the CI failure auto-fix flow being blocked by overly broad dedup keys. GitHub sends multiple `check_suite.completed` webhooks per SHA (one for each workflow), but the previous dedup key format (`repo:pr:sha`) caused the first webhook to block all subsequent failures from different workflows.

**Changes:**
- Extract `check_suite_id` from GitHub webhook payload in `github_handler.py`
- Update dedup key format to `{repo}:{pr}:{sha}:{check_suite_id}` to allow different workflows to trigger independently
- Fallback to old format if `check_suite_id` is not available (backward compatibility)
- Add `check_suite_id` to all CI failure logs for observability

**Updates from review feedback:**
- Added defensive try-except around `int()` conversion for `check_suite_id` (logs warning and falls back to `None` if conversion fails)
- Changed to keyword argument `check_suite_id=check_suite_id` for improved signature robustness
- Removed raw `dedup_key` from logs to avoid exposing internal key format

Closes #3513

## Review & Testing Checklist for Human

- [ ] **Verify dedup key format change is correct** - The new format `{repo}:{pr}:{sha}:{check_suite_id}` should differentiate workflows while still preventing duplicate processing of the same workflow
- [ ] **Test fallback behavior** - When `check_suite_id` is missing or invalid, the code falls back to old format. Verify this doesn't cause issues with older webhook payloads
- [ ] **Staging validation** - After merge and deploy to staging, push a new commit to PR #3483 to verify the CI failure auto-fix flow now works (should see `ci_failure_actionable` logs instead of `ci_failure_skip_dedup`)

### Notes

- No unit tests added in this PR - Issue #3512 tracks test coverage as a follow-up
- Existing Redis dedup keys won't match the new format, which is the desired behavior (allows previously blocked events to be processed)
- The `check_suite_id` is now logged in both skip and actionable logs for debugging
- Delimiter collision concern (`:` in key) was evaluated and deemed safe: repo follows `owner/repo` format, sha is hex, pr_number and check_suite_id are integers - none contain `:`

**Link to Devin run:** https://app.devin.ai/sessions/8442f839efae4ff2b86c282142178bc1
**Requested by:** Ryan Chen (ryan2939z@gmail.com) / @RC918