### PR TITLE
fix(#3584): add default git author identity to SimpleGitTool

### DIFF
--- a/agents/dev_agent/dev_agent_wrapper.py
+++ b/agents/dev_agent/dev_agent_wrapper.py
@@ -64,20 +64,51 @@ class SimpleGitTool:
     ) -> Dict[str, Any]:
         """Commit changes."""
         try:
+            cwd = os.getcwd()
             if files:
-                subprocess.run(['git', 'add'] + files, cwd=os.getcwd())
+                add_result = subprocess.run(
+                    ['git', 'add'] + files,
+                    capture_output=True,
+                    text=True,
+                    cwd=cwd
+                )
+                if add_result.returncode != 0:
+                    logger.error(f"[SimpleGitTool] git add failed: {add_result.stderr}")
+                    return {
+                        'success': False,
+                        'error': f'git add failed: {add_result.stderr}'
+                    }
+            
+            # Issue #3584: Use git -c options to set author identity
+            commit_cmd = [
+                'git',
+                '-c', f'user.name={self.DEFAULT_GIT_AUTHOR_NAME}',
+                '-c', f'user.email={self.DEFAULT_GIT_AUTHOR_EMAIL}',
+                'commit', '-m', message
+            ]
+            
+            logger.info(
+                f"[SimpleGitTool] Committing with author: "
+                f"{self.DEFAULT_GIT_AUTHOR_NAME} <{self.DEFAULT_GIT_AUTHOR_EMAIL}>"
+            )
+            
             result = subprocess.run(
-                ['git', 'commit', '-m', message],
+                commit_cmd,
                 capture_output=True,
                 text=True,
-                cwd=os.getcwd()
+                cwd=cwd
             )
+            
+            if result.returncode != 0:
+                logger.error(f"[SimpleGitTool] git commit failed: {result.stderr}")
+            
             return {
                 'success': result.returncode == 0,
                 'output': result.stdout,
                 'error': result.stderr if result.returncode != 0 else None
             }
         except Exception as e:
+            logger.error(f"[SimpleGitTool] commit failed with exception: {e}")
             return {'success': False, 'error': str(e)}
 
     async def push(


### PR DESCRIPTION
## Summary

Fixes "Author identity unknown" errors in CI/CD environments where `git user.name` and `git user.email` are not configured globally.

**Root Cause #14** from EPIC D investigation: The staging worker environment doesn't have git identity configured, causing all automated commits from the AutoFixer workflow to fail with:
```
[SimpleGitTool] git commit failed: Author identity unknown
```

**Solution**: Use `git -c user.name=... -c user.email=...` options to set author identity per-commit, eliminating the need for environment-level git configuration.

## Updates since last revision

- Applied the same git author identity fix to the `commit()` method (per gemini-code-assist review)
- Added error handling for `git add` command in `commit()` method
- Added logging for commit operations in both methods
- Both `commit()` and `commit_and_push()` now consistently use the bot identity

## Review & Testing Checklist for Human

- [ ] **Verify bot identity is correct**: Hardcoded as "MorningAI Bot <bot@morningai.com>" - confirm this is the desired identity for automated commits
- [ ] **Test in staging**: Trigger Probe 0 CI failure (#3528) after deployment and verify commits are created successfully with the bot identity
- [ ] **Verify both methods work**: Both `commit()` (used by BugFixWorkflow) and `commit_and_push()` (used by AutoFixer) should now succeed in CI environments

**Recommended test plan**: After deployment, push an empty commit to PR #3528 to trigger a CI failure. Monitor staging worker logs for `[SimpleGitTool] Committing with author: MorningAI Bot` and verify a fix PR is created successfully.

### Notes

- This is a code-level fix that doesn't require any environment variable configuration in staging or production
- The bot identity is intentionally hardcoded for consistency across all automated commits

Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
Requested by: Ryan Chen (@RC918)