### PR TITLE
fix(#3516): fix ci_monitor_node fast path to skip API call when ci_failure_trigger=True

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -4034,17 +4034,36 @@ def ci_monitor_node(state: AgentState) -> AgentState:
         metrics.record_node_complete("ci_monitor", trace_id, success=True, latency_ms=latency_ms)
         return state
 
-    if ci_failure_trigger and ci_state == "failure":
-        logger.info(
-            "[CI Monitor] CI failure trigger active with ci_state=failure, "
-            "preserving state and skipping API call for fast path",
-            extra={
-                "operation": "ci_monitor",
-                "trace_id": trace_id,
-                "ci_failure_trigger": ci_failure_trigger,
-                "ci_state": ci_state,
-            }
-        )
+    # Issue #3516: Fix CI failure fast path - skip API call when ci_failure_trigger=True
+    # Previously required ci_state=="failure", but ci_state might be "pending" or other value
+    # from _create_base_initial_state() before run_orchestrator() sets it to "failure".
+    # The key insight: when ci_failure_trigger=True, we KNOW CI failed (from webhook),
+    # so we should preserve that state and skip the API call that would overwrite it.
+    if ci_failure_trigger:
+        # Ensure ci_state is "failure" for downstream router fast path
+        if ci_state != "failure":
+            logger.warning(
+                f"[CI Monitor] CI failure trigger active but ci_state={ci_state}, "
+                "forcing ci_state=failure for fast path",
+                extra={
+                    "operation": "ci_monitor",
+                    "trace_id": trace_id,
+                    "ci_failure_trigger": ci_failure_trigger,
+                    "original_ci_state": ci_state,
+                }
+            )
+            state["ci_state"] = "failure"
+        else:
+            logger.info(
+                "[CI Monitor] CI failure trigger active with ci_state=failure, "
+                "preserving state and skipping API call for fast path",
+                extra={
+                    "operation": "ci_monitor",
+                    "trace_id": trace_id,
+                    "ci_failure_trigger": ci_failure_trigger,
+                    "ci_state": ci_state,
+                }
+            )
         latency_ms = (time.time() - start_time) * 1000
         metrics.record_node_complete("ci_monitor", trace_id, success=True, latency_ms=latency_ms)
         return state


### PR DESCRIPTION
## Summary

Fixes a bug where the CI failure auto-fix flow wasn't being triggered correctly. The `ci_monitor_node` was calling the GitHub API and overwriting `ci_state` to "success" even when `ci_failure_trigger=True`.

**Root cause:** The previous condition `if ci_failure_trigger and ci_state == "failure"` required both conditions, but `ci_state` wasn't always "failure" when the node ran. Staging logs showed:
```
[ROUTER_STATE_DEBUG] Router entry state: ci_failure_trigger=True ci_state=success
```

**Fix:** When `ci_failure_trigger=True`, skip the GitHub API call entirely and ensure `ci_state="failure"` for the downstream router fast path.

## Review & Testing Checklist for Human

- [ ] **Verify logic change is safe**: The condition changed from `ci_failure_trigger and ci_state == "failure"` to just `ci_failure_trigger`. Confirm this won't cause issues for non-CI-failure workflows.
- [ ] **Check downstream dependencies**: The router fast path condition is `ci_failure_trigger and ci_state != "success"`. Verify this will now trigger correctly.
- [ ] **Test in staging**: After deploying, push a new commit to PR #3483 and verify:
  - Worker logs show `[CI Monitor] CI failure trigger active but ci_state=X, forcing ci_state=failure`
  - Router logs show `[CI_FAILURE_ROUTER_SHORT_CIRCUIT]`
  - AutoFixer logs show `[AutoFixer] CI failure mode - using CI evidence`

### Notes

This is part of the EPIC D CI failure auto-fix validation. The JSON serialization fix (PR #3515) and dedup fix (PR #3514) are already deployed and working - this fixes the final piece where the router wasn't short-circuiting to the fixer.

**Link to Devin run:** https://app.devin.ai/sessions/8442f839efae4ff2b86c282142178bc1
**Requested by:** Ryan Chen (@RC918)