### PR TITLE
fix(epic-d): P3 enhancement - expand check_run conclusion detection

### DIFF
--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -1838,7 +1838,7 @@ class EventNormalizer:
             # GitHub check_run conclusions: success, failure, neutral, cancelled,
             # skipped, timed_out, action_required, stale, startup_failure
             all_check_runs_info = []
-            failure_conclusions = {"failure", "cancelled", "timed_out", "startup_failure"}
+            failure_conclusions = {"failure", "cancelled", "timed_out", "startup_failure", "action_required"}
 
             for check_run in check_runs:
                 # Log all check_runs for debugging P3 issues


### PR DESCRIPTION
## Summary

Fixes P3 check name extraction issue where the system was falling back to generic "GitHub Actions" instead of extracting specific check names like "lint".

**Root cause hypothesis:** The original code only checked for `conclusion == "failure"`, but GitHub Actions can report other failure-like conclusions when jobs fail:
- `failure` - explicit failure
- `cancelled` - job cancelled (e.g., due to another job failing first)
- `timed_out` - job exceeded time limit
- `startup_failure` - job failed to start
- `action_required` - check paused pending manual intervention (stalled workflow)

**Changes:**
- Expand conclusion check to include all five failure-like conclusions above
- Add debug logging to track all check_runs in a check_suite (helps diagnose if this fix doesn't resolve the issue)

## Updates since last revision

- Added `action_required` to `failure_conclusions` per gemini-code-assist review feedback

## Review & Testing Checklist for Human

- [ ] **Verify root cause assumption**: Check GitHub webhook logs to confirm that check_runs are returning non-"failure" conclusions (e.g., "cancelled"). If the actual issue is different (API errors, wrong check_suite_id, timing), this fix won't help.
- [ ] **Test with Probe 0**: Trigger a CI failure on PR #3627 and verify that specific check names (e.g., "lint") are now extracted instead of "GitHub Actions"
- [ ] **Evaluate debug logging**: The new `logger.info` will run in production - verify this is acceptable for ongoing P3 diagnosis
- [ ] **Review `action_required` inclusion**: This conclusion indicates a check is paused pending manual intervention. Verify this is the desired behavior (treating stalled workflows as failures).

### Notes

This is a hypothesis-based fix. If the issue persists after merging, the debug logging will help identify the actual root cause by showing what check_runs and conclusions are being returned by the GitHub API.

**Follow-up consideration**: gemini-code-assist suggested moving `failure_conclusions` to a module-level constant for better performance. This is a low-priority refactoring task.

Refs: #3629

---
**Requested by:** @RC918
**Link to Devin run:** https://app.devin.ai/sessions/e77f2bd7d00d4fe6b1c47a63f2e812d2