### PR TITLE
fix(epic-d): fix get_repo() signature and synthesize review_outcome for CI failure path

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -4956,21 +4956,55 @@ def _ensure_comment_body_for_ci_failure(state: dict, trace_id: str) -> None:
     # Issue #3618: Synthesize review_outcome for CI failure path
     # CI failure fast path bypasses reviewer_node which normally populates review_outcome.
     # Without review_outcome, is_autofix_allowed() gate always fails.
-    # Synthesize minimal review_outcome for low-risk CI failures (lint, docstring, etc.)
+    #
+    # These are the MINIMAL fields required by is_autofix_allowed() in coder/autofix_gate.py:
+    # - schema_validated: Must be True for autofix to proceed
+    # - severity: Must be "low" for SimpleCoder (higher severity blocks autofix)
+    # - diff_truncated: Must be False for autofix to proceed
+    #
+    # We use setdefault() to only fill missing keys, preserving any values set by upstream.
+    # This avoids brittleness if reviewer_node adds more fields in the future.
     existing_review_outcome = state.get("review_outcome")
-    if not existing_review_outcome:
+    if existing_review_outcome is None:
+        # No review_outcome at all - create minimal dict for autofix gate
+        ci_context = state.get("ci_failure_context", {})
+        failed_check_name = (ci_context.get("failed_check_name") or "").lower()
+
+        # Infer severity from CI failure type to prevent unsafe auto-fixes
+        # Security/vulnerability scans and build failures should NOT be auto-fixed
+        severity = "low"
+        if any(k in failed_check_name for k in ["security", "scan", "vulnerability"]):
+            severity = "critical"
+        elif any(k in failed_check_name for k in ["build", "compile"]):
+            severity = "high"
+
         state["review_outcome"] = {
             "schema_validated": True,
-            "severity": "low",
+            "severity": severity,
             "diff_truncated": False,
         }
         logger.info(
             f"[Fixer] Synthesized review_outcome for CI failure path. "
-            f"trace_id={trace_id}",
+            f"failed_check={failed_check_name}, severity={severity}, trace_id={trace_id}",
             extra={
                 "operation": "fixer_synthesize_review_outcome",
                 "trace_id": trace_id,
-                "review_outcome": state["review_outcome"],
+                "failed_check_name": failed_check_name,
+                "severity": severity,
+            }
+        )
+    elif isinstance(existing_review_outcome, dict):
+        # review_outcome exists but may be missing required keys - fill only missing ones
+        # This preserves any upstream-set values (e.g., severity from reviewer_node)
+        existing_review_outcome.setdefault("schema_validated", True)
+        existing_review_outcome.setdefault("severity", "low")
+        existing_review_outcome.setdefault("diff_truncated", False)
+        logger.debug(
+            f"[Fixer] Filled missing review_outcome keys for CI failure path. "
+            f"trace_id={trace_id}",
+            extra={
+                "operation": "fixer_fill_review_outcome",
+                "trace_id": trace_id,
             }
         )
 


### PR DESCRIPTION
## Summary

This PR fixes two critical blockers preventing EPIC D Probe 0-3 tests from progressing:

**Phase 1: Fix `get_repo()` signature mismatch (Hard Bug)**
- `get_repo()` was being called with `repo_name` parameter in `_attempt_general_coder_fix` and `_attempt_simple_coder_fix`
- However, `get_repo()` is defined with no parameters - it reads `GITHUB_REPO` from environment internally
- This caused a silent TypeError, preventing SimpleCoder and GeneralCoder from fetching file content

**Phase 2: Synthesize `review_outcome` for CI failure path**
- CI failure fast path (via `ci_monitor` entry point) bypasses `reviewer_node` which normally populates `review_outcome`
- Without `review_outcome`, `is_autofix_allowed()` gate always fails with missing `schema_validated`
- Added synthesis of minimal `review_outcome` in `_ensure_comment_body_for_ci_failure` for CI failure scenarios
- Uses `setdefault()` pattern to fill only missing keys, preserving any upstream-set values
- Dynamically infers severity from `failed_check_name` to prevent unsafe auto-fixes

## Updates since last revision

Addressed code review comments:

1. **Falsy check fix**: Changed `if not existing_review_outcome:` to `if existing_review_outcome is None:` to avoid incorrectly overwriting empty dicts

2. **Brittle schema fix**: Added `elif isinstance(existing_review_outcome, dict):` branch using `setdefault()` to fill only missing keys, preserving any values set by upstream (e.g., reviewer_node)

3. **Dynamic severity inference**: Now infers severity from `ci_failure_context.failed_check_name`:
   - Security/vulnerability scans → `"critical"` (blocks autofix)
   - Build/compile failures → `"high"` (blocks autofix)
   - Lint/docstring failures → `"low"` (allows autofix)

## Review & Testing Checklist for Human

- [ ] **Verify `get_repo()` signature**: Confirm that `tools/github_api.py:get_repo()` indeed takes no parameters (line ~221)
- [ ] **Review severity keyword lists**: The severity inference uses hardcoded keywords (`["security", "scan", "vulnerability"]` for critical, `["build", "compile"]` for high). Verify these cover your CI check names or suggest additions.
- [ ] **Test end-to-end**: Trigger a CI failure (e.g., flake8 docstring error) on a test PR in staging and verify:
  - Log shows `[Fixer] Synthesized review_outcome for CI failure path`
  - Log shows `[SIMPLE_CODER_ATTEMPT]` instead of `[SIMPLE_CODER_GATE_FAIL]`
  - SimpleCoder successfully commits a fix

### Notes

Blueprint Alignment:
- Three Don'ts Principle: Dynamically blocks high-severity CI failures (security, build) from auto-fix
- Fail-safe by Design: Uses `setdefault()` to preserve upstream values, only fills missing keys

Requested by: @RC918
Link to Devin run: https://app.devin.ai/sessions/d04d9b4e738d4e2988620b759ac84c97