### PR TITLE
fix(epic-d): P3-P4 fixes for CI failure pipeline

### DIFF
--- a/agents/dev_agent/workflows/code_generation_workflow.py
+++ b/agents/dev_agent/workflows/code_generation_workflow.py
@@ -10,6 +10,7 @@ Supports 5 task types:
 4. Test Generation
 5. Documentation Update
 """
+import ast
 import logging
 import re
 import time
@@ -530,8 +531,48 @@ class CodeGenerationWorkflow:
 
         return state
 
+    def _validate_python_syntax(self, code: str, file_path: str) -> tuple:
+        """
+        Validate Python code syntax using ast.parse.
+
+        Issue #3629: P4 fail-closed validation to prevent writing invalid code.
+        When the LLM generates conversational text instead of code (e.g.,
+        "As an AI model, I need to see..."), this validation catches it before
+        the invalid content is written to disk.
+
+        Args:
+            code: The generated code to validate
+            file_path: The target file path (for error messages)
+
+        Returns:
+            Tuple of (is_valid: bool, error_message: str or None)
+        """
+        try:
+            ast.parse(code)
+            return (True, None)
+        except SyntaxError as e:
+            error_msg = (
+                f"Generated code has invalid Python syntax: "
+                f"{e.msg} at line {e.lineno}, column {e.offset}"
+            )
+            logger.error(
+                f"[Stage 5] {error_msg}",
+                extra={
+                    "operation": "apply_code_syntax_validation",
+                    "file_path": file_path,
+                    "syntax_error_line": e.lineno,
+                    "syntax_error_msg": e.msg,
+                    "code_preview": code[:200] if code else "",
+                }
+            )
+            return (False, error_msg)
+
     async def apply_code(self, state: CodeGenState) -> CodeGenState:
-        """Stage 5: Apply generated code to files with atomic writes"""
+        """Stage 5: Apply generated code to files with atomic writes
+
+        Issue #3629: Added fail-closed validation for Python files using ast.parse.
+        This prevents writing invalid code (e.g., LLM conversational text) to disk.
+        """
         logger.info(f"[Stage 5] Applying code for task #{state['task_id']}")
 
         try:
@@ -553,6 +594,25 @@ class CodeGenerationWorkflow:
                 state["error"] = f"Unsafe file path in apply_code: {target_file}"
                 logger.error(state["error"])
                 return state
+
+            # Issue #3629: P4 fail-closed validation for Python files
+            # Validate syntax BEFORE writing to prevent corrupting files with
+            # invalid LLM output (e.g., conversational text instead of code)
+            if target_file.endswith(".py"):
+                is_valid, syntax_error = self._validate_python_syntax(
+                    generated_code, target_file
+                )
+                if not is_valid:
+                    state["error"] = syntax_error
+                    logger.error(
+                        f"[Stage 5] Refusing to write invalid Python code to {target_file}",
+                        extra={
+                            "operation": "apply_code_fail_closed",
+                            "file_path": target_file,
+                            "task_id": state["task_id"],
+                        }
+                    )
+                    return state
 
             # Issue #3616: Use helper for path conversion with sandbox validation
             abs_target_file = self._to_abs_repo_path(target_file)

--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -1783,6 +1783,106 @@ class EventNormalizer:
     _ci_failure_dedup_fallback: Dict[str, float] = {}
     _CI_FAILURE_DEDUP_FALLBACK_MAX_SIZE = 1000  # Max entries for fallback
 
+    def _fetch_failed_check_runs(
+        self,
+        repo: str,
+        check_suite_id: int,
+        event_id: str
+    ) -> tuple:
+        """
+        Fetch failed check_runs from GitHub API for a check_suite.
+
+        Issue #3629: P3 fix - Extract specific failed check names instead of
+        generic "GitHub Actions". This enables the LLM to receive actual error
+        context (e.g., "lint" check failed with F821 error).
+
+        Args:
+            repo: Repository in owner/repo format
+            check_suite_id: GitHub check_suite ID
+            event_id: Event ID for logging
+
+        Returns:
+            Tuple of (failed_check_names: List[str], error_summary: str or None)
+            - failed_check_names: List of specific check names that failed
+            - error_summary: Truncated error output from failed checks (max 500 chars)
+        """
+        failed_check_names = []
+        error_summary_parts = []
+
+        try:
+            import os
+            from github import Github
+
+            # Use GITHUB_TOKEN from environment (same as tools.github_api)
+            github_token = os.environ.get("GITHUB_TOKEN")
+            if not github_token:
+                logger.warning(
+                    "[EventNormalizer] Cannot fetch check_runs - GITHUB_TOKEN not set",
+                    extra={
+                        "operation": "fetch_failed_check_runs_skip",
+                        "event_id": event_id,
+                        "repo": repo,
+                    }
+                )
+                return ([], None)
+
+            gh = Github(github_token)
+            github_repo = gh.get_repo(repo)
+
+            # Fetch check_runs for this check_suite
+            # GitHub API: GET /repos/{owner}/{repo}/check-suites/{check_suite_id}/check-runs
+            check_suite = github_repo.get_check_suite(check_suite_id)
+            check_runs = check_suite.get_check_runs()
+
+            for check_run in check_runs:
+                if check_run.conclusion == "failure":
+                    failed_check_names.append(check_run.name)
+                    # Extract error summary from check_run output
+                    # PyGithub returns output as a dict-like object
+                    output = check_run.output
+                    if output:
+                        summary = output.get("summary") if isinstance(output, dict) else getattr(output, "summary", None)
+                        if summary:
+                            # Truncate to avoid huge payloads
+                            summary_text = str(summary)[:200]
+                            error_summary_parts.append(f"{check_run.name}: {summary_text}")
+
+            # Combine error summaries (max 500 chars total)
+            error_summary = None
+            if error_summary_parts:
+                combined = "; ".join(error_summary_parts)
+                error_summary = combined[:500] if len(combined) > 500 else combined
+
+            logger.info(
+                "[EventNormalizer] Fetched failed check_runs from GitHub API",
+                extra={
+                    "operation": "fetch_failed_check_runs_success",
+                    "event_id": event_id,
+                    "repo": repo,
+                    "check_suite_id": check_suite_id,
+                    "failed_check_count": len(failed_check_names),
+                    "failed_check_names": failed_check_names[:5],  # Log first 5
+                }
+            )
+
+            return (failed_check_names, error_summary)
+
+        except Exception as e:
+            # Fail-open: if API call fails, return empty results
+            # The downstream code will fall back to generic "GitHub Actions"
+            logger.warning(
+                "[EventNormalizer] Failed to fetch check_runs from GitHub API",
+                extra={
+                    "operation": "fetch_failed_check_runs_error",
+                    "event_id": event_id,
+                    "repo": repo,
+                    "check_suite_id": check_suite_id,
+                    "error": str(e)[:200],
+                    "error_type": type(e).__name__,
+                }
+            )
+            return ([], None)
+
     def _handle_ci_check_completed(self, event: WebhookEvent) -> bool:
         """
         Handle CI_CHECK_COMPLETED events for CI failure reflex.
