### PR TITLE
fix(#3602): add GITHUB_TOKEN authentication for git push in SimpleGitTool

### DIFF
--- a/agents/dev_agent/dev_agent_wrapper.py
+++ b/agents/dev_agent/dev_agent_wrapper.py
@@ -87,12 +87,13 @@ class SimpleGitTool:
         # This script will be called by git when it needs credentials
         # Security fix: Read token from environment at runtime to prevent
         # command injection if token contains shell metacharacters
-        askpass_script = tempfile.NamedTemporaryFile(
-            mode='w',
-            suffix='.sh',
-            delete=False
-        )
+        askpass_script = None
         try:
+            askpass_script = tempfile.NamedTemporaryFile(
+                mode='w',
+                suffix='.sh',
+                delete=False
+            )
             # The script reads GITHUB_TOKEN from environment at runtime
             # Using printf '%s' instead of echo to:
             # - Avoid shell metacharacter interpretation
@@ -118,13 +119,11 @@ class SimpleGitTool:
                 'GIT_TERMINAL_PROMPT': '0',  # Disable interactive prompts
                 'GITHUB_TOKEN': github_token,  # Pass through for askpass script
             }
-        except Exception as e:
+        except (IOError, OSError) as e:
             logger.error(f"[SimpleGitTool] Failed to create askpass script: {e}")
-            # Clean up on error
-            try:
-                os.unlink(askpass_script.name)
-            except OSError:
-                pass
+            # Clean up on error using existing cleanup method (DRY)
+            if askpass_script and hasattr(askpass_script, 'name'):
+                self._cleanup_askpass_script({'GIT_ASKPASS': askpass_script.name})
             return {}
 
     def _cleanup_askpass_script(self, env: Dict[str, str]) -> None:


### PR DESCRIPTION
## Summary

Fixes Root Cause #27: `git push` fails with `fatal: could not read Username for 'https://github.com'` in staging because `SimpleGitTool` was not using `GITHUB_TOKEN` for authentication.

**Solution:** Uses `GIT_ASKPASS` mechanism to securely provide credentials:
- Creates a temporary askpass script that reads the token from environment at runtime
- Uses `x-access-token` as username (standard for GitHub token auth)
- Sets `GIT_TERMINAL_PROMPT=0` to disable interactive prompts
- Cleans up the askpass script after git operation completes

This approach avoids exposing the token in remote URLs, git config, or process arguments.

## Updates since last revision

**MorningAI Code Review fixes:**

1. **Command injection fix**: Token is now read from `$GITHUB_TOKEN` environment variable at runtime using `printf '%s'` instead of being embedded in the script. This prevents command injection if the token contains shell metacharacters.

2. **NameError fix**: `auth_env` is initialized to `{}` before calling `_get_git_auth_env()` to ensure cleanup works even if the method raises an exception.

3. **Robustness**: Added default case `*) exit 0 ;;` to shell case statement.

**gemini-code-assist fixes:**

4. **Exception handling improvement**: Wrapped `tempfile.NamedTemporaryFile` creation in try block by initializing `askpass_script = None` first. This ensures exceptions during temp file creation (e.g., permissions, full disk) are properly caught.

5. **Specific exception types**: Changed from broad `Exception` to `(IOError, OSError)` to avoid hiding unrelated bugs.

6. **DRY cleanup**: Reuse `_cleanup_askpass_script()` method for error cleanup instead of duplicating logic.

## Review & Testing Checklist for Human

- [ ] **Security review**: Token is written to a temp file with owner-only permissions (S_IRWXU) and read from environment at runtime. Verify this is acceptable for your security requirements.
- [ ] **Verify GITHUB_TOKEN exists in Render staging** with repo write permissions
- [ ] **Deploy and trigger Probe 0 (#3528)** to verify git push now succeeds
- [ ] Check staging logs for `[SimpleGitTool] GITHUB_TOKEN found (length=...)` to confirm token is being detected

**Test Plan:**
1. Merge and deploy to staging
2. Trigger Probe 0 CI failure (push empty commit to PR #3528)
3. Monitor staging logs for successful git push (no "could not read Username" error)
4. Verify AutoFixer successfully commits and pushes fix

### Notes

- Part of EPIC D CI Failure Auto-Fix investigation
- Discovered during Probe 0 (#3528) testing after PR #3600 deployment
- Related to Issue #3599 (Root Cause #26)

Closes #3602

---
Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
Requested by: Ryan Chen (@RC918)