### PR TITLE
fix(#3536): add create_pr method to SimpleGitTool for AutoFixer

### DIFF
--- a/agents/dev_agent/dev_agent_wrapper.py
+++ b/agents/dev_agent/dev_agent_wrapper.py
@@ -89,31 +89,28 @@ class SimpleGitTool:
         except Exception as e:
             return {'success': False, 'error': str(e)}
 
-    async def create_pr(
-        self, title: str, body: str
+    async def commit_and_push(
+        self, title: str, body: str = ""
     ) -> Dict[str, Any]:
         """
         Commit and push changes to the current branch.
 
-        NOTE: This method name matches the interface expected by
-        CodeGenerationWorkflow but does NOT create a new GitHub PR.
-        For AutoFixer scenarios, the PR already exists and this method
-        commits and pushes fixes to the existing PR branch.
+        This is the preferred method name for new code. For interface
+        compatibility with CodeGenerationWorkflow, use create_pr() which
+        delegates to this method.
 
         Steps:
         1. Check for uncommitted changes
         2. Stage all modified files
-        3. Commit with the provided title as commit message
+        3. Commit with the provided title/body as commit message
         4. Push to the current branch
 
         Args:
-            title: Used as commit message subject
-            body: Included in commit message body
+            title: Commit message subject line
+            body: Commit message body (optional)
 
         Returns:
             Dict with success status, commit_sha, and branch name.
-            Note: pr_number and pr_url are not returned since we're
-            pushing to an existing PR branch, not creating a new PR.
         """
         try:
             cwd = os.getcwd()
@@ -145,9 +142,11 @@ class SimpleGitTool:
                     'error': f'git add failed: {add_result.stderr}'
                 }
 
-            commit_message = f"{title}\n\n{body}" if body else title
+            commit_cmd = ['git', 'commit', '-m', title]
+            if body:
+                commit_cmd.extend(['-m', body])
             commit_result = subprocess.run(
-                ['git', 'commit', '-m', commit_message],
+                commit_cmd,
                 capture_output=True,
                 text=True,
                 cwd=cwd
@@ -165,7 +164,7 @@ class SimpleGitTool:
                 text=True,
                 cwd=cwd
             )
-            commit_sha = sha_result.stdout.strip() if sha_result.returncode == 0 else None
+            commit_sha = sha_result.stdout.strip() if sha_result.returncode == 0 else "unknown"
 
             branch_result = subprocess.run(
                 ['git', 'branch', '--show-current'],
@@ -173,9 +172,10 @@ class SimpleGitTool:
                 text=True,
                 cwd=cwd
             )
-            branch = branch_result.stdout.strip() if branch_result.returncode == 0 else None
+            branch = branch_result.stdout.strip() if branch_result.returncode == 0 else "unknown"
 
-            logger.info(f"[SimpleGitTool] Committed {commit_sha[:8] if commit_sha else 'unknown'}: {title}")
+            commit_sha_short = commit_sha[:8] if len(commit_sha) >= 8 else commit_sha
+            logger.info(f"[SimpleGitTool] Committed {commit_sha_short}: {title}")
 
             push_result = subprocess.run(
                 ['git', 'push'],
@@ -187,7 +187,9 @@ class SimpleGitTool:
                 logger.error(f"[SimpleGitTool] git push failed: {push_result.stderr}")
                 return {
                     'success': False,
-                    'error': f'git push failed: {push_result.stderr}'
+                    'error': f'git push failed: {push_result.stderr}',
+                    'commit_sha': commit_sha,
+                    'branch': branch
                 }
 
             logger.info(f"[SimpleGitTool] Pushed to branch '{branch}'")
@@ -197,12 +199,40 @@ class SimpleGitTool:
                 'commit_pushed': True,
                 'commit_sha': commit_sha,
                 'branch': branch,
-                'output': f'Committed and pushed {commit_sha[:8] if commit_sha else "changes"} to {branch}'
+                'output': f'Committed and pushed {commit_sha_short} to {branch}'
             }
 
         except Exception as e:
-            logger.error(f"[SimpleGitTool] create_pr failed: {e}")
+            logger.error(f"[SimpleGitTool] commit_and_push failed: {e}")
             return {'success': False, 'error': str(e)}
+
+    async def create_pr(
+        self, title: str, body: str = ""
+    ) -> Dict[str, Any]:
+        """
+        Commit and push changes to the current branch.
+
+        DEPRECATION NOTE: This method name is kept for interface compatibility
+        with CodeGenerationWorkflow. It does NOT create a new GitHub PR.
+        For new code, prefer using commit_and_push() directly.
+
+        For AutoFixer scenarios, the PR already exists and this method
+        commits and pushes fixes to the existing PR branch.
+
+        Args:
+            title: Commit message subject line
+            body: Commit message body (optional)
+
+        Returns:
+            Dict with success status, commit_sha, and branch name.
+            Note: pr_number and pr_url are not returned since we're
+            pushing to an existing PR branch, not creating a new PR.
+        """
+        logger.debug(
+            "[SimpleGitTool] create_pr called - delegating to commit_and_push "
+            "(create_pr is kept for interface compatibility)"
+        )
+        return await self.commit_and_push(title, body)
 
 
 class SimpleFilesystemTool:


### PR DESCRIPTION
## Summary

Adds `commit_and_push()` and `create_pr()` methods to `SimpleGitTool` class to enable `CodeGenerationWorkflow` to commit and push fixes to existing PR branches. This fixes the root cause of AutoFixer reporting "success" without actually pushing any commits.

**Root Cause:** `CodeGenerationWorkflow.create_pr()` calls `self.agent.git_tool.create_pr(title, body)` but `SimpleGitTool` didn't have this method, causing the workflow to silently skip PR creation.

**Solution:** Add `commit_and_push()` as the core implementation that:
1. Checks for uncommitted changes (returns success with `commit_pushed: False` for no-op)
2. Stages all modified files (`git add -A`)
3. Commits with `git commit -m title -m body` format
4. Pushes to the current branch
5. Returns `commit_sha` and `branch` for observability

`create_pr()` delegates to `commit_and_push()` for interface compatibility with `CodeGenerationWorkflow`.

## Updates Since Last Revision

**Revision 3** (fbff71c2):
- **Added `commit_and_push()` method**: Preferred method name for new code; `create_pr()` now delegates to it with deprecation note
- **Fixed None slicing bug**: Uses `"unknown"` fallback for `commit_sha` and `branch` when git commands fail, with safe length check before slicing
- **Improved commit message handling**: Changed from single `-m` with embedded newlines to `git commit -m title -m body` format for robustness
- **Better error responses**: Include `commit_sha` and `branch` in push failure response for debugging

**Revision 2** (f3dccd7c):
- **No-op case handling**: Returns `success: True` with `commit_pushed: False` when no changes
- **Improved observability**: Returns `commit_sha`, `branch`, and descriptive `output` message

## Review & Testing Checklist for Human

- [ ] **Verify `git add -A` is acceptable** - This stages ALL changes including untracked files. If AutoFixer runs in a dirty working tree, this could commit unintended files.
- [ ] **Check downstream handling of missing `pr_number`/`pr_url`** - This method returns `success: True` but no `pr_number` or `pr_url`. Verify `ProjectEngineerAgent` and `AutoFixer` handle this correctly.
- [ ] **End-to-end test**: After deploying to staging, push a commit with intentional lint error to PR #3528 and verify AutoFixer pushes a fix commit.
- [ ] **Verify git credentials in runtime** - Confirm the AutoFixer environment has git push credentials configured.

### Notes

- `create_pr()` is kept for interface compatibility with `CodeGenerationWorkflow`, with deprecation note recommending `commit_and_push()` for new code
- Uses synchronous `subprocess.run` in async method, following existing pattern in `SimpleGitTool`. Async refactor is out of scope for this bug fix.
- Related Issue: #3536
- Part of EPIC D Track B Sprint B0 (Probe 0 validation)

Link to Devin run: https://app.devin.ai/sessions/8442f839efae4ff2b86c282142178bc1
Requested by: Ryan Chen (@RC918)