### PR TITLE
fix: update TaskClassifier tests to dynamically count task types

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_task_classifier.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_task_classifier.py
@@ -26,7 +26,7 @@ class TestTaskClassifierInitialization:
         assert hasattr(classifier, 'patterns')
         assert isinstance(classifier.patterns, dict)
         # Patterns should exist for all TaskTypes except UNKNOWN
-        expected_pattern_count = len([t for t in TaskType if t != TaskType.UNKNOWN])
+        expected_pattern_count = sum(1 for t in TaskType if t != TaskType.UNKNOWN)
         assert len(classifier.patterns) == expected_pattern_count
 
     def test_init_patterns_have_correct_task_types(self):


### PR DESCRIPTION
## Summary

Fixes failing `test_init_creates_patterns` test in Orchestrator Tests CI job. The test was hardcoded to expect 5 task types, but after LINT_FIX was added in #3559, the TaskClassifier now has 6 task types.

Instead of just changing `5` to `6`, this PR makes the tests more maintainable by dynamically deriving expected values from the `TaskType` enum:

```python
# Before
assert len(classifier.patterns) == 6  # hardcoded magic number

# After  
expected_pattern_count = sum(1 for t in TaskType if t != TaskType.UNKNOWN)
assert len(classifier.patterns) == expected_pattern_count
```

This prevents future test failures when new task types are added.

### Updates since last revision

- Resolved merge conflict with main branch (main had already updated count to 6 and added explicit LINT_FIX to lists; this PR replaces those hardcoded values with dynamic derivation)
- Implemented gemini-code-assist suggestion: use `sum(1 for ...)` generator expression instead of `len([...])` for better memory efficiency

## Review & Testing Checklist for Human

- [ ] Verify the assumption that ALL non-UNKNOWN TaskTypes should have patterns is correct for the TaskClassifier design
- [ ] Confirm Orchestrator Tests CI job passes after merge
- [ ] Consider if there could ever be a TaskType that intentionally shouldn't have patterns (if so, the dynamic approach would need adjustment)

### Notes

**Root cause:** PR #3559 added `TaskType.LINT_FIX` but didn't update the test expectations.

**MorningAI Review:** Approved (Score: 80)

**gemini-code-assist:** Suggestion adopted (use generator expression for memory efficiency)

Link to Devin run: https://app.devin.ai/sessions/09f9b0d9ca9d4fef99b11cb59b92db6a
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918