@@ -1914,26 +2014,57 @@ class EventNormalizer:
         # Only build context if required fields are present to avoid brittle behavior
         # Use explicit is not None for pr_number (int) to align with dataclass requirements
         if pr_number is not None and head_sha and head_branch and conclusion:
-            ci_app_name = metadata.get("ci_app_name") or ""
-            if not ci_app_name:
-                ci_app_name = "unknown"
-                logger.warning(
-                    "[EventNormalizer] CiFailureContext using 'unknown' for failed_check_name",
-                    extra={
-                        "operation": "ci_failure_context_unknown_check",
-                        "event_id": event.event_id,
-                        "pr_number": pr_number,
-                        "head_sha": head_sha[:8] if head_sha else "unknown",
-                    }
+            # Issue #3629: P3 fix - Fetch specific failed check names from GitHub API
+            # Instead of using generic ci_app_name (e.g., "GitHub Actions"), we now
+            # query the check_runs API to get specific check names (e.g., "lint")
+            failed_check_name = "unknown"
+            ci_error_summary = metadata.get("ci_error_summary")
+
+            if check_suite_id:
+                failed_check_names, api_error_summary = self._fetch_failed_check_runs(
+                    repo, check_suite_id, event.event_id
                 )
+                if failed_check_names:
+                    # Use first failed check name (most specific)
+                    # For multiple failures, join them with comma
+                    failed_check_name = ", ".join(failed_check_names[:3])
+                    logger.info(
+                        "[EventNormalizer] Using specific failed check names from API",
+                        extra={
+                            "operation": "ci_failure_specific_check_names",
+                            "event_id": event.event_id,
+                            "failed_check_name": failed_check_name,
+                            "total_failed": len(failed_check_names),
+                        }
+                    )
+                if api_error_summary:
+                    # Prefer API error summary over metadata (more specific)
+                    ci_error_summary = api_error_summary
+
+            # Fallback to ci_app_name if API call didn't return specific names
+            if failed_check_name == "unknown":
+                ci_app_name = metadata.get("ci_app_name") or ""
+                if ci_app_name:
+                    failed_check_name = ci_app_name
+                else:
+                    logger.warning(
+                        "[EventNormalizer] CiFailureContext using 'unknown' for failed_check_name",
+                        extra={
+                            "operation": "ci_failure_context_unknown_check",
+                            "event_id": event.event_id,
+                            "pr_number": pr_number,
+                            "head_sha": head_sha[:8] if head_sha else "unknown",
+                        }
+                    )
+
             ci_failure_context = CiFailureContext(
-                failed_check_name=ci_app_name,
+                failed_check_name=failed_check_name,
                 conclusion=conclusion,
                 pr_number=pr_number,
                 head_sha=head_sha,
                 head_branch=head_branch,
                 logs_url=metadata.get("ci_logs_url"),
-                error_summary=metadata.get("ci_error_summary"),
+                error_summary=ci_error_summary,
                 check_run_id=metadata.get("ci_check_run_id"),
             )
             # Use to_dict() for JSON serialization compatibility with RQ queue
@@ -1952,6 +2083,16 @@ class EventNormalizer:
                 }
             )
 
