### PR TITLE
fix(#3585): correct repo root discovery to prevent path corruption

### DIFF
--- a/agents/dev_agent/workflows/code_generation_workflow.py
+++ b/agents/dev_agent/workflows/code_generation_workflow.py
@@ -12,7 +12,6 @@ Supports 5 task types:
 """
 import logging
 import re
-import subprocess
 import time
 import os
 from typing import Dict, Any, List, Optional, TypedDict
@@ -22,50 +21,25 @@ from langgraph.graph import StateGraph
 
 import sys
 
+# Issue #3585: Root Cause #16 - Path corruption fix
+# The previous calculation using dirname() was incorrect:
+# - Old: os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+# - This gave /path/to/agents instead of /path/to (repo root)
+#
+# Now uses common.utils.repo_root.get_repo_root() which is the canonical
+# implementation with proper fallback chain and error handling.
+# Must bootstrap sys.path first to import from common.utils.
+_bootstrap_root = Path(__file__).resolve()
+for _parent in _bootstrap_root.parents:
+    if (_parent / '.git').exists():
+        _bootstrap_root = _parent
+        break
+if str(_bootstrap_root) not in sys.path:
+    sys.path.insert(0, str(_bootstrap_root))
 
-def _discover_repo_root() -> str:
-    """
-    Discover repository root path using git rev-parse.
-    
-    Issue #3585: Root Cause #16 - Path corruption fix
-    The previous calculation using dirname() was incorrect:
-    - Old: os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-    - This gave /path/to/agents instead of /path/to (repo root)
-    
-    Now uses git rev-parse --show-toplevel which correctly returns
-    the repository root regardless of where the code is located.
-    
-    Fallback chain:
-    1. git rev-parse --show-toplevel (most reliable)
-    2. Traverse up from __file__ looking for .git directory
-    3. Original dirname calculation (last resort)
-    
-    Returns:
-        Absolute path to repository root
-    """
-    try:
-        result = subprocess.run(
-            ['git', 'rev-parse', '--show-toplevel'],
-            capture_output=True,
-            text=True,
-            timeout=5,
-            check=True
-        )
-        repo_root = result.stdout.strip()
-        if repo_root and os.path.exists(repo_root):
-            return os.path.abspath(repo_root)
-    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, FileNotFoundError):
-        pass
-    
-    current = Path(__file__).resolve()
-    for parent in current.parents:
-        if (parent / '.git').exists():
-            return str(parent)
-    
-    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from common.utils.repo_root import get_repo_root
 
-
-project_root = _discover_repo_root()
+project_root = str(get_repo_root())
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
 


### PR DESCRIPTION
## Summary

Fixes Root Cause #16 (Issue #3585) - Path corruption in CI failure auto-fix workflow.

**Problem:** The previous `project_root` calculation used `dirname()` 3 times from `agents/dev_agent/workflows/code_generation_workflow.py`, which incorrectly resolved to `/path/to/agents` instead of `/path/to` (the actual repo root). This caused path duplication errors like:
```
Failed to parse handoff/.../orchestrator/handoff/.../api-backend/src/file.py
```

**Fix:** Reuses the canonical `common.utils.repo_root.get_repo_root()` which provides:
- Proper error handling (raises `RuntimeError` on failure instead of silent fallback)
- `lru_cache` for performance
- Comprehensive fallback chain: `REPO_ROOT_PATH` env → `git rev-parse` → sentinel file search
- Consistent behavior across the codebase

A minimal bootstrap finds `.git` to add repo root to `sys.path` before importing from `common.utils.repo_root`.

## Updates since last revision

- Refactored to reuse existing `common.utils.repo_root.get_repo_root()` instead of duplicating logic (addresses gemini-code-assist review)
- Removed custom `_discover_repo_root()` function
- Now properly raises `RuntimeError` on failure instead of falling back to incorrect dirname calculation

## Review & Testing Checklist for Human

- [ ] **Bootstrap relies on .git**: The bootstrap code traverses up looking for `.git` directory. Verify this works in staging where worker CWD is `/opt/render/project/src/handoff/20250928/40_App/orchestrator` (should find `.git` at `/opt/render/project/src/.git`)
- [ ] **Import-time subprocess**: `get_repo_root()` is called at import time, spawning a subprocess. Verify this is acceptable for performance.
- [ ] **Staging verification**: After deployment, trigger a CI failure on Probe 0 (#3528) and verify the path corruption error no longer occurs in worker logs.

**Recommended test plan:**
1. Deploy to staging
2. Push a commit to PR #3528 to trigger CI failure
3. Check staging worker logs for path-related errors
4. Verify AutoFixer can now correctly resolve file paths

### Notes

Closes #3585

**Staging environment investigation confirmed:**
- `WORKSPACE_PATH`, `MORNINGAI_REPO_PATH`, `REPO_ROOT_PATH` are NOT SET in staging worker
- Worker CWD is `/opt/render/project/src/handoff/20250928/40_App/orchestrator`
- The incorrect dirname calculation was producing `/opt/render/project/src/agents` instead of `/opt/render/project/src`

Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918