### PR TITLE
fix(#3614): set git identity inline for cherry-pick retry

### DIFF
--- a/agents/dev_agent/dev_agent_wrapper.py
+++ b/agents/dev_agent/dev_agent_wrapper.py
@@ -625,8 +625,8 @@ class SimpleGitTool:
                                     # available in the new checkout context. Using -c options
                                     # ensures identity is always set regardless of git config.
                                     git_identity_args = [
-                                        '-c', f'user.email={self.DEFAULT_GIT_EMAIL}',
-                                        '-c', f'user.name={self.DEFAULT_GIT_NAME}',
+                                        '-c', f'user.email={self.DEFAULT_GIT_AUTHOR_EMAIL}',
+                                        '-c', f'user.name={self.DEFAULT_GIT_AUTHOR_NAME}',
                                     ]
 
                                     if base_sha and base_sha != commit_sha:


### PR DESCRIPTION
## Summary

Fixes "Committer identity unknown" error during cherry-pick retry in the git push non-fast-forward handling path.

After `git checkout -B <branch> origin/<branch>`, the git committer identity may not be available in the new checkout context. This change uses inline `-c` options to set the identity directly in the cherry-pick command, which is more robust than relying on git config persistence.

**Root Cause #34**: The initial commit succeeded, but when the retry logic attempted to cherry-pick after fetching the remote branch, git couldn't find the committer identity.

## Updates since last revision

- Fixed incorrect constant names per gemini-code-assist review: using `DEFAULT_GIT_AUTHOR_EMAIL` and `DEFAULT_GIT_AUTHOR_NAME` (the actual constants defined in SimpleGitTool class)

## Review & Testing Checklist for Human

- [ ] Verify `self.DEFAULT_GIT_AUTHOR_EMAIL` and `self.DEFAULT_GIT_AUTHOR_NAME` constants exist in `SimpleGitTool` class (lines 49-50)
- [ ] Verify git command syntax: `-c` options must come before the `cherry-pick` subcommand (they do in this diff)
- [ ] **Test plan**: Deploy to staging, trigger Probe 0 CI failure, and verify the cherry-pick retry succeeds (look for `[SimpleGitTool] Retry push succeeded after fetch+cherry-pick` in logs)

### Notes

Closes #3614

**Link to Devin run**: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
**Requested by**: Ryan Chen (@RC918)