### PR TITLE
fix(#3579): disable LangGraph checkpointer inheritance to prevent NotImplementedError

### DIFF
--- a/agents/dev_agent/workflows/code_generation_workflow.py
+++ b/agents/dev_agent/workflows/code_generation_workflow.py
@@ -157,7 +157,13 @@ class CodeGenerationWorkflow:
         
         workflow.set_finish_point("create_pr")
         
-        return workflow.compile()
+        # Issue #3579: Explicitly disable checkpointer to prevent NotImplementedError
+        # When CodeGenerationWorkflow runs inside the orchestrator's LangGraph context,
+        # checkpointer=None can inherit the parent graph's checkpointer via contextvars.
+        # This causes NotImplementedError when LangGraph tries to use abstract methods
+        # from BaseCheckpointSaver that aren't implemented. Setting checkpointer=False
+        # explicitly disables checkpointing and prevents inheritance.
+        return workflow.compile(checkpointer=False)
     
     def _should_continue_after_classify(self, state: CodeGenState) -> str:
         """Decide next step after task classification"""


### PR DESCRIPTION
## Summary

Fixes Root Cause #13 in the EPIC D CI failure auto-fix investigation. When `CodeGenerationWorkflow` runs inside the orchestrator's LangGraph context (via AutoFixer), the `compile()` call with `checkpointer=None` can inherit the parent graph's checkpointer via contextvars. This causes `NotImplementedError` when LangGraph tries to use abstract methods from `BaseCheckpointSaver` that aren't implemented.

The fix explicitly sets `checkpointer=False` to disable checkpointing and prevent inheritance.

**Evidence from staging logs:**
```
Workflow execution failed: NotImplementedError: (empty exception message)
[ProjectEngineerAgent] Code generation failed: NotImplementedError: (empty exception message)
[AutoFixer] Auto-fix failed: NotImplementedError: (empty exception message)
```

The bare `raise NotImplementedError` (no message) matches the pattern in LangGraph's `BaseCheckpointSaver` abstract methods.

## Review & Testing Checklist for Human

- [ ] **Verify hypothesis is correct**: Deploy to staging and trigger a CI failure on Probe 0 (#3528) to confirm the NotImplementedError is resolved
- [ ] **Check for side effects**: Confirm that disabling checkpointing doesn't break any other workflow functionality
- [ ] **Review LangGraph docs**: Verify that `checkpointer=False` is the correct way to explicitly disable checkpointing (vs other approaches)

**Recommended test plan:**
1. Merge and deploy to staging
2. Push an empty commit to Probe 0 PR (#3528) to trigger CI failure
3. Monitor staging worker logs for:
   - Absence of `NotImplementedError`
   - Successful code generation workflow execution
   - Fix PR creation

### Notes

Closes #3579

This is part of the ongoing EPIC D investigation. PR #3573 (Root Cause #12) is already working - the synthesis log appears in staging. This fix addresses the next blocker.

---
Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918