### PR TITLE
fix: add JSON serialization support to CiFailureContext for RQ queue

### DIFF
--- a/handoff/20250928/40_App/orchestrator/core/flow/schema.py
+++ b/handoff/20250928/40_App/orchestrator/core/flow/schema.py
@@ -187,6 +187,10 @@ class CiFailureContext:
     Schema Evolution:
     - version field enables backward-compatible changes
     - Consumers should check version and handle unknown versions gracefully
+
+    Serialization:
+    - Use to_dict() for JSON serialization (e.g., RQ queue)
+    - Use from_dict() to reconstruct from serialized form
     """
 
     failed_check_name: str  # Name of the failed check (e.g., "lint", "test")
@@ -198,6 +202,46 @@ class CiFailureContext:
     logs_url: Optional[str] = None  # URL to CI logs for reference
     error_summary: Optional[str] = None  # Top N error lines/annotations (if available)
     check_run_id: Optional[int] = None  # GitHub check_run ID for API lookups
+
+    def to_dict(self) -> dict:
+        """Convert to JSON-serializable dict for RQ queue serialization.
+
+        Returns:
+            Dict representation suitable for JSON serialization
+        """
+        return {
+            "failed_check_name": self.failed_check_name,
+            "conclusion": self.conclusion,
+            "pr_number": self.pr_number,
+            "head_sha": self.head_sha,
+            "head_branch": self.head_branch,
+            "version": self.version,
+            "logs_url": self.logs_url,
+            "error_summary": self.error_summary,
+            "check_run_id": self.check_run_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "CiFailureContext":
+        """Reconstruct CiFailureContext from serialized dict.
+
+        Args:
+            data: Dict from to_dict() or JSON deserialization
+
+        Returns:
+            CiFailureContext instance
+        """
+        return cls(
+            failed_check_name=data["failed_check_name"],
+            conclusion=data["conclusion"],
+            pr_number=data["pr_number"],
+            head_sha=data["head_sha"],
+            head_branch=data["head_branch"],
+            version=data.get("version", 1),
+            logs_url=data.get("logs_url"),
+            error_summary=data.get("error_summary"),
+            check_run_id=data.get("check_run_id"),
+        )
 
 
 class RoutingContext(BaseModel):

--- a/handoff/20250928/40_App/orchestrator/project_engineer/fixer_integration.py
+++ b/handoff/20250928/40_App/orchestrator/project_engineer/fixer_integration.py
@@ -289,10 +289,12 @@ class AutoFixer:
             # use it directly instead of relying on ReviewerAgent judgment (which may
             # use different rules than CI lint checks)
             ci_failure_trigger = state.get("ci_failure_trigger", False)
-            ci_failure_context = state.get("ci_failure_context")
+            ci_failure_context_data = state.get("ci_failure_context")
 
-            if ci_failure_trigger is True and ci_failure_context:
+            if ci_failure_trigger is True and ci_failure_context_data:
                 # CI failure mode: use CI evidence directly
+                # Reconstruct CiFailureContext from serialized dict (RQ JSON serialization)
+                ci_failure_context = CiFailureContext.from_dict(ci_failure_context_data)
                 fix_description = self._build_ci_fix_description(
                     ci_failure_context, pr_number, changed_files
                 )

--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -1688,7 +1688,9 @@ class EventNormalizer:
                 error_summary=metadata.get("ci_error_summary"),
                 check_run_id=metadata.get("ci_check_run_id"),
             )
-            event.metadata["ci_failure_context"] = ci_failure_context
+            # Use to_dict() for JSON serialization compatibility with RQ queue
+            # The worker will use CiFailureContext.from_dict() to reconstruct
+            event.metadata["ci_failure_context"] = ci_failure_context.to_dict()
         else:
             logger.warning(
                 "[EventNormalizer] Skipping CiFailureContext - missing required fields",


### PR DESCRIPTION
## Summary

Fixes a critical bug where CI failure auto-fix tasks were failing to enqueue with error:
```
[Webhooks] Failed to enqueue CI failure task: Object of type CiFailureContext is not JSON serializable
```

This was introduced in PR #3511 which added `CiFailureContext` as a frozen dataclass, but dataclasses are not JSON-serializable by default. RQ uses JSON serialization, so the enqueue operation failed silently.

**Changes:**
- Add `to_dict()` method to `CiFailureContext` for JSON serialization
- Add `from_dict()` classmethod to reconstruct from serialized dict
- Update `normalizer.py` to serialize context before storing in metadata
- Update `fixer_integration.py` to deserialize context when consuming

## Review & Testing Checklist for Human

- [ ] **Verify field symmetry**: Confirm `to_dict()` and `from_dict()` handle all 9 fields identically (failed_check_name, conclusion, pr_number, head_sha, head_branch, version, logs_url, error_summary, check_run_id)
- [ ] **Test end-to-end in staging**: After deployment, push a commit with lint errors to PR #3483 and verify:
  1. Web service logs show `Enqueued CI failure task` (not `Failed to enqueue`)
  2. Worker logs show `CI failure mode - using CI evidence for fix`
  3. AutoFixer actually executes
- [ ] **Check for KeyError risk**: `from_dict()` will raise KeyError if required fields are missing - verify this is acceptable behavior

### Notes

This PR does not include unit tests for the new serialization methods. Consider adding tests in a follow-up.

**Recommended test plan:**
1. Merge and deploy to staging
2. Push a new commit to test PR #3483 with intentional lint errors
3. Check Render logs within 5 minutes (job TTL is 10 min)
4. Confirm the full CI failure → AutoFixer flow completes

---
Link to Devin run: https://app.devin.ai/sessions/8442f839efae4ff2b86c282142178bc1
Requested by: Ryan Chen (@RC918)