### PR TITLE
fix(#3604): use explicit refspec for git push to fix 'not a full refname' error

### DIFF
--- a/agents/dev_agent/dev_agent_wrapper.py
+++ b/agents/dev_agent/dev_agent_wrapper.py
@@ -416,8 +416,29 @@ class SimpleGitTool:
                 push_env = os.environ.copy()
                 push_env.update(auth_env)
 
+                # Issue #3604: Root Cause #28 - Use explicit refspec for git push
+                # When pushing to a newly added remote, 'git push -u origin HEAD' fails with
+                # "The destination you provided is not a full refname" because git doesn't
+                # know what branch name to create on the remote.
+                # Solution: Use explicit refspec 'HEAD:refs/heads/<branch_name>'
+                # This tells git exactly what remote branch to create/update.
+                # Handle detached HEAD case: if branch is empty, we can't push with -u
+                if branch and branch != 'HEAD':
+                    # Normal case: on a named branch
+                    push_cmd = [
+                        'git', 'push', '-u', self.DEFAULT_REMOTE_NAME,
+                        f'HEAD:refs/heads/{branch}'
+                    ]
+                else:
+                    # Detached HEAD case: push without setting upstream
+                    # This is rare in AutoFixer workflow but handle it gracefully
+                    logger.warning(
+                        "[SimpleGitTool] Detached HEAD detected, pushing without upstream tracking"
+                    )
+                    push_cmd = ['git', 'push', self.DEFAULT_REMOTE_NAME, 'HEAD:refs/heads/main']
+
                 push_result = subprocess.run(
-                    ['git', 'push', '-u', self.DEFAULT_REMOTE_NAME, 'HEAD'],
+                    push_cmd,
                     capture_output=True,
                     text=True,
                     cwd=cwd,


### PR DESCRIPTION
## Summary

Fixes Root Cause #28: When pushing to a newly added remote, `git push -u origin HEAD` fails with "The destination you provided is not a full refname" because git doesn't know what branch name to create on the remote.

**Solution:** Use explicit refspec `HEAD:refs/heads/<branch_name>` which tells git exactly what remote branch to create/update.

This issue was discovered after PR #3603 fixed the GITHUB_TOKEN authentication (Root Cause #27). The auth now works correctly, but the push command itself needed adjustment for newly-added remotes.

## Review & Testing Checklist for Human

- [ ] Verify the `branch` variable (from `git branch --show-current` on line 318-324) is always populated before the push code runs
- [ ] Consider if hardcoding `main` in the detached HEAD fallback case is acceptable for your workflow (line 438)
- [ ] **Test Plan:** Deploy to staging, trigger Probe 0 (#3528) CI failure, and verify in Render logs:
  - `[SimpleGitTool] GITHUB_TOKEN found` appears
  - `[SimpleGitTool] Pushed to branch` appears (no refname error)
  - AutoFixer successfully creates fix PR

### Notes

- The C901 complexity warning for `commit_and_push` is pre-existing and not caused by this change
- This is part of the EPIC D CI failure auto-fix investigation

**Link to Devin run:** https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
**Requested by:** Ryan Chen (@RC918)