### PR TITLE
fix: bypass executor_node for CI failure auto-fix to avoid ValueGate blocking

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -2447,6 +2447,12 @@ class AgentState(TypedDict):
     # head_sha, head_branch, logs_url, error_summary, check_run_id.
     # Used by fixer_integration.py to use CI evidence directly instead of ReviewerAgent.
     ci_failure_context: Optional[dict]
+    # Issue #3541: CI Failure Fast Path Consumed Flag
+    # Set by ci_monitor_node on first pass when ci_failure_trigger=True.
+    # Prevents infinite loop: after fixer applies fix and routes back to ci_monitor,
+    # this flag ensures ci_monitor makes actual API call to check real CI status
+    # instead of forcing ci_state="failure" again.
+    ci_failure_fast_path_consumed: Optional[bool]
 
 
 def _get_learning_context_for_planner(goal: str, task_type: Optional[str] = None) -> str:
@@ -4045,34 +4051,57 @@ def ci_monitor_node(state: AgentState) -> AgentState:
     # from _create_base_initial_state() before run_orchestrator() sets it to "failure".
     # The key insight: when ci_failure_trigger=True, we KNOW CI failed (from webhook),
     # so we should preserve that state and skip the API call that would overwrite it.
-    if ci_failure_trigger:
+    #
+    # Issue #3541: Make fast path one-shot to prevent infinite loop
+    # After fixer applies fix and routes back to ci_monitor (via should_proceed_after_fixer),
+    # we need to check real CI status to see if the fix worked. The consumed flag ensures
+    # we only skip the API call on the FIRST pass, then do normal CI check on subsequent passes.
+    fast_path_consumed = state.get("ci_failure_fast_path_consumed") is True
+    if ci_failure_trigger and not fast_path_consumed:
+        # Mark fast path as consumed so subsequent ci_monitor calls check real CI status
+        state["ci_failure_fast_path_consumed"] = True
         # Ensure ci_state is "failure" for downstream router fast path
         if ci_state != "failure":
             logger.warning(
                 f"[CI Monitor] CI failure trigger active but ci_state={ci_state}, "
-                "forcing ci_state=failure for fast path",
+                "forcing ci_state=failure for fast path (first pass)",
                 extra={
                     "operation": "ci_monitor",
                     "trace_id": trace_id,
                     "ci_failure_trigger": ci_failure_trigger,
                     "original_ci_state": ci_state,
+                    "fast_path_consumed": False,
                 }
             )
             state["ci_state"] = "failure"
         else:
             logger.info(
                 "[CI Monitor] CI failure trigger active with ci_state=failure, "
-                "preserving state and skipping API call for fast path",
+                "preserving state and skipping API call for fast path (first pass)",
                 extra={
                     "operation": "ci_monitor",
                     "trace_id": trace_id,
                     "ci_failure_trigger": ci_failure_trigger,
                     "ci_state": ci_state,
+                    "fast_path_consumed": False,
                 }
             )
         latency_ms = (time.time() - start_time) * 1000
         metrics.record_node_complete("ci_monitor", trace_id, success=True, latency_ms=latency_ms)
         return state
+
+    # Issue #3541: Log when fast path was already consumed (post-fix CI check)
+    if ci_failure_trigger and fast_path_consumed:
+        logger.info(
+            "[CI Monitor] CI failure trigger active but fast path already consumed, "
+            "proceeding to check real CI status (post-fix verification)",
+            extra={
+                "operation": "ci_monitor",
+                "trace_id": trace_id,
+                "ci_failure_trigger": ci_failure_trigger,
+                "fast_path_consumed": True,
+            }
+        )
 
     # Note: We don't check for GitHub token here - instead we rely on exception handling
     # below to catch GitHubAuthenticationError when the token is missing/invalid.

--- a/handoff/20250928/40_App/orchestrator/tests/test_ci_failure_trigger.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_ci_failure_trigger.py
@@ -286,3 +286,146 @@ class TestCIFailureFastPath:
             entry_point = "ci_monitor"
 
         assert entry_point == "planner"
