### PR TITLE
fix: add security_validated to test state in test_cto_review_fixes.py

### DIFF
--- a/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_cto_review_fixes.py
+++ b/handoff/20250928/40_App/orchestrator/project_engineer/tests/test_cto_review_fixes.py
@@ -230,6 +230,7 @@ class TestPRCreationFailureHandling:
             "code_diff": "diff",
             "test_results": {"summary": "passed"},
             "error": None,
+            "security_validated": True,  # Required for create_pr to proceed
         }
 
         result_state = await workflow.create_pr(state)
@@ -263,6 +264,7 @@ class TestPRCreationFailureHandling:
             "code_diff": "diff",
             "test_results": {"summary": "passed"},
             "error": None,
+            "security_validated": True,  # Required for create_pr to proceed
         }
 
         result_state = await workflow.create_pr(state)


### PR DESCRIPTION
# fix: add security_validated to test state in test_cto_review_fixes.py

## Summary
Fixes pre-existing test failures in `TestPRCreationFailureHandling` by adding the required `security_validated: True` field to test state dictionaries.

The `create_pr()` method in `CodeGenerationWorkflow` checks for `security_validated` in state before proceeding. Without this field, tests were failing with "PR creation skipped: security validation not passed" instead of testing the actual PR creation logic.

This was a pre-existing issue on main branch - the tests were written before the security validation check was added to `create_pr()`.

## Review & Testing Checklist for Human
- [ ] Verify that `security_validated: True` is the correct setup for testing PR creation scenarios (the tests are meant to test PR creation success/failure, not security validation)

### Notes
- Verified tests pass locally after fix
- This unblocks PR #3606 which was failing CI due to these pre-existing test failures

Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
Requested by: Ryan Chen (@RC918)