### PR TITLE
fix(#3533): properly re-export knowledge_graph submodules for alias package

### DIFF
--- a/knowledge_graph/__init__.py
+++ b/knowledge_graph/__init__.py
@@ -10,7 +10,6 @@
 # We must explicitly import submodules to make them available as attributes.
 
 import sys
-from agents.dev_agent import knowledge_graph as _kg
 
 # Re-export all public names from the actual package
 from agents.dev_agent.knowledge_graph import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary

Fixes the root `knowledge_graph/` alias package to properly re-export submodules from `agents/dev_agent/knowledge_graph/`. The previous implementation only used wildcard import (`from X import *`), which re-exports **names** but doesn't make submodules importable.

**Before:** `from knowledge_graph.knowledge_graph_manager import KnowledgeGraphManager` → FAILS  
**After:** `from knowledge_graph.knowledge_graph_manager import KnowledgeGraphManager` → WORKS

This was blocking the AutoFixer from importing DevAgent, causing CI failure auto-fix to fail with `No module named 'knowledge_graph.knowledge_graph_manager'`.

## Updates since last revision

- Removed unused `_kg` import (addressed review feedback)
- Created follow-up issue #3535 for auto-enumeration of submodules instead of hardcoding

## Review & Testing Checklist for Human

- [ ] **Verify sys.modules manipulation is safe** - The fix registers submodules in `sys.modules` to make them importable. Confirm this won't cause import conflicts if another `knowledge_graph` package exists.
- [ ] **Check for missing submodules** - The fix hardcodes 6 submodules. Verify no submodules in `agents/dev_agent/knowledge_graph/` are missing.

**Test Plan:**
1. Merge and deploy to staging
2. Push a new commit to PR #3528 to trigger CI failure
3. Check Render logs for `[AutoFixer]` - should no longer see `No module named 'knowledge_graph.knowledge_graph_manager'`
4. Search for `CODER_PATCH` to confirm AutoFixer successfully applied a fix

### Notes

Closes #3533

Discovered during EPIC D Probe 0 validation - this was root cause #4 blocking the CI failure auto-fix pipeline.

**Follow-up:** Issue #3535 tracks refactoring to auto-enumerate submodules instead of hardcoding.

---
Link to Devin run: https://app.devin.ai/sessions/8442f839efae4ff2b86c282142178bc1  
Requested by: Ryan Chen (@RC918)