+
+
+class TestCIMonitorFastPathConsumed:
+    """Test CI monitor fast path consumed flag (Issue #3541).
+
+    This prevents infinite loop when fixer routes back to ci_monitor:
+    - First pass: ci_failure_trigger=True, fast_path_consumed=False -> skip API, force failure
+    - Second pass: ci_failure_trigger=True, fast_path_consumed=True -> check real CI status
+    """
+
+    def test_ci_monitor_first_pass_skips_api_and_sets_consumed(self):
+        """Test that first ci_monitor pass skips API call and sets consumed flag."""
+        from unittest.mock import patch, MagicMock
+
+        state = {
+            "trace_id": "test-trace-first-pass",
+            "ci_failure_trigger": True,
+            "ci_state": "pending",  # Will be forced to "failure"
+            "pr_number": 123,
+            "messages": [],
+        }
+
+        with patch("langgraph_orchestrator.time") as mock_time:
+            mock_time.time.return_value = 1000.0
+            with patch("langgraph_orchestrator._get_metrics") as mock_metrics:
+                mock_metrics.return_value = MagicMock()
+                with patch("tools.github_api") as mock_github:
+                    from langgraph_orchestrator import ci_monitor_node
+                    result = ci_monitor_node(state)
+
+        # First pass should skip API call
+        mock_github.get_repo.assert_not_called()
+        mock_github.get_pr_checks.assert_not_called()
+
+        # First pass should force ci_state to "failure"
+        assert result["ci_state"] == "failure"
+
+        # First pass should set consumed flag
+        assert result["ci_failure_fast_path_consumed"] is True
+
+    def test_ci_monitor_second_pass_checks_real_ci_status(self):
+        """Test that second ci_monitor pass (post-fix) checks real CI status."""
+        from unittest.mock import patch, MagicMock
+
+        state = {
+            "trace_id": "test-trace-second-pass",
+            "ci_failure_trigger": True,
+            "ci_state": "failure",
+            "ci_failure_fast_path_consumed": True,  # Already consumed
+            "pr_number": 123,
+            "messages": [],
+        }
+
+        with patch("langgraph_orchestrator.time") as mock_time:
+            mock_time.time.return_value = 1000.0
+            with patch("langgraph_orchestrator._get_metrics") as mock_metrics:
+                mock_metrics.return_value = MagicMock()
+                with patch("tools.github_api") as mock_github:
+                    mock_repo = MagicMock()
+                    mock_github.get_repo.return_value = mock_repo
+                    # Simulate CI now passing after fix
+                    mock_github.get_pr_checks.return_value = ("success", [])
+
+                    from langgraph_orchestrator import ci_monitor_node
+                    result = ci_monitor_node(state)
+
+        # Second pass should call API to check real CI status
+        mock_github.get_repo.assert_called_once()
+        mock_github.get_pr_checks.assert_called_once_with(mock_repo, 123)
+
+        # Second pass should update ci_state based on real CI status
+        assert result["ci_state"] == "success"
+
+    def test_ci_monitor_no_infinite_loop_after_fix(self):
+        """Test that ci_monitor can observe CI recovery after fixer applies fix.
+
+        This is a regression test for Issue #3541:
+        Without the consumed flag, ci_monitor would always force ci_state="failure"
+        when ci_failure_trigger=True, causing an infinite loop.
+        """
+        from unittest.mock import patch, MagicMock
+
+        # Simulate state after fixer has applied fix and routed back to ci_monitor
+        state = {
+            "trace_id": "test-trace-no-loop",
+            "ci_failure_trigger": True,
+            "ci_state": "failure",
+            "ci_failure_fast_path_consumed": True,
+            "pr_number": 456,
+            "messages": [],
+        }
+
+        with patch("langgraph_orchestrator.time") as mock_time:
+            mock_time.time.return_value = 1000.0
+            with patch("langgraph_orchestrator._get_metrics") as mock_metrics:
+                mock_metrics.return_value = MagicMock()
+                with patch("tools.github_api") as mock_github:
+                    mock_repo = MagicMock()
+                    mock_github.get_repo.return_value = mock_repo
+                    # CI is now passing after the fix
+                    mock_github.get_pr_checks.return_value = ("success", [
+                        {"name": "lint", "conclusion": "success"},
+                    ])
+
+                    from langgraph_orchestrator import ci_monitor_node
+                    result = ci_monitor_node(state)
+
+        # The key assertion: ci_state should be updated to "success"
+        # If the infinite loop bug existed, ci_state would still be "failure"
+        assert result["ci_state"] == "success"
+        assert result["ci_checks"] == [{"name": "lint", "conclusion": "success"}]
+
+    def test_ci_monitor_normal_flow_unaffected(self):
+        """Test that normal flow (no ci_failure_trigger) is unaffected."""
+        from unittest.mock import patch, MagicMock
+
+        state = {
+            "trace_id": "test-trace-normal",
+            "ci_failure_trigger": False,
+            "ci_state": "pending",
+            "pr_number": 789,
+            "messages": [],
+        }
+
+        with patch("langgraph_orchestrator.time") as mock_time:
+            mock_time.time.return_value = 1000.0
+            with patch("langgraph_orchestrator._get_metrics") as mock_metrics:
+                mock_metrics.return_value = MagicMock()
+                with patch("tools.github_api") as mock_github:
+                    mock_repo = MagicMock()
+                    mock_github.get_repo.return_value = mock_repo
+                    mock_github.get_pr_checks.return_value = ("success", [])
+
+                    from langgraph_orchestrator import ci_monitor_node
+                    result = ci_monitor_node(state)
+
+        # Normal flow should always check real CI status
+        mock_github.get_repo.assert_called_once()
+        mock_github.get_pr_checks.assert_called_once()
+        assert result["ci_state"] == "success"
+
+        # Normal flow should not set consumed flag
+        assert result.get("ci_failure_fast_path_consumed") is None


