### PR TITLE
test(probe1-v3): EPIC D GeneralCoder Multi-file Validation - Fresh test

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/probe1_main.py
+++ b/handoff/20250928/40_App/api-backend/src/probe1_main.py
@@ -1,0 +1,36 @@
+"""
+Probe 1: EPIC D GeneralCoder Multi-file Validation - Main Module
+
+This file is part of a 2-file test to validate GeneralCoder's multi-file capabilities:
+- probe1_utils.py: Utility functions
+- probe1_main.py (this file): Main module that imports from probe1_utils
+
+DO NOT MERGE THIS FILE - it is a test vehicle only.
+
+Expected CI failure: F821 (undefined name 'calcualte_total')
+GeneralCoder should:
+1. Detect the typo in the import usage
+2. Understand the relationship between the two files
+3. Fix 'calcualte_total' -> 'calculate_total'
+"""
+from probe1_utils import calculate_total, format_result
+
+
+def process_data(data: list) -> str:
+    """Process a list of data and return formatted result."""
+    # INTENTIONAL TYPO: 'calcualte_total' instead of 'calculate_total'
+    # This should trigger F821 (undefined name) lint error
+    # GeneralCoder should detect this and fix it
+    total = calcualte_total(data)  # noqa: F821 - intentional typo for testing
+    return format_result(total)
+
+
+def main():
+    """Main entry point."""
+    sample_data = [1, 2, 3, 4, 5]
+    result = process_data(sample_data)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/handoff/20250928/40_App/api-backend/src/probe1_utils.py
+++ b/handoff/20250928/40_App/api-backend/src/probe1_utils.py
@@ -1,0 +1,27 @@
+"""
+Probe 1: EPIC D GeneralCoder Multi-file Validation - Utility Module
+
+This file is part of a 2-file test to validate GeneralCoder's multi-file capabilities:
+- probe1_utils.py (this file): Utility functions
+- probe1_main.py: Main module that imports from this file
+
+DO NOT MERGE THIS FILE - it is a test vehicle only.
+
+This test validates:
+- D-1b: Multi-file support (<=5 files)
+- Import relationship understanding
+- Per-file syntax validation
+"""
+
+
+def calculate_total(items: list) -> int:
+    """Calculate the total of a list of numbers."""
+    total = 0
+    for item in items:
+        total += item
+    return total
+
+
+def format_result(value: int) -> str:
+    """Format a numeric result as a string."""
+    return f"Result: {value}"


### PR DESCRIPTION
## Summary

This PR introduces an **intentional lint error** across 2 files to validate the GeneralCoder multi-file capabilities (D-1b). This is a fresh test PR created because previous Probe 1 PRs (#3670, #3672) hit the AutoFix Loop Protection (max 3 retries exceeded).

**Test setup:**
- `probe1_utils.py`: Utility module with `calculate_total()` function
- `probe1_main.py`: Main module that imports from utils but has a typo: `calcualte_total` (missing 'l')

**Expected CI failure:** F821 (undefined name 'calcualte_total')

**What GeneralCoder should do:**
1. Detect the typo in the import usage
2. Understand the relationship between the two files
3. Fix `calcualte_total` → `calculate_total`

## Review & Testing Checklist for Human

- [ ] **CRITICAL: Do NOT merge this PR** - This is a test vehicle with intentionally broken code
- [ ] Verify CI `lint` job fails with F821 error for `probe1_main.py`
- [ ] After CI fails, check Render staging logs for:
  - `[FIXER_ENTRY_DIAGNOSTIC]` to confirm fixer_node was entered
  - `[GENERAL_CODER_ATTEMPT]` to see if GeneralCoder is now being attempted (after import fix PR #3673)
  - If GeneralCoder still fails, check for any new error messages
- [ ] If GeneralCoder commits a fix, verify it correctly changes `calcualte_total` → `calculate_total`
- [ ] Close this PR after validation (do not merge broken code)

### Test Plan
1. Wait for CI to fail with lint error (F821)
2. Check Render staging logs for GeneralCoder activity
3. Verify whether GeneralCoder or SimpleCoder handles the fix
4. Compare behavior to previous tests (Probe 0 v3 used SimpleCoder for single-file)

### Notes

This is part of EPIC D capability validation. Previous tests:
- Probe 0 v3 (PR #3667): SimpleCoder single-file - PASSED (closed)
- Probe 1 (PR #3670): Hit AutoFix Loop Protection after 3 retries (closed)
- Probe 1 v2 (PR #3672): Hit AutoFix Loop Protection again (still open)

This fresh PR resets the attempt counter to properly test GeneralCoder with the import fix from PR #3673.

---
**Requested by:** @RC918
**Link to Devin run:** https://app.devin.ai/sessions/e77f2bd7d00d4fe6b1c47a63f2e812d2