### PR TITLE
test(#3552): add regression tests for SAFE_TASK_TYPES and action_mapping consistency

### DIFF
--- a/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_agent_security_rules.py
+++ b/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_agent_security_rules.py
@@ -575,37 +575,42 @@ class TestSafeTaskActionMappingConsistency:
     fail with "Action 'analyze_code' is not in allowed actions whitelist".
 
     These tests prevent future drift between the two taxonomies.
+
+    NOTE: ACTION_MAPPING is a copy of agent.py:_process_step() action_mapping.
+    A future improvement (tracked separately) is to extract ACTION_MAPPING to a
+    module-level constant in agent.py so tests can import it directly.
     """
+
+    ACTION_MAPPING = {
+        "documentation_update": "write_file",
+        "test_generation": "write_file",
+        "code_review": "review_code",
+        "bug_fix": "write_file",
+        "refactoring": "write_file",
+        "feature_implementation": "write_file",
+        "backend_utils_bug_fix": "write_file",
+        "frontend_ui_tokens": "write_file",
+        "simple_api_endpoint": "write_file",
+        "fix_lint": "write_file",
+        "fix_typo": "write_file",
+        "update_readme": "write_file",
+        "comment_enhancement": "write_file",
+        "env_sync": "write_file",
+        "config_update": "write_file",
+        "i18n_update": "write_file",
+    }
 
     def test_all_safe_task_types_have_action_mapping(self):
         """Every SAFE_TASK_TYPE should have a corresponding action_mapping entry"""
         from project_engineer.safe_tasks import SAFE_TASK_TYPES
 
-        action_mapping = {
-            "documentation_update": "write_file",
-            "test_generation": "write_file",
-            "code_review": "review_code",
-            "bug_fix": "write_file",
-            "refactoring": "write_file",
-            "feature_implementation": "write_file",
-            "backend_utils_bug_fix": "write_file",
-            "frontend_ui_tokens": "write_file",
-            "simple_api_endpoint": "write_file",
-            "fix_lint": "write_file",
-            "fix_typo": "write_file",
-            "update_readme": "write_file",
-            "comment_enhancement": "write_file",
-            "env_sync": "write_file",
-            "config_update": "write_file",
-            "i18n_update": "write_file",
-        }
+        missing_mappings = [
+            task_type
+            for task_type in SAFE_TASK_TYPES
+            if task_type not in self.ACTION_MAPPING
+        ]
 
-        missing_mappings = []
-        for task_type in SAFE_TASK_TYPES:
-            if task_type not in action_mapping:
-                missing_mappings.append(task_type)
-
-        assert len(missing_mappings) == 0, (
+        assert not missing_mappings, (
             f"SAFE_TASK_TYPES contains task types without action_mapping entries: "
             f"{missing_mappings}. This will cause semantic validation to fail with "
             f"'Action not in allowed actions whitelist'. "
@@ -617,33 +622,14 @@ class TestSafeTaskActionMappingConsistency:
         from project_engineer.safe_tasks import SAFE_TASK_TYPES
         from project_engineer.semantic_rules import DEFAULT_ALLOWED_ACTIONS
 
-        action_mapping = {
-            "documentation_update": "write_file",
-            "test_generation": "write_file",
-            "code_review": "review_code",
-            "bug_fix": "write_file",
-            "refactoring": "write_file",
-            "feature_implementation": "write_file",
-            "backend_utils_bug_fix": "write_file",
-            "frontend_ui_tokens": "write_file",
-            "simple_api_endpoint": "write_file",
-            "fix_lint": "write_file",
-            "fix_typo": "write_file",
-            "update_readme": "write_file",
-            "comment_enhancement": "write_file",
-            "env_sync": "write_file",
-            "config_update": "write_file",
-            "i18n_update": "write_file",
-        }
+        invalid_actions = [
+            (task_type, self.ACTION_MAPPING[task_type])
+            for task_type in SAFE_TASK_TYPES
+            if task_type in self.ACTION_MAPPING
+            and self.ACTION_MAPPING[task_type] not in DEFAULT_ALLOWED_ACTIONS
+        ]
 
-        invalid_actions = []
-        for task_type in SAFE_TASK_TYPES:
-            if task_type in action_mapping:
-                action = action_mapping[task_type]
-                if action not in DEFAULT_ALLOWED_ACTIONS:
-                    invalid_actions.append((task_type, action))
-
-        assert len(invalid_actions) == 0, (
+        assert not invalid_actions, (
             f"SAFE_TASK_TYPES have actions not in DEFAULT_ALLOWED_ACTIONS: "
             f"{invalid_actions}. This will cause semantic validation to fail. "
             f"Either add the action to DEFAULT_ALLOWED_ACTIONS in semantic_rules.py "


### PR DESCRIPTION
## Summary

Adds regression tests to prevent future drift between `SAFE_TASK_TYPES` (in `safe_tasks.py`) and `action_mapping` (in `agent.py`). This drift caused Root Cause #9 (Issue #3552) where `fix_lint` was in the safe tasks whitelist but missing from action_mapping, causing semantic validation to fail with "Action 'analyze_code' is not in allowed actions whitelist".

**New tests in `TestSafeTaskActionMappingConsistency`:**
- `test_all_safe_task_types_have_action_mapping`: Ensures every SAFE_TASK_TYPE has a corresponding action_mapping entry
- `test_all_safe_task_actions_are_in_allowed_whitelist`: Ensures all mapped actions are in DEFAULT_ALLOWED_ACTIONS
- `test_default_fallback_action_is_in_whitelist`: Ensures the default fallback action (`read_file`) is whitelisted

## Updates since last revision

Addressed gemini-code-assist feedback:
- Moved duplicated `action_mapping` dict to class attribute `ACTION_MAPPING` (DRY improvement)
- Refactored assertions to use list comprehensions for cleaner code
- Added docstring note about future improvement to import ACTION_MAPPING from agent.py

## Review & Testing Checklist for Human

- [ ] **Verify ACTION_MAPPING class attribute matches agent.py**: The tests use a hardcoded copy. Confirm it matches `agent.py:_process_step()` lines 508-529
- [ ] **Run tests locally**: `pytest handoff/20250928/40_App/orchestrator/project_engineer/tests/test_agent_security_rules.py::TestSafeTaskActionMappingConsistency -v`

### Notes

This is a test-only change with no production code modifications. The tests are designed to fail CI if someone adds a new safe task type without adding the corresponding action_mapping entry.

**Known limitation**: The `ACTION_MAPPING` is a hardcoded copy rather than imported from agent.py. If agent.py's mapping changes, these tests must be manually updated. A future improvement (tracked separately) is to extract ACTION_MAPPING to a module-level constant in agent.py so tests can import it directly.

**Link to Devin run:** https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
**Requested by:** Ryan Chen (@RC918)