### PR TITLE
test(epic-d): update knowledge_graph_e2e tests for EmbeddingClient migration

### DIFF
--- a/agents/dev_agent/tests/test_knowledge_graph_e2e.py
+++ b/agents/dev_agent/tests/test_knowledge_graph_e2e.py
@@ -15,6 +15,30 @@ from knowledge_graph import (
 )
 
 
+def is_embedding_available(kg_manager) -> bool:
+    """
+    Check if embedding functionality is available on the KnowledgeGraphManager.
+
+    Supports both legacy (openai_api_key) and new (_embedding_client) APIs
+    for backward compatibility during the EmbeddingClient migration (PR #3652).
+
+    Args:
+        kg_manager: KnowledgeGraphManager instance
+
+    Returns:
+        bool: True if embedding is configured and available
+    """
+    if hasattr(kg_manager, '_embedding_client'):
+        # New EmbeddingClient abstraction (PR #3652+)
+        return (
+            kg_manager._embedding_client is not None and
+            kg_manager._embedding_client.is_available()
+        )
+    else:
+        # Legacy OpenAI-only implementation
+        return kg_manager.openai_api_key is not None
+
+
 class TestEmbeddingsCache:
     """Test embeddings cache functionality"""
 
@@ -83,16 +107,7 @@ class TestKnowledgeGraphManager:
 
         result = kg_manager.generate_embedding(test_code)
 
-        # Check if embedding is available - supports both old (openai_api_key) and new (_embedding_client) APIs
-        if hasattr(kg_manager, '_embedding_client'):
-            # New EmbeddingClient abstraction (PR #3652+)
-            embedding_available = (
-                kg_manager._embedding_client is not None and
-                kg_manager._embedding_client.is_available()
-            )
-        else:
-            # Legacy OpenAI-only implementation
-            embedding_available = kg_manager.openai_api_key is not None
+        embedding_available = is_embedding_available(kg_manager)
 
         if not embedding_available:
             assert not result.get('success')
@@ -204,16 +219,7 @@ def function():
         """Test indexing behavior without API credentials"""
         result = indexer.index_directory(temp_code_dir)
 
-        # Check if embedding is available - supports both old (openai_api_key) and new (_embedding_client) APIs
-        if hasattr(indexer.kg_manager, '_embedding_client'):
-            # New EmbeddingClient abstraction (PR #3652+)
-            embedding_available = (
-                indexer.kg_manager._embedding_client is not None and
-                indexer.kg_manager._embedding_client.is_available()
-            )
-        else:
-            # Legacy OpenAI-only implementation
-            embedding_available = indexer.kg_manager.openai_api_key is not None
+        embedding_available = is_embedding_available(indexer.kg_manager)
 
         if not embedding_available:
             if 'data' in result:
@@ -341,16 +347,7 @@ class TestKnowledgeGraphIntegration:
         assert 'success' in health or 'error' in health
 
         print("✓ Knowledge Graph system components initialized")
-        # Support both old (openai_api_key) and new (_embedding_client) APIs
-        if hasattr(kg_manager, '_embedding_client'):
-            # New EmbeddingClient abstraction (PR #3652+)
-            embedding_available = (
-                kg_manager._embedding_client is not None and
-                kg_manager._embedding_client.is_available()
-            )
-        else:
-            # Legacy OpenAI-only implementation
-            embedding_available = kg_manager.openai_api_key is not None
+        embedding_available = is_embedding_available(kg_manager)
         print(f"  - Embedding configured: {embedding_available}")
         print(f"  - Database configured: {kg_manager.db_pool is not None}")
         print(f"  - Cache enabled: {cache.enabled if cache else False}")


### PR DESCRIPTION
## Summary

Updates test assertions in `test_knowledge_graph_e2e.py` to support the EmbeddingClient abstraction introduced in PR #3652. The tests are now **backward compatible**, meaning they work both with the current main branch (legacy OpenAI-only implementation) and after the EmbeddingClient migration.

**Changes:**
- Extract `is_embedding_available()` helper function to reduce code duplication
- Use `hasattr()` to check for `_embedding_client` before accessing it
- Support both old (`openai_api_key`) and new (`_embedding_client`) APIs
- Support both old (`openai_configured`) and new (`embedding_configured`) health check keys
- Handle both old (`result['embedding']`) and new (`result['data']['embedding']`) response formats

## Updates since last revision

Addressed MorningAI Reviewer feedback (Comment #2669371917):
- Extracted duplicated embedding availability check logic into a module-level helper function `is_embedding_available()`
- Replaced 3 instances of duplicated code with calls to the helper function
- Improves maintainability and reduces risk of inconsistency when the logic evolves

## Review & Testing Checklist for Human

- [ ] Verify `is_embedding_available()` helper function correctly handles both old and new APIs
- [ ] Confirm tests pass on current main branch (before PR #3652 is merged)
- [ ] After merging PR #3652, confirm tests still pass with the new EmbeddingClient implementation

**Recommended test plan:** 
1. Merge this PR first
2. Verify Dev Agent Tests pass in CI
3. Then merge PR #3651 and PR #3652
4. Verify Dev Agent Tests still pass after those merges

### Notes

This PR enables a flexible merge order - it can be merged before or after PR #3651 and PR #3652, which migrate SimpleLLM and dev_agent_v2/knowledge_graph_manager from hardcoded OpenAI to the LLMClient/EmbeddingClient abstraction layer.

Requested by: @RC918
Link to Devin run: https://app.devin.ai/sessions/e77f2bd7d00d4fe6b1c47a63f2e812d2