### PR TITLE
fix: align supabase version to 2.27.0 to resolve Render build conflict

### DIFF
--- a/handoff/20250928/40_App/api-backend/requirements.txt
+++ b/handoff/20250928/40_App/api-backend/requirements.txt
@@ -23,7 +23,8 @@ redis>=5.2.0,<7.0.0
 upstash-redis>=1.1.0,<2.0.0
 rq
 sentry-sdk==2.48.0
-supabase==2.11.0
+# Must match orchestrator/requirements.txt version (both installed in morningai-backend-v2)
+supabase==2.27.0
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
 pandas


### PR DESCRIPTION
## Summary

Fixes Render deployment failure caused by conflicting supabase versions. The `morningai-backend-v2` service's buildCommand (render.yaml lines 34-35) installs both api-backend and orchestrator requirements in the same environment:

```yaml
pip install -r handoff/20250928/40_App/api-backend/requirements.txt \
            -r handoff/20250928/40_App/orchestrator/requirements.txt
```

This caused pip resolution to fail because:
- `api-backend/requirements.txt` had `supabase==2.11.0`
- `orchestrator/requirements.txt` has `supabase==2.27.0`

Upgraded api-backend to 2.27.0 to match orchestrator, which requires the newer version for google-genai httpx compatibility.

## Review & Testing Checklist for Human

- [ ] **Verify supabase API compatibility**: Check that api-backend's supabase usage (auth, table CRUD, etc.) is compatible with 2.27.0 - this is a 16 minor version jump
- [ ] **Test Render deployment**: Confirm the build succeeds after merging
- [ ] **Smoke test api-backend**: Verify any supabase-dependent functionality still works (user auth, data queries)

### Notes

- Link to Devin run: https://app.devin.ai/sessions/570bbc753ba34610b6333a610727b001
- Requested by: Ryan Chen (@RC918)