### PR TITLE
fix(test): Add AutoFixLoopProtection mock to TestFixerNodeIntegration tests

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_simple_coder_wiring.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_simple_coder_wiring.py
@@ -439,7 +439,7 @@ def create_mock_loop_protection():
 class TestFixerNodeIntegration:
     """Tests for fixer_node integration with SimpleCoder"""
 
-    @patch("langgraph_orchestrator.AutoFixLoopProtection")
+    @patch("utils.auto_fix_policy.AutoFixLoopProtection")
     @patch("langgraph_orchestrator._attempt_simple_coder_fix")
     @patch("langgraph_orchestrator._get_metrics")
     @patch("langgraph_orchestrator._get_agent_eval")
@@ -461,7 +461,7 @@ class TestFixerNodeIntegration:
         mock_attempt.assert_called_once()
         assert result["retry_count"] == 1
 
-    @patch("langgraph_orchestrator.AutoFixLoopProtection")
+    @patch("utils.auto_fix_policy.AutoFixLoopProtection")
     @patch("langgraph_orchestrator._attempt_simple_coder_fix")
     @patch("langgraph_orchestrator._get_metrics")
     @patch("langgraph_orchestrator._get_agent_eval")
@@ -486,7 +486,7 @@ class TestFixerNodeIntegration:
             if hasattr(msg, "content")
         )
 
-    @patch("langgraph_orchestrator.AutoFixLoopProtection")
+    @patch("utils.auto_fix_policy.AutoFixLoopProtection")
     @patch("langgraph_orchestrator._attempt_simple_coder_fix")
     @patch("langgraph_orchestrator._get_metrics")
     @patch("langgraph_orchestrator._get_agent_eval")


### PR DESCRIPTION
## Summary

Fixes CI test failures in PR #3636 by adding proper mocking for `AutoFixLoopProtection` in the `TestFixerNodeIntegration` test class.

PR #3636 added loop protection to `fixer_node` that checks `AutoFixLoopProtection.check_and_increment()` BEFORE calling `_attempt_simple_coder_fix`. Without mocking this, the loop protection check returns early and `_attempt_simple_coder_fix` is never called, causing the 3 tests to fail with:
```
AssertionError: Expected '_attempt_simple_coder_fix' to have been called once. Called 0 times.
```

**Changes:**
- Added `create_mock_loop_protection()` helper function that returns a mock allowing execution
- Added `@patch("utils.auto_fix_policy.AutoFixLoopProtection")` decorator to all 3 tests in `TestFixerNodeIntegration`

## Updates since last revision

- **Fixed mock path**: Changed from `langgraph_orchestrator.AutoFixLoopProtection` to `utils.auto_fix_policy.AutoFixLoopProtection` to match where the class is actually imported inside `fixer_node`

## Review & Testing Checklist for Human

- [ ] Verify the mock patch path `"utils.auto_fix_policy.AutoFixLoopProtection"` matches how the class is imported in `fixer_node` (it's imported from `utils.auto_fix_policy` inside the function)
- [ ] Confirm CI Orchestrator Tests pass with this fix
- [ ] Verify the hardcoded return value `(True, 1)` matches the expected signature of `check_and_increment()` method

**Merge order:**
1. Merge this PR first
2. Then merge PR #3636 (AutoFixer loop protection)

### Notes

This is a prerequisite fix for PR #3636 to pass CI.

Link to Devin run: https://app.devin.ai/sessions/32556f9957a64d1aa6f326e1b9abc339
Requested by: @RC918