### PR TITLE
fix(#3612): use cherry-pick instead of rebase for git push retry

### DIFF
--- a/agents/dev_agent/dev_agent_wrapper.py
+++ b/agents/dev_agent/dev_agent_wrapper.py
@@ -620,8 +620,12 @@ class SimpleGitTool:
                                     # Per code review: support multiple commits using
                                     # base_sha..commit_sha range instead of single SHA
                                     # This handles cases where multiple commits were created
-                                    if base_sha:
+                                    if base_sha and base_sha != commit_sha:
                                         # Use range to get all commits created by this invocation
+                                        # Note: base_sha..commit_sha means "commits reachable from
+                                        # commit_sha but not from base_sha" - this is correct.
+                                        # Do NOT use base_sha^..commit_sha as that would include
+                                        # base_sha itself, which we don't want to transplant.
                                         cherry_pick_range = f'{base_sha}..{commit_sha}'
                                         logger.info(
                                             f"[SimpleGitTool] Cherry-picking commits "
@@ -632,9 +636,22 @@ class SimpleGitTool:
                                         ]
                                     else:
                                         # Fallback: single commit if base_sha not available
+                                        # or if base_sha == commit_sha (edge case)
+                                        if not base_sha:
+                                            logger.warning(
+                                                "[SimpleGitTool] base_sha not available, "
+                                                "multi-commit cherry-pick not supported. "
+                                                "Falling back to single commit."
+                                            )
+                                        elif base_sha == commit_sha:
+                                            logger.warning(
+                                                "[SimpleGitTool] base_sha == commit_sha, "
+                                                "range would be empty. "
+                                                "Falling back to single commit."
+                                            )
                                         logger.info(
                                             f"[SimpleGitTool] Cherry-picking single commit "
-                                            f"{commit_sha[:8]} (base_sha not available)"
+                                            f"{commit_sha[:8]}"
                                         )
                                         cherry_pick_cmd = [
                                             'git', 'cherry-pick', commit_sha


### PR DESCRIPTION
# fix(#3612): use cherry-pick instead of rebase for git push retry

## Summary

Fixes Root Cause #32: When AutoFixer's git push fails with non-fast-forward rejection, the previous rebase approach failed because it replayed ALL commits between the local base and HEAD, including commits already in the remote branch.

**Problem observed in staging logs:**
```
[SimpleGitTool] Push rejected (non-fast-forward), attempting fetch+rebase+retry
Rebasing (1/13)
error: could not apply 486cdb3c... fix(#3609): add fetch+rebase retry logic...
```

The rebase was trying to replay 13 commits, including one that was already in the remote branch, causing conflicts.

**New approach:** Replace rebase with cherry-pick:
1. Fetch the latest remote branch
2. Verify working directory is clean (safety check)
3. Checkout the remote branch tip (`git checkout -B <branch> origin/<branch>`)
4. Cherry-pick the commit(s) created by this invocation (`git cherry-pick base_sha..commit_sha`)
5. Push again

This only transplants the fix commit(s) we just created, avoiding conflicts from replaying unrelated commits.

## Updates since last revision

**Round 2 - Defensive guards for edge cases:**

1. **Guard for empty range** - Added check `base_sha != commit_sha` to prevent empty cherry-pick range (edge case where commit didn't create a new commit)
2. **Warning logs for fallback paths** - Added explicit warnings when falling back to single-commit cherry-pick due to missing `base_sha` or `base_sha == commit_sha`
3. **Code documentation** - Added comments explaining why NOT to use `base_sha^..commit_sha` (would incorrectly include base commit)

**Round 1 - Code review feedback:**

1. **Safety check for `-B` checkout** - Added working directory clean check before `git checkout -B` to prevent discarding uncommitted changes
2. **Multi-commit support** - Captures `base_sha` before commit and uses `base_sha..commit_sha` range for cherry-pick
3. **Accurate return values** - After successful cherry-pick, re-reads HEAD to return the actual pushed commit SHA

## Review & Testing Checklist for Human

- [ ] **Verify cherry-pick range logic** - `base_sha..commit_sha` excludes base_sha (correct), but verify this works when there's exactly 1 commit between them
- [ ] **Check edge case handling** - The `base_sha == commit_sha` fallback should never trigger in normal flow; if it does, something is wrong upstream
- [ ] **Deploy to staging and trigger Probe 0** - This fix is based on log analysis; needs end-to-end verification
- [ ] **Check staging logs for new log messages** - Should see "fetch+cherry-pick+retry", "Cherry-picking commits in range", and "Cherry-picked onto origin/{branch}"

**Recommended test plan:**
1. Merge and deploy to `morningai-backend-v2-stg-worker`
2. Trigger Probe 0 (#3528) CI re-run
3. Monitor staging logs for:
   - `Push rejected (non-fast-forward), attempting fetch+cherry-pick+retry`
   - `Cherry-picking commits in range {base_sha}..{commit_sha}`
   - `Cherry-picked onto origin/{branch}, new HEAD: {sha}`
   - `Retry push succeeded after fetch+cherry-pick`
4. Verify AutoFixer successfully creates a fix PR

### Notes

Closes #3612

- **Link to Devin run**: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
- **Requested by**: Ryan Chen (ryan2939z@gmail.com) / @RC918