### PR TITLE
fix(#3529): add ci_failure_context to AgentState TypedDict

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -2441,6 +2441,12 @@ class AgentState(TypedDict):
     # Set by run_orchestrator() when CI failure webhook triggers auto-fix flow.
     # When True, workflow routes directly to fixer_node for auto-fix without planner.
     ci_failure_trigger: Optional[bool]
+    # Issue #3529: CI Failure Context for AutoFixer
+    # Set by run_orchestrator() when CI failure webhook provides structured error context.
+    # Contains CiFailureContext.to_dict() with failed_check_name, conclusion, pr_number,
+    # head_sha, head_branch, logs_url, error_summary, check_run_id.
+    # Used by fixer_integration.py to use CI evidence directly instead of ReviewerAgent.
+    ci_failure_context: Optional[dict]
 
 
 def _get_learning_context_for_planner(goal: str, task_type: Optional[str] = None) -> str:


### PR DESCRIPTION
## Summary

Fixes a P1 bug where `ci_failure_context` was being set in `initial_state` by `run_orchestrator()` but was **NOT defined in the `AgentState` TypedDict**. This caused LangGraph to drop the field when passing state between nodes, so `fixer_integration.py` received `None` instead of the CI failure context.

**Impact**: AutoFixer was falling back to ReviewerAgent mode (which gives false positives like "Review passed, no fixes needed") instead of using CI evidence directly.

**Fix**: Add `ci_failure_context: Optional[dict]` to `AgentState` with proper documentation.

## Review & Testing Checklist for Human

- [ ] Verify the field type `Optional[dict]` matches what `CiFailureContext.to_dict()` returns (see `core/ci_failure_context.py`)
- [ ] After deployment to staging, re-run Probe 0 by pushing a commit to PR #3528
- [ ] Check Render logs for `[AutoFixer] CI failure mode - using CI evidence for fix` event code (should appear now, was missing before)

**Recommended Test Plan**:
1. Merge and deploy to staging
2. Push a new commit to PR #3528 (the Probe 0 test PR with intentional lint error)
3. Wait for CI to fail
4. Monitor `morningai-backend-v2-stg-worker` logs for:
   - `ci_failure_context` being passed (should now be preserved)
   - `[AutoFixer] CI failure mode - using CI evidence for fix` (success indicator)
   - `[CODER_PATCH]` event (fix was applied)

### Notes

- Discovered during EPIC D Track B Sprint B0 - Capability Probe 0 validation
- Related: Issue #3510 (CiFailureContext), PR #3511, PR #3515, PR #3516
- Closes #3529

---
Link to Devin run: https://app.devin.ai/sessions/8442f839efae4ff2b86c282142178bc1
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918