### PR TITLE
fix(#3587): use passed task_type in CodeGenerationWorkflow.execute()

### DIFF
--- a/agents/dev_agent/workflows/code_generation_workflow.py
+++ b/agents/dev_agent/workflows/code_generation_workflow.py
@@ -240,7 +240,14 @@ class CodeGenerationWorkflow:
                 f"[Stage 1] Skipping classification - task_type already set: {state['task_type']}"
             )
             if not state.get("task_metadata"):
-                state["task_metadata"] = {"complexity": "medium", "requires_tests": False}
+                try:
+                    task_type_enum = TaskType(state["task_type"])
+                    state["task_metadata"] = self.classifier.get_task_metadata(task_type_enum)
+                except ValueError:
+                    logger.warning(
+                        f"Invalid task_type '{state['task_type']}' provided, using default metadata."
+                    )
+                    state["task_metadata"] = {"complexity": "medium", "requires_tests": False}
             return state
         
         try:


### PR DESCRIPTION
# fix(#3587): use passed task_type in CodeGenerationWorkflow.execute()

## Summary

Fixes Root Cause #17: `CodeGenerationWorkflow.execute()` was ignoring the `task_type` passed in the task dict and always re-classifying the task. This caused CI failure auto-fix to fail with "Task type 'unknown' not supported" because the CI fix description didn't match LINT_FIX patterns.

**Changes:**
- `execute()`: Use `task.get('task_type')` and `task.get('task_metadata')` instead of hardcoding `None`
- `classify_task()`: Skip classification if `task_type` is already set, with debug logging
- When skipping classification, use `TaskClassifier.get_task_metadata()` to get proper metadata for the task type (with fallback for invalid types)

This allows `task_type_hint` from `fixer_integration.py` to flow through `ProjectEngineerAgent` to `CodeGenerationWorkflow` without being overwritten.

## Updates since last revision

- Addressed gemini-code-assist suggestion: Now using `TaskClassifier.get_task_metadata()` instead of hardcoded default metadata when task_type is pre-set. This ensures consistency with the classification system and handles invalid task types gracefully with a fallback.

## Review & Testing Checklist for Human

- [ ] **Critical**: Deploy to staging and trigger Probe 0 (#3528) CI failure to verify AutoFixer no longer fails with "Task type 'unknown' not supported"
- [ ] Check staging logs for `[Stage 1] Skipping classification - task_type already set: lint_fix`
- [ ] Verify that when `task_type` is `None` (not passed), the classifier still runs as before
- [ ] Verify `TaskType(state["task_type"])` correctly parses the string value (e.g., "lint_fix" matches `TaskType.LINT_FIX`)

### Notes

This is part of EPIC D debugging. Root Cause #18 (NoneType error on PR creation) should also be resolved as a cascading effect of this fix.

Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
Requested by: Ryan Chen (@RC918)