### PR TITLE
fix(#3605): handle detached HEAD properly - don't push to protected main

### DIFF
--- a/agents/dev_agent/dev_agent_wrapper.py
+++ b/agents/dev_agent/dev_agent_wrapper.py
@@ -422,20 +422,46 @@ class SimpleGitTool:
                 # know what branch name to create on the remote.
                 # Solution: Use explicit refspec 'HEAD:refs/heads/<branch_name>'
                 # This tells git exactly what remote branch to create/update.
-                # Handle detached HEAD case: if branch is empty, we can't push with -u
-                if branch and branch != 'HEAD':
-                    # Normal case: on a named branch
-                    push_cmd = [
-                        'git', 'push', '-u', self.DEFAULT_REMOTE_NAME,
-                        f'HEAD:refs/heads/{branch}'
-                    ]
-                else:
-                    # Detached HEAD case: push without setting upstream
-                    # This is rare in AutoFixer workflow but handle it gracefully
-                    logger.warning(
-                        "[SimpleGitTool] Detached HEAD detected, pushing without upstream tracking"
-                    )
-                    push_cmd = ['git', 'push', self.DEFAULT_REMOTE_NAME, 'HEAD:refs/heads/main']
+                #
+                # Issue #3605: Root Cause #29 - Handle detached HEAD properly
+                # In detached HEAD state, we must NOT push to 'main' (it's protected).
+                # Instead, try to get the branch name from environment variables.
+                target_branch = branch
+                if not target_branch or target_branch == 'HEAD':
+                    # Detached HEAD case - try to get branch from environment
+                    # GITHUB_HEAD_REF is set by GitHub Actions for PR events
+                    target_branch = os.environ.get('GITHUB_HEAD_REF', '')
+                    if target_branch:
+                        logger.info(
+                            f"[SimpleGitTool] Detached HEAD detected, using GITHUB_HEAD_REF: "
+                            f"{target_branch}"
+                        )
+                    else:
+                        # No branch name available - fail gracefully
+                        # Do NOT push to 'main' as it's likely protected
+                        logger.error(
+                            "[SimpleGitTool] Detached HEAD detected and no GITHUB_HEAD_REF set. "
+                            "Cannot determine target branch for push."
+                        )
+                        return {
+                            'success': False,
+                            'error': (
+                                'git push failed: Detached HEAD state and no GITHUB_HEAD_REF '
+                                'environment variable set. Cannot determine target branch. '
+                                'Please checkout a named branch before committing.'
+                            ),
+                            'commit_sha': commit_sha,
+                            'branch': branch
+                        }
+
+                push_cmd = [
+                    'git', 'push', '-u', self.DEFAULT_REMOTE_NAME,
+                    f'HEAD:refs/heads/{target_branch}'
+                ]
+                logger.info(
+                    f"[SimpleGitTool] Pushing to branch '{target_branch}' "
+                    f"(detected from: {'git branch' if branch == target_branch else 'GITHUB_HEAD_REF'})"
+                )
 
                 push_result = subprocess.run(
                     push_cmd,


### PR DESCRIPTION
## Summary

Fixes Root Cause #29: In detached HEAD state, the previous fallback (from PR #3604) tried to push to `main`, which is protected by GitHub branch protection rules, causing `GH013: Repository rule violations found for refs/heads/main` errors.

**Solution:**
1. Try to get branch name from `GITHUB_HEAD_REF` environment variable (set by GitHub Actions for PR events)
2. If not available, fail gracefully with a clear error message
3. Never attempt to push to protected `main` branch in the fallback path

## Review & Testing Checklist for Human

- [ ] **Verify GITHUB_HEAD_REF availability**: Confirm that the staging worker environment has `GITHUB_HEAD_REF` set when processing PR events. If not, consider adding it to the Render environment variables.
- [ ] **Test Plan**: Deploy to staging, trigger Probe 0 (#3528) CI failure, and verify in Render logs:
  - No more `GH013: Repository rule violations found for refs/heads/main` errors
  - Either `[SimpleGitTool] Detached HEAD detected, using GITHUB_HEAD_REF: <branch>` appears (success path)
  - Or `[SimpleGitTool] Detached HEAD detected and no GITHUB_HEAD_REF set` appears (graceful failure)
- [ ] Consider if additional fallback env vars should be checked (e.g., `GITHUB_REF_NAME`, `CI_COMMIT_REF_NAME`)

### Notes

- The C901 complexity warning for `commit_and_push` is pre-existing (increased from 16 to 17)
- This is part of the EPIC D CI failure auto-fix investigation
- If `GITHUB_HEAD_REF` is not available in staging, we may need to pass the PR branch name through the AutoFixer context

**Link to Devin run:** https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
**Requested by:** Ryan Chen (@RC918)