### PR TITLE
fix(#3595): filter disallowed directories from changed_files fallback and skip PR on error

### DIFF
--- a/agents/dev_agent/workflows/code_generation_workflow.py
+++ b/agents/dev_agent/workflows/code_generation_workflow.py
@@ -115,6 +115,7 @@ class CodeGenerationWorkflow:
         '.github/',      # CI/CD workflows - high risk, can bypass security checks
         '.circleci/',    # CI/CD config
         '.gitlab/',      # CI/CD config
+        '.buildkite/',   # CI/CD config (gemini-code-assist suggestion)
         'infra/',        # Infrastructure code
         'terraform/',    # Infrastructure as code
         'k8s/',          # Kubernetes configs
@@ -614,12 +615,13 @@ class CodeGenerationWorkflow:
             return state
 
         # Issue #3595: Skip PR creation if security validation didn't pass
+        # Note: The error check above already returned, so state["error"] is guaranteed
+        # to be falsy here (gemini-code-assist suggestion to simplify)
         if not state.get("security_validated", False):
             logger.warning(
                 "[Stage 8] Skipping PR creation - security validation not passed"
             )
-            if not state.get("error"):
-                state["error"] = "PR creation skipped: security validation not passed"
+            state["error"] = "PR creation skipped: security validation not passed"
             return state
 
         try:


### PR DESCRIPTION
# fix(#3595): filter disallowed directories from changed_files fallback and skip PR on error

## Summary

Fixes two blocking issues discovered during Probe 0 verification that prevented AutoFixer from successfully creating fix PRs:

**Root Cause #24**: The `changed_files` fallback was including files like `.github/workflows/openapi-verify.yml` which are not in the `allowed_directories` for `fix_lint` tasks. These files would always fail security validation, causing misleading errors.

**Root Cause #25**: When security validation failed, the workflow still proceeded to `create_pr()` which crashed with `'NoneType' object has no attribute 'get'` because no code was applied.

**Changes:**
- Add `DISALLOWED_DIRECTORIES` constant listing high-risk directories (`.github/`, `.circleci/`, `.gitlab/`, `.buildkite/`, `infra/`, `terraform/`, `k8s/`, `deploy/`)
- Filter out files in disallowed directories early in `analyze_context()` before they reach security validation
- Add early return in `create_pr()` when error exists or security validation didn't pass

## Updates since last revision

Implemented gemini-code-assist suggestions:
- ✅ Added `.buildkite/` to `DISALLOWED_DIRECTORIES` (consistent with CI/CD blocking policy)
- ✅ Simplified redundant `if not state.get("error")` check in `create_pr()` for code clarity
- ⏳ `scripts/` was NOT added - created follow-up issue #3597 for policy decision (scripts/ contains legitimate code that might need lint fixes)

## Review & Testing Checklist for Human

- [ ] **Check filtering logic edge cases** - The `startswith()` check should correctly match directory prefixes. Verify files named `.github-something.py` are NOT filtered (they shouldn't be, since they don't start with `.github/`)
- [ ] **Deploy to staging and trigger Probe 0** - Push empty commit to `test/capability-probe-validation-1767450121` branch to trigger CI failure and verify:
  - Log shows `[Stage 2] Filtered out X files in disallowed directories`
  - No more `'NoneType' object has no attribute 'get'` errors
  - AutoFixer processes only allowed files and creates a fix PR

### Notes

- The filtering happens at the `changed_files` fallback level, not at the security validation level, so files extracted from task descriptions are still subject to the existing security checks
- Pre-existing lint errors (E402, E722, C901) remain unchanged
- Follow-up issue #3597 created for `scripts/` directory policy decision

---
Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918