+        # Issue #3629: P3 fix - Log the specific failed check name (not generic ci_app_name)
+        # The failed_check_name variable is set above from API call or fallback
+        log_failed_check_name = "unknown"
+        if pr_number is not None and head_sha and head_branch and conclusion:
+            # Use the failed_check_name from CiFailureContext building above
+            log_failed_check_name = failed_check_name
+        else:
+            # Fallback to ci_app_name if CiFailureContext wasn't built
+            log_failed_check_name = metadata.get("ci_app_name") or "unknown"
+
         logger.info(
             "[EventNormalizer] CI failure is actionable - triggering auto-fix",
             extra={
@@ -1963,7 +2104,7 @@ class EventNormalizer:
                 "head_sha": head_sha[:8] if head_sha else "unknown",
                 "check_suite_id": check_suite_id,  # Issue #3513
                 "conclusion": conclusion,
-                "failed_check_name": ci_app_name,
+                "failed_check_name": log_failed_check_name,
                 # Note: dedup_key not logged to avoid exposing internal key format
                 # All constituent fields (repo, pr, sha, check_suite_id) are logged above
             }


### PR DESCRIPTION
## Summary

This PR addresses two critical issues in the CI failure → AutoFixer → SimpleCoder pipeline that were causing Probe 0 validation failures:

**P3: Extract specific failed check names from GitHub API**
- Added `_fetch_failed_check_runs()` method to query check_runs API for specific check names (e.g., "lint") instead of generic "GitHub Actions"
- Extracts error summaries from check_run output to provide LLM with actual error context
- Fail-open design: falls back to generic name if API call fails

**P4: Add fail-closed syntax validation before writing files**
- Added `_validate_python_syntax()` using `ast.parse()` to validate Python code before writing
- Prevents writing invalid LLM output (e.g., conversational text like "As an AI model, I need to see...") to disk
- Only validates `.py` files; other file types pass through

## Review & Testing Checklist for Human

- [ ] **Verify PyGithub API compatibility**: The `check_run.output` access pattern (line 1842-1844 in normalizer.py) assumes it can be accessed as dict or object. Confirm this matches PyGithub's actual return type.
- [ ] **Test P3 in staging**: Trigger CI failure on PR #3627 and check logs for `fetch_failed_check_runs_success` with specific check names (should show "lint" not "GitHub Actions")
- [ ] **Test P4 with invalid code**: Manually test that `_validate_python_syntax()` correctly rejects conversational text and allows valid Python
- [ ] **Check GitHub API rate limits**: The new API call in `_fetch_failed_check_runs()` adds one request per CI failure event

**Recommended test plan:**
1. Deploy to staging
2. Push empty commit to PR #3627 to trigger CI failure
3. Search staging logs for `ci_failure_specific_check_names` - should show "lint" as failed_check_name
4. Verify SimpleCoder receives actual error context and generates correct fix

### Notes

Phase 4 (review_files for multi-file) and P5 (planner dedup/termination) were deferred as they don't block Probe 0 validation (SimpleCoder is single-file and CI-failure fast path bypasses planner).

**Devin run:** https://app.devin.ai/sessions/d04d9b4e738d4e2988620b759ac84c97
**Requested by:** @RC918