### PR TITLE
fix(agent-eval): add edge-trigger and cooldown to prevent sticky regression warnings

### DIFF
--- a/handoff/20250928/40_App/orchestrator/agent_eval_integration.py
+++ b/handoff/20250928/40_App/orchestrator/agent_eval_integration.py
@@ -732,6 +732,10 @@ class AgentEvalIntegration:
         """
         Check if we're within the alert cooldown period.
 
+        Uses timestamp-based validation instead of relying solely on Redis TTL
+        to prevent silent suppression if TTL is lost (e.g., Redis restart).
+        Fail-open: if parsing fails, allow the alert (return False).
+
         Returns:
             True if within cooldown (should suppress alert), False otherwise
         """
@@ -739,8 +743,24 @@ class AgentEvalIntegration:
             return False
 
         try:
-            last_alert = self.redis.get(self.regression_alert_key)
-            return last_alert is not None
+            last_alert_data = self.redis.get(self.regression_alert_key)
+            if last_alert_data is None:
+                return False
+
+            if isinstance(last_alert_data, bytes):
+                last_alert_data = last_alert_data.decode("utf-8")
+
+            alert_info = json.loads(last_alert_data)
+            timestamp_str = alert_info.get("timestamp")
+            if not timestamp_str:
+                return False
+
+            last_alert_time = datetime.fromisoformat(timestamp_str)
+            elapsed_seconds = (datetime.utcnow() - last_alert_time).total_seconds()
+            return elapsed_seconds < self.regression_alert_cooldown_seconds
+        except (json.JSONDecodeError, ValueError, KeyError, TypeError) as e:
+            logger.debug(f"[AgentEval] Failed to parse alert cooldown data, allowing alert: {e}")
+            return False
         except Exception as e:
             logger.debug(f"[AgentEval] Failed to check alert cooldown: {e}")
             return False
@@ -984,8 +1004,7 @@ class AgentEvalIntegration:
                         }
                     )
             else:
-                if current_health_status == "healthy":
-                    self._update_health_status_if_changed(current_health_status)
+                self._update_health_status_if_changed(current_health_status)
                 logger.info(
                     "[AgentEval] No capability regression detected",
                     extra={


### PR DESCRIPTION
# fix(agent-eval): add edge-trigger and cooldown to prevent sticky regression warnings

## Summary

Fixes the "sticky warning" issue where `[AgentEval] Capability regression detected` was being logged on every workflow completion when metrics were below threshold, causing log spam and alert fatigue (20+ warnings in ~3 hours observed in production).

The fix implements edge-trigger + cooldown logic:
- **Edge-trigger**: Only alert on state transitions (healthy → degraded/critical, or degraded → critical)
- **Cooldown**: For same-state regressions, only alert if 30 minutes have passed since last alert
- **Observability preserved**: All regression data still returned in result dict; suppressed alerts logged at DEBUG level
- **Fail-open design**: If cooldown data parsing fails, alerts are allowed (prevents silent suppression)

New Redis keys used:
- `orchestrator:eval:health_status` - persists last known health status
- `orchestrator:eval:regression_alert` - stores alert timestamp with TTL for cleanup

## Updates since last revision

Addressed PR review feedback:
- **Timestamp-based cooldown validation**: Now parses and validates the stored timestamp instead of relying solely on Redis TTL existence. This prevents silent suppression if TTL is lost (e.g., Redis restart or key set without TTL by other code).
- **Removed redundant check**: Simplified `else` branch by removing unnecessary `if current_health_status == "healthy"` condition (gemini-code-assist suggestion).
- **Backward compatibility**: The new `regression_alert_cooldown_seconds` parameter has a default value, maintaining API compatibility.

## Review & Testing Checklist for Human

- [ ] **Verify `has_critical` parameter usage**: The `_should_emit_regression_alert` method accepts `has_critical` but doesn't use it in the logic. Confirm this is intentional or fix if it's a bug.
- [ ] **Test edge-trigger state transitions**: Manually verify that alerts fire correctly for: unknown→degraded, healthy→degraded, healthy→critical, degraded→critical
- [ ] **Verify cooldown behavior**: Confirm that repeated same-state regressions are suppressed within 30 min window, and that cooldown expiry triggers new alert

**Recommended test plan:**
1. Deploy to staging
2. Trigger a workflow that causes regression (success_rate < 70%)
3. Verify WARNING is logged once with `alert_reason` field
4. Trigger another workflow immediately - verify WARNING is NOT logged (suppressed)
5. Wait 30+ minutes, trigger again - verify WARNING is logged (cooldown expired)
6. Check Render logs for `alert_reason` field to confirm edge-trigger logic

### Notes

- Existing 34 tests pass; no new tests added for the helper methods (recommend follow-up)
- Default cooldown is 30 minutes, configurable via `regression_alert_cooldown_seconds` constructor param
- Aligns with Blueprint Section 5.2 (Telemetry & Logs v2) principle of meaningful signals over noise

Requested by: @RC918
Link to Devin run: https://app.devin.ai/sessions/32556f9957a64d1aa6f326e1b9abc339