### PR TITLE
fix(#3531): add PYTHONPATH to worker for DevAgent imports

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -99,9 +99,8 @@ services:
       python -c "import httpx, websockets, supabase; print(f'httpx={httpx.__version__}, websockets={websockets.__version__}, supabase={supabase.__version__}')"
     startCommand: cd handoff/20250928/40_App/orchestrator && python redis_queue/worker.py
     envVars:
-      # Issue #3531: Add PYTHONPATH for DevAgent imports (knowledge_graph module)
       - key: PYTHONPATH
-        value: /opt/render/project/src/handoff/20250928/40_App:/opt/render/project/src/handoff/20250928/40_App/api-backend/src:/opt/render/project/src/agents/dev_agent
+        value: /opt/render/project/src:/opt/render/project/src/handoff/20250928/40_App:/opt/render/project/src/handoff/20250928/40_App/api-backend/src:/opt/render/project/src/agents/dev_agent
       - key: REDIS_URL
         sync: false
       - key: SENTRY_DSN


### PR DESCRIPTION
## Summary

Adds missing `PYTHONPATH` environment variable to the `morningai-agent-worker` service in render.yaml. This fixes a DevAgent import error that was blocking AutoFixer from applying fixes.

**Root cause:** The worker service was missing PYTHONPATH, causing `from knowledge_graph.knowledge_graph_manager import ...` to fail with `No module named 'knowledge_graph.knowledge_graph_manager'`. The backend-v2 service already had PYTHONPATH configured (lines 43-44), but the worker service did not.

**Evidence from Render logs:**
```
[AutoFixer] CI failure mode - using CI evidence for fix  # PR #3530 fix working!
[AutoFixer] Failed to import DevAgent: No module named 'knowledge_graph.knowledge_graph_manager'
[AutoFixer] Auto-fix failed: Import error
```

## Updates since last revision

**gemini-code-assist Critical review adopted:** Added project root (`/opt/render/project/src`) to PYTHONPATH.

- `worker.py` line 58 imports `from common.config.settings import settings`
- `common` module is at repo root (`/opt/render/project/src/common`)
- Without project root in PYTHONPATH, worker startup would fail with ImportError before even reaching DevAgent code

Final PYTHONPATH:
```
/opt/render/project/src:/opt/render/project/src/handoff/20250928/40_App:/opt/render/project/src/handoff/20250928/40_App/api-backend/src:/opt/render/project/src/agents/dev_agent
```

## Review & Testing Checklist for Human

- [ ] Verify the PYTHONPATH paths match Render's actual project structure (`/opt/render/project/src/...`)
- [ ] Confirm no module name collisions exist between repo root packages (`common`, `agents`) and subdirectory packages
- [ ] After deployment, check Render worker logs for successful startup (no `ImportError` on `common.config.settings`)
- [ ] Re-run Probe 0 (push commit to PR #3528) to verify AutoFixer can now apply fixes end-to-end

**Recommended test plan:** After merging and deploying, push a new commit to PR #3528 to trigger CI failure. Monitor Render logs for `[CODER_PATCH]` or `[GENERAL_CODER_PATCH]` events indicating a fix was applied.

### Notes

- This is part of EPIC D Track B Sprint B0 validation
- Related: Issue #3529 (ci_failure_context bug, fixed in PR #3530)
- Closes #3531

---
Link to Devin run: https://app.devin.ai/sessions/8442f839efae4ff2b86c282142178bc1
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918