### PR TITLE
fix(#3550): default to fix_lint for generic CI providers like GitHub Actions

### DIFF
--- a/handoff/20250928/40_App/orchestrator/project_engineer/fixer_integration.py
+++ b/handoff/20250928/40_App/orchestrator/project_engineer/fixer_integration.py
@@ -806,6 +806,21 @@ class AutoFixer:
             )
             return "documentation_update"
 
+        # Issue #3550: When failed_check_name is a generic CI provider name
+        # (e.g., "GitHub Actions") and error_summary is empty, we cannot
+        # reliably infer the task type. However, since CI failure auto-fix
+        # is typically triggered by lint failures, default to fix_lint as
+        # a safe fallback to avoid classifier misclassification.
+        generic_ci_providers = ["github actions", "circleci", "travis ci", "jenkins"]
+        if failed_check_name.lower() in generic_ci_providers:
+            logger.info(
+                "[AutoFixer] failed_check_name is generic CI provider '%s', "
+                "defaulting to fix_lint as safe fallback (Issue #3550)",
+                failed_check_name,
+                extra={"ci_failure_task_type_inference": "fix_lint_fallback"}
+            )
+            return "fix_lint"
+
         # No match - let classifier decide (may fail whitelist check)
         logger.warning(
             "[AutoFixer] Could not infer task_type from CI failure context. "


### PR DESCRIPTION
## Summary

When `failed_check_name` is a generic CI provider name (e.g., "GitHub Actions") instead of the actual check name (e.g., "lint"), the token-based matching in `_infer_task_type_from_ci_failure()` cannot infer the correct task type. This causes fallback to the LLM classifier which may produce non-whitelisted types like `backend_utils_bug_fix`, blocking AutoFixer from completing CI failure fixes.

**Root cause:** `github_handler.py` uses `check_suite.app.name` ("GitHub Actions") instead of `check_run.name` ("lint") when populating `CiFailureContext.failed_check_name`.

**This fix:** Adds a fallback that returns `fix_lint` when `failed_check_name` matches known generic CI provider names. This is a workaround - the proper fix would be to populate the actual check name from the GitHub API.

Closes #3550

## Review & Testing Checklist for Human

- [ ] **Verify assumption is acceptable**: This assumes generic CI provider names should default to `fix_lint`. If CI failures are often non-lint (tests, builds), this could cause incorrect task classification
- [ ] **Check CI provider list completeness**: Currently includes "github actions", "circleci", "travis ci", "jenkins" - verify this covers your CI providers
- [ ] **Staging validation**: After merging, deploy to staging and re-run Probe 0 (PR #3528) to verify AutoFixer now completes the fix
- [ ] **Monitor logs**: Search for `fix_lint_fallback` in Render logs to confirm the fallback is triggered

### Notes

- `fix_lint` is in the safe_tasks whitelist, so this won't enable unsafe code generation
- This is a workaround for Issue #3550. A follow-up should fix the root cause in `github_handler.py` to use actual `check_run.name`
- Part of EPIC D Track B Sprint B0 (Probe 0 validation)

---
**Requested by:** Ryan Chen (@RC918)
**Link to Devin run:** https://app.devin.ai/sessions/8442f839efae4ff2b86c282142178bc1