### PR TITLE
fix(epic-d): correct AgentInput import path for GeneralCoder and SimpleCoder

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -4447,7 +4447,7 @@ def _attempt_general_coder_fix(
     try:
         from coder.autofix_gate import is_autofix_allowed, is_senior_coder_required
         from coder.general_coder import get_general_coder, CoderStatus
-        from common.agents.base_agent import AgentInput
+        from core.agents import AgentInput
         from tools.github_api import get_repo, commit_files
     except ImportError as e:
         logger.info(f"[GENERAL_CODER_DISABLED] Import failed: {e}")
@@ -4721,7 +4721,7 @@ def _attempt_simple_coder_fix(
     try:
         from coder.autofix_gate import is_autofix_allowed, is_path_excluded
         from coder.simple_coder import get_simple_coder, CoderStatus
-        from common.agents.base_agent import AgentInput
+        from core.agents import AgentInput
         from tools.github_api import get_repo, commit_file
     except ImportError as e:
         logger.debug(f"[SIMPLE_CODER_DISABLED] Import failed: {e}")


### PR DESCRIPTION
## Summary

Fixes an incorrect import path that was preventing GeneralCoder from ever running in production.

The import was using `from common.agents.base_agent import AgentInput` which doesn't exist. The correct path is `from core.agents import AgentInput`, which is what `general_coder.py` and `simple_coder.py` already use.

This bug caused GeneralCoder to always fail with `ImportError` and silently fall back to SimpleCoder, meaning **GeneralCoder has never worked in production**.

## Review & Testing Checklist for Human

- [ ] Verify the import path matches what `coder/general_coder.py` and `coder/simple_coder.py` use (they both use `from core.agents import AgentInput`)
- [ ] After merging, deploy to staging and trigger a multi-file test (Probe 1) to verify GeneralCoder now runs instead of falling back
- [ ] Check staging logs for `[GENERAL_CODER_ATTEMPT]` instead of `[GENERAL_CODER_DISABLED] Import failed`

### Notes

**Root cause investigation:** The `common/agents/` directory doesn't exist in the codebase. The `AgentInput` class is defined in `core/agents/base.py` and exported via `core/agents/__init__.py`.

**Impact:** After this fix, GeneralCoder will actually be invoked when `ENABLE_GENERAL_CODER=True`. Ensure the feature flag is set appropriately in each environment.

---
**Requested by:** @RC918
**Link to Devin run:** https://app.devin.ai/sessions/e77f2bd7d00d4fe6b1c47a63f2e812d2