### PR TITLE
refactor(#3555): extract ACTION_MAPPING to module-level constant in agent.py

### DIFF
--- a/handoff/20250928/40_App/orchestrator/project_engineer/agent.py
+++ b/handoff/20250928/40_App/orchestrator/project_engineer/agent.py
@@ -14,10 +14,39 @@ Features:
 """
 import logging
 import uuid
-from typing import List, Optional
+from typing import List, Optional, Dict
 from dataclasses import dataclass
 
 logger = logging.getLogger(__name__)
+
+# Module-level constant for task type to action mapping
+# Used by _process_step() for semantic rules validation
+# Keys match TaskClassifier TaskType enum values AND safe_tasks.py SAFE_TASK_TYPES
+# Exported for use by regression tests (Issue #3555)
+ACTION_MAPPING: Dict[str, str] = {
+    # TaskClassifier produced types
+    "documentation_update": "write_file",
+    "test_generation": "write_file",
+    "code_review": "review_code",
+    "bug_fix": "write_file",
+    "refactoring": "write_file",
+    "feature_implementation": "write_file",
+    "backend_utils_bug_fix": "write_file",
+    "frontend_ui_tokens": "write_file",
+    "simple_api_endpoint": "write_file",
+    # Safe task types from safe_tasks.py (Issue #3552: CI failure auto-fix)
+    "fix_lint": "write_file",
+    "fix_typo": "write_file",
+    "update_readme": "write_file",
+    "comment_enhancement": "write_file",
+    "env_sync": "write_file",
+    "config_update": "write_file",
+    "i18n_update": "write_file",
+}
+
+# Default fallback action when task_type is not in ACTION_MAPPING
+# Must be in DEFAULT_ALLOWED_ACTIONS whitelist (semantic_rules.py)
+DEFAULT_FALLBACK_ACTION: str = "read_file"
 
 
 @dataclass
@@ -503,33 +532,8 @@ class ProjectEngineerAgent:
                 )
 
             # Phase 1 Security Foundation: Comprehensive semantic rules validation
-            # Maps task_type to action for semantic rules validation
-            # Keys match TaskClassifier TaskType enum values AND safe_tasks.py SAFE_TASK_TYPES
-            action_mapping = {
-                # TaskClassifier produced types
-                "documentation_update": "write_file",
-                "test_generation": "write_file",
-                "code_review": "review_code",
-                "bug_fix": "write_file",
-                "refactoring": "write_file",
-                "feature_implementation": "write_file",
-                "backend_utils_bug_fix": "write_file",  # Backend utility bug fixes
-                "frontend_ui_tokens": "write_file",  # Frontend UI token updates
-                "simple_api_endpoint": "write_file",  # Simple API endpoint creation
-                # Safe task types from safe_tasks.py (Issue #3552: CI failure auto-fix)
-                "fix_lint": "write_file",  # Fix linting errors
-                "fix_typo": "write_file",  # Fix typos in code/comments
-                "update_readme": "write_file",  # Update README files
-                "comment_enhancement": "write_file",  # Enhance code comments
-                "env_sync": "write_file",  # Sync environment files
-                "config_update": "write_file",  # Update config files
-                "i18n_update": "write_file",  # Update i18n files
-                # Note: 'unknown' key removed per MorningAI Reviewer feedback to ensure
-                # single source of truth - default fallback is controlled by .get() below
-            }
-            # Default fallback: 'read_file' is in DEFAULT_ALLOWED_ACTIONS whitelist
-            # (changed from 'analyze_code' which was not in whitelist)
-            action = action_mapping.get(task_type, "read_file")
+            # Use module-level ACTION_MAPPING constant (Issue #3555)
+            action = ACTION_MAPPING.get(task_type, DEFAULT_FALLBACK_ACTION)
 
             semantic_valid, semantic_error, requires_approval = self._validate_task_semantic_rules(
                 repo=repo,

--- a/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_agent_security_rules.py
+++ b/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_agent_security_rules.py
@@ -576,77 +576,58 @@ class TestSafeTaskActionMappingConsistency:
 
     These tests prevent future drift between the two taxonomies.
 
-    NOTE: ACTION_MAPPING is a copy of agent.py:_process_step() action_mapping.
-    A future improvement (tracked separately) is to extract ACTION_MAPPING to a
-    module-level constant in agent.py so tests can import it directly.
+    Issue #3555: ACTION_MAPPING is now imported directly from agent.py as a
+    module-level constant, eliminating the need for a hardcoded copy in tests.
     """
-
-    ACTION_MAPPING = {
-        "documentation_update": "write_file",
-        "test_generation": "write_file",
-        "code_review": "review_code",
-        "bug_fix": "write_file",
-        "refactoring": "write_file",
-        "feature_implementation": "write_file",
-        "backend_utils_bug_fix": "write_file",
-        "frontend_ui_tokens": "write_file",
-        "simple_api_endpoint": "write_file",
-        "fix_lint": "write_file",
-        "fix_typo": "write_file",
-        "update_readme": "write_file",
-        "comment_enhancement": "write_file",
-        "env_sync": "write_file",
-        "config_update": "write_file",
-        "i18n_update": "write_file",
-    }
 
     def test_all_safe_task_types_have_action_mapping(self):
         """Every SAFE_TASK_TYPE should have a corresponding action_mapping entry"""
+        from project_engineer.agent import ACTION_MAPPING
         from project_engineer.safe_tasks import SAFE_TASK_TYPES
 
         missing_mappings = [
             task_type
             for task_type in SAFE_TASK_TYPES
-            if task_type not in self.ACTION_MAPPING
+            if task_type not in ACTION_MAPPING
         ]
 
         assert not missing_mappings, (
-            f"SAFE_TASK_TYPES contains task types without action_mapping entries: "
+            f"SAFE_TASK_TYPES contains task types without ACTION_MAPPING entries: "
             f"{missing_mappings}. This will cause semantic validation to fail with "
             f"'Action not in allowed actions whitelist'. "
-            f"Add these to action_mapping in agent.py:_process_step()"
+            f"Add these to ACTION_MAPPING in agent.py"
         )
 
     def test_all_safe_task_actions_are_in_allowed_whitelist(self):
         """Every action mapped from SAFE_TASK_TYPES should be in DEFAULT_ALLOWED_ACTIONS"""
+        from project_engineer.agent import ACTION_MAPPING
         from project_engineer.safe_tasks import SAFE_TASK_TYPES
         from project_engineer.semantic_rules import DEFAULT_ALLOWED_ACTIONS
 
         invalid_actions = [
-            (task_type, self.ACTION_MAPPING[task_type])
+            (task_type, ACTION_MAPPING[task_type])
             for task_type in SAFE_TASK_TYPES
-            if task_type in self.ACTION_MAPPING
-            and self.ACTION_MAPPING[task_type] not in DEFAULT_ALLOWED_ACTIONS
+            if task_type in ACTION_MAPPING
+            and ACTION_MAPPING[task_type] not in DEFAULT_ALLOWED_ACTIONS
         ]
 
         assert not invalid_actions, (
             f"SAFE_TASK_TYPES have actions not in DEFAULT_ALLOWED_ACTIONS: "
             f"{invalid_actions}. This will cause semantic validation to fail. "
             f"Either add the action to DEFAULT_ALLOWED_ACTIONS in semantic_rules.py "
-            f"or change the action_mapping in agent.py:_process_step()"
+            f"or change ACTION_MAPPING in agent.py"
         )
 
     def test_default_fallback_action_is_in_whitelist(self):
         """The default fallback action should be in DEFAULT_ALLOWED_ACTIONS"""
+        from project_engineer.agent import DEFAULT_FALLBACK_ACTION
         from project_engineer.semantic_rules import DEFAULT_ALLOWED_ACTIONS
 
-        default_fallback = "read_file"
-
-        assert default_fallback in DEFAULT_ALLOWED_ACTIONS, (
-            f"Default fallback action '{default_fallback}' is not in "
+        assert DEFAULT_FALLBACK_ACTION in DEFAULT_ALLOWED_ACTIONS, (
+            f"DEFAULT_FALLBACK_ACTION '{DEFAULT_FALLBACK_ACTION}' is not in "
             f"DEFAULT_ALLOWED_ACTIONS. This will cause semantic validation to fail "
-            f"for unknown task types. Update agent.py:_process_step() to use an "
-            f"action from: {DEFAULT_ALLOWED_ACTIONS}"
+            f"for unknown task types. Update DEFAULT_FALLBACK_ACTION in agent.py "
+            f"to use an action from: {DEFAULT_ALLOWED_ACTIONS}"
         )
 
 


### PR DESCRIPTION
## Summary

Extracts the `action_mapping` dictionary from inside `_process_step()` to a module-level constant `ACTION_MAPPING`, enabling tests to import it directly rather than maintaining a hardcoded copy. This implements the DRY principle improvement suggested in Issue #3555.

**Changes:**
- Added `ACTION_MAPPING: Dict[str, str]` as module-level constant in `agent.py`
- Added `DEFAULT_FALLBACK_ACTION: str = "read_file"` constant
- Updated `_process_step()` to use the module-level constants
- Updated regression tests to import from `agent.py` instead of using hardcoded copy

## Review & Testing Checklist for Human

- [ ] Verify `ACTION_MAPPING` values are identical to the previous inline dictionary (no accidental changes to mappings)
- [ ] Confirm no circular import issues when tests import from `agent.py`
- [ ] Run the regression tests locally: `pytest handoff/20250928/40_App/orchestrator/project_engineer/tests/test_agent_security_rules.py::TestSafeTaskActionMappingConsistency -v`

**Recommended test plan:** Run the full test suite for `test_agent_security_rules.py` to ensure no regressions in the security validation logic.

### Notes

This PR closes #3555, which was created as a follow-up from PR #3554 based on gemini-code-assist feedback.

**Link to Devin run:** https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
**Requested by:** Ryan Chen (@RC918)