### PR TITLE
chore: add diagnostic logging for task_type in run_tests() (Issue #3599)

### DIFF
--- a/agents/dev_agent/workflows/code_generation_workflow.py
+++ b/agents/dev_agent/workflows/code_generation_workflow.py
@@ -603,6 +603,13 @@ class CodeGenerationWorkflow:
         # verified by running lint, not pytest. Running pytest for lint fixes
         # causes unnecessary failures and retry loops.
         task_type = state.get("task_type", "")
+
+        # Diagnostic logging to debug task_type matching (Issue #3599)
+        logger.info(
+            f"[Stage 7] DIAGNOSTIC: task_type={task_type!r} type={type(task_type).__name__} "
+            f"task_id={state['task_id']}"
+        )
+
         if task_type in ("fix_lint", "lint_fix"):
             logger.info(
                 f"[Stage 7] Skipping pytest for {task_type} task - "


### PR DESCRIPTION
## Summary

Adds diagnostic logging to `run_tests()` in `CodeGenerationWorkflow` to debug why the `fix_lint` task type skip logic from PR #3600 may not be triggering in staging.

The log outputs:
- `task_type` value using `repr()` for exact string representation
- `type(task_type)` to identify if it's a string vs Enum object
- `task_id` for correlation with other logs

This will help identify if the issue is:
1. `task_type` not being propagated correctly (empty/None)
2. `task_type` being an Enum object instead of string (which would fail the `in ("fix_lint", "lint_fix")` check)
3. A different string value than expected

## Review & Testing Checklist for Human

- [ ] Verify the log format will be useful for debugging in Render logs
- [ ] After deploying, trigger Probe 0 and search for `[Stage 7] DIAGNOSTIC:` in staging logs to see actual task_type values

### Notes

This is a temporary diagnostic change to help debug Issue #3599. Once the root cause is identified and fixed, this logging can be removed or converted to debug level.

---
Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
Requested by: Ryan Chen (ryan2939z@gmail.com) / @RC918