### PR TITLE
fix(#3609): add fetch+rebase retry logic for git push non-fast-forward rejection

### DIFF
--- a/agents/dev_agent/dev_agent_wrapper.py
+++ b/agents/dev_agent/dev_agent_wrapper.py
@@ -539,7 +539,7 @@ class SimpleGitTool:
                             )
 
                             # Step 2: Rebase local commit(s) on top of remote
-                            # Use --onto to rebase even in detached HEAD state
+                            # This replays local commits on top of the fetched remote branch
                             rebase_cmd = [
                                 'git', 'rebase',
                                 f'{self.DEFAULT_REMOTE_NAME}/{push_target}'
@@ -559,16 +559,25 @@ class SimpleGitTool:
                                     f"{rebase_result.stderr}"
                                 )
                                 # Abort the rebase to restore clean state
-                                subprocess.run(
+                                # Per gemini-code-assist review: check abort result
+                                abort_result = subprocess.run(
                                     ['git', 'rebase', '--abort'],
                                     capture_output=True,
                                     text=True,
-                                    cwd=cwd
+                                    cwd=cwd,
+                                    env=push_env
                                 )
-                                logger.info(
-                                    "[SimpleGitTool] Rebase aborted, "
-                                    "returning original push error"
-                                )
+                                if abort_result.returncode == 0:
+                                    logger.info(
+                                        "[SimpleGitTool] Rebase aborted, "
+                                        "returning original push error"
+                                    )
+                                else:
+                                    # Note: "No rebase in progress" is not critical
+                                    logger.warning(
+                                        f"[SimpleGitTool] 'git rebase --abort' returned "
+                                        f"non-zero: {abort_result.stderr.strip()}"
+                                    )
                                 # Fall through to return the original push error
                             else:
                                 logger.info(


### PR DESCRIPTION
## Summary

Adds retry logic to `SimpleGitTool.commit_and_push()` to handle non-fast-forward push rejections. When AutoFixer's workspace is based on an older commit and the remote branch has newer commits, the initial push fails. This fix detects that specific error and attempts a fetch+rebase+retry sequence.

**Root Cause #31**: Discovered during Probe 0 testing when concurrent commits to the PR branch caused push failures.

**Retry sequence:**
1. Initial push attempt (fast path)
2. If rejected due to non-fast-forward, detect via stderr patterns
3. Fetch latest remote branch
4. Rebase local commit(s) on top of remote
5. Retry push (should now be fast-forward)
6. If rebase fails (conflicts), abort and return original error

**Safety considerations:**
- Does NOT use force push
- Aborts rebase on conflicts to restore clean state
- Checks `git rebase --abort` return code and logs warning if non-zero
- Structured logging for observability

Closes #3609

## Updates since last revision

Per gemini-code-assist review:
- Added check for `git rebase --abort` return code with appropriate logging
- Added `env=push_env` for consistency with other git commands
- Fixed misleading comment about `--onto` (not actually used in the command)

Follow-up issue created: #3611 (unit tests for retry logic)

## Review & Testing Checklist for Human

- [ ] **Verify error detection patterns** - Check that `'fetch first'`, `'non-fast-forward'`, and `'Updates were rejected'` cover all git non-fast-forward error messages
- [ ] **Rebase in detached HEAD** - Confirm rebase works correctly when AutoFixer is in detached HEAD state (common scenario)
- [ ] **Rebase abort safety** - Verify that `git rebase --abort` properly restores the repo to a clean state if conflicts occur
- [ ] **Test in staging** - Deploy and trigger Probe 0 with concurrent commits to verify the retry path works end-to-end

### Recommended Test Plan
1. Deploy to staging worker
2. Trigger Probe 0 CI failure
3. While AutoFixer is processing, push another commit to the PR branch
4. Verify staging logs show: `Push rejected (non-fast-forward), attempting fetch+rebase+retry`
5. Verify retry push succeeds and fix commit appears on PR

### Notes
- The `commit_and_push` method complexity (C901) warning is pre-existing (now 25, was 24)
- No unit tests added in this PR - follow-up issue #3611 created for unit tests
- Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
- Requested by: Ryan Chen (@RC918)