### PR DESCRIPTION
# fix: bypass executor_node for CI failure auto-fix to avoid ValueGate blocking

## Summary
When CI failure auto-fix runs, the fixer node was routing to `executor_node`, which calls `graph.execute()` (the FAQ documentation generation flow). This flow includes a ValueGate check that blocks PRs with low significance scores (e.g., score=13 for a typo fix), causing CI failure auto-fixes to be blocked.

This PR modifies `should_proceed_after_fixer()` to route directly to `ci_monitor` when `ci_failure_trigger=True`, bypassing the executor_node entirely.

**Changes:**
- Added `ci_failure_trigger` check in `should_proceed_after_fixer()`
- Added `ci_monitor` route to fixer's conditional edges
- Added logging for `CI_FAILURE_FIXER_TO_CI_MONITOR` event

## Updates since last revision

**Infinite Loop Prevention (Issue #3541):**

Addressed gemini-code-assist's CRITICAL review comment about potential infinite loop. When fixer routes back to `ci_monitor`, `ci_failure_trigger` remains `True`, which would cause `ci_monitor_node` to keep forcing `ci_state="failure"` indefinitely.

**Fix:** Added `ci_failure_fast_path_consumed` flag to make the fast path one-shot:
- First pass: `ci_failure_trigger=True`, `consumed=False` → skip API, force failure
- Second pass (post-fix): `ci_failure_trigger=True`, `consumed=True` → check real CI status

**Added:**
- `ci_failure_fast_path_consumed: Optional[bool]` to AgentState TypedDict
- One-shot logic in `ci_monitor_node` to consume the fast path on first use
- 4 regression tests in `TestCIMonitorFastPathConsumed` class

## Review & Testing Checklist for Human
- [ ] **Verify consumed flag logic**: Confirm that `ci_failure_fast_path_consumed` is set on first `ci_monitor` pass and that subsequent passes check real CI status (review lines 4059-4104 in langgraph_orchestrator.py)
- [ ] **Test infinite loop prevention**: After fixer applies fix, verify `ci_monitor` can observe CI recovery (ci_state changes from "failure" to "success")
- [ ] **Verify `ci_failure_trigger` state propagation**: Confirm that `ci_failure_trigger=True` is correctly set in state when CI failure webhook triggers the auto-fix flow
- [ ] **Test end-to-end CI failure auto-fix**: Push a commit with a lint error to a test PR, wait for CI to fail, and verify the auto-fix flow completes without ValueGate blocking or infinite loops
- [ ] **Verify normal flows unaffected**: Confirm that non-CI-failure workflows still route to `executor` as expected

### Test Plan
1. Merge this PR and deploy to staging
2. Push a new commit to PR #3528 (the Probe 0 test PR) with an intentional lint error
3. Wait for CI to fail and trigger the auto-fix webhook
4. Check Render logs for:
   - `CI_FAILURE_FIXER_TO_CI_MONITOR` log message (fixer routing)
   - `fast path (first pass)` log message (first ci_monitor)
   - `post-fix verification` log message (second ci_monitor checking real CI)
5. Verify the fix is committed and pushed to the PR
6. Verify CI passes after the fix (no infinite loop)

### Notes
- This is part of EPIC D Track B Sprint B0 validation work
- Related to the ValueGate blocking issue discovered during Probe 0 testing
- Addresses gemini-code-assist CRITICAL review about infinite loop risk
- Follow-up issues to be created for: webhook security verification, ci_monitor scalability, monitoring/runbook updates

Link to Devin run: https://app.devin.ai/sessions/8442f839efae4ff2b86c282142178bc1
Requested by: Ryan Chen (@RC918)