### PR TITLE
fix(#3599): skip pytest for fix_lint tasks and handle pytest not found gracefully

### DIFF
--- a/agents/dev_agent/workflows/code_generation_workflow.py
+++ b/agents/dev_agent/workflows/code_generation_workflow.py
@@ -574,6 +574,22 @@ class CodeGenerationWorkflow:
 
         return state
 
+    def _is_pytest_not_found_error(self, error_msg: str) -> bool:
+        """Check if error message indicates pytest is not found (Issue #3599)."""
+        return 'No such file or directory' in error_msg and 'pytest' in error_msg
+
+    def _mark_tests_as_skipped_for_missing_pytest(self, state: CodeGenState) -> None:
+        """Update state to mark tests as skipped due to missing pytest (Issue #3599)."""
+        logger.warning(
+            "[Stage 7] pytest not available in environment - "
+            "treating as skipped, not failed"
+        )
+        state["test_results"] = {
+            "success": True,
+            "skipped": True,
+            "reason": "pytest not available in environment"
+        }
+
     async def run_tests(self, state: CodeGenState) -> CodeGenState:
         """Stage 7: Run tests to verify generated code
 
@@ -607,18 +623,9 @@ class CodeGenerationWorkflow:
                 if test_results.get("success"):
                     logger.info("Tests passed!")
                 else:
-                    # Issue #3599: Check if failure is due to pytest not being available
                     error_msg = str(test_results.get('error', ''))
-                    if 'No such file or directory' in error_msg and 'pytest' in error_msg:
-                        logger.warning(
-                            "[Stage 7] pytest not available in environment - "
-                            "treating as skipped, not failed"
-                        )
-                        state["test_results"] = {
-                            "success": True,
-                            "skipped": True,
-                            "reason": "pytest not available in environment"
-                        }
+                    if self._is_pytest_not_found_error(error_msg):
+                        self._mark_tests_as_skipped_for_missing_pytest(state)
                     else:
                         logger.warning(f"Tests failed: {error_msg}")
             else:
@@ -627,17 +634,8 @@ class CodeGenerationWorkflow:
 
         except Exception as e:
             error_msg = str(e)
-            # Issue #3599: Check if exception is due to pytest not being available
-            if 'No such file or directory' in error_msg and 'pytest' in error_msg:
-                logger.warning(
-                    "[Stage 7] pytest not available in environment - "
-                    "treating as skipped, not failed"
-                )
-                state["test_results"] = {
-                    "success": True,
-                    "skipped": True,
-                    "reason": "pytest not available in environment"
-                }
+            if self._is_pytest_not_found_error(error_msg):
+                self._mark_tests_as_skipped_for_missing_pytest(state)
             else:
                 logger.warning(f"Test execution failed: {error_msg}")
                 state["test_results"] = {"success": False, "error": error_msg}


### PR DESCRIPTION
## Summary

Fixes an infinite retry loop in the AutoFixer workflow that was preventing fix PRs from being created. When the `run_tests` stage failed due to pytest not being available in the staging environment, the workflow would retry code generation repeatedly until the LLM eventually generated code with dangerous patterns (subprocess calls), which was then correctly blocked by security validation.

**Changes:**
- Skip pytest entirely for `fix_lint` and `lint_fix` task types (lint fixes should be verified by running lint, not pytest)
- Treat "pytest not found" errors as skipped rather than failed, preventing unnecessary retries

## Updates since last revision

Per gemini-code-assist suggestion, extracted duplicated "pytest not found" error handling into two helper methods:
- `_is_pytest_not_found_error()`: checks if error message indicates pytest not found
- `_mark_tests_as_skipped_for_missing_pytest()`: updates state to mark tests as skipped

This improves maintainability by centralizing the business rule.

## Review & Testing Checklist for Human

- [ ] **Verify task type values**: Confirm that `"fix_lint"` and `"lint_fix"` are the correct task type string values used by `TaskClassifier`. Check `task_classifier.py` for the actual enum values.
- [ ] **String matching robustness**: The error detection uses `'No such file or directory' in error_msg and 'pytest' in error_msg`. Consider if this could miss other pytest-not-found error formats or accidentally match unrelated errors.
- [ ] **Deploy to staging and trigger Probe 0**: Push empty commit to `test/capability-probe-validation-1767450121` branch and verify:
  - Log shows `[Stage 7] Skipping pytest for fix_lint task`
  - No retry loops occur
  - AutoFixer successfully creates a fix PR

### Notes

- This fix addresses the symptom (retry loop) but not the underlying issue that `retry_attempted` mutations in the router callback may not persist in LangGraph. A follow-up may be needed if retry issues occur for non-lint tasks.
- Pre-existing lint errors (E402, E722, C901) remain unchanged.

---
Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918

Closes #3599