### PR TITLE
fix(epic-d): add multi-file extraction for GeneralCoder CI failure support

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -4922,6 +4922,79 @@ def _extract_file_path_from_error(error_summary: str) -> str:
     return ""
 
 
+def _extract_file_paths_from_error(error_summary: str) -> list:
+    """Extract ALL file paths from CI error summary for multi-file support.
+
+    Issue #3675: D-1b GeneralCoder needs multiple file paths for multi-file fixes.
+    This function extracts all unique file paths from CI error output, enabling
+    GeneralCoder to handle multi-file lint errors.
+
+    Parses common lint error formats:
+    - "path/to/file.py:123:45: E501 line too long"
+    - "path/to/file.py(123): error"
+    - "Error in path/to/file.py"
+
+    Args:
+        error_summary: CI error output text
+
+    Returns:
+        List of unique file paths (max 5 for D-1b limit), empty list if none found
+
+    Event Codes (greppable):
+        [MULTI_FILE_EXTRACT_SUCCESS] - Successfully extracted multiple file paths
+        [MULTI_FILE_EXTRACT_SINGLE] - Only one file path found
+        [MULTI_FILE_EXTRACT_NONE] - No file paths found
+    """
+    if not error_summary:
+        logger.debug("[MULTI_FILE_EXTRACT_NONE] Empty error_summary")
+        return []
+
+    file_paths = set()
+
+    # Pattern 1: "path/file.py:line:col: error" (flake8, pylint, eslint)
+    pattern1_matches = re.findall(
+        fr'^([^\s:]+\.(?:{_SUPPORTED_SOURCE_EXTENSIONS})):',
+        error_summary,
+        re.MULTILINE
+    )
+    file_paths.update(pattern1_matches)
+
+    # Pattern 2: "path/file.py(line): error" (some compilers)
+    pattern2_matches = re.findall(
+        fr'^([^\s(]+\.(?:{_SUPPORTED_SOURCE_EXTENSIONS}))\(',
+        error_summary,
+        re.MULTILINE
+    )
+    file_paths.update(pattern2_matches)
+
+    # Pattern 3: "Error in path/file.py" or "File path/file.py"
+    pattern3_matches = re.findall(
+        fr'(?:Error in|File|in file)\s+([^\s:]+\.(?:{_SUPPORTED_SOURCE_EXTENSIONS}))',
+        error_summary,
+        re.IGNORECASE
+    )
+    file_paths.update(pattern3_matches)
+
+    # Convert to list and limit to 5 files (D-1b limit)
+    result = list(file_paths)[:5]
+
+    if len(result) == 0:
+        logger.debug("[MULTI_FILE_EXTRACT_NONE] No file paths found in error_summary")
+    elif len(result) == 1:
+        logger.debug(f"[MULTI_FILE_EXTRACT_SINGLE] Found 1 file: {result[0]}")
+    else:
+        logger.info(
+            f"[MULTI_FILE_EXTRACT_SUCCESS] Found {len(result)} files: {result}",
+            extra={
+                "operation": "multi_file_extract",
+                "file_count": len(result),
+                "file_paths": result,
+            }
+        )
+
+    return result
+
+
 def _ensure_comment_body_for_ci_failure(state: dict, trace_id: str) -> None:
     """Synthesize comment_body and review_outcome from ci_failure_context for CI failure scenarios.
 
@@ -5058,7 +5131,24 @@ def _ensure_comment_body_for_ci_failure(state: dict, trace_id: str) -> None:
         error_summary_truncated = error_summary[:500]
         synthesized = f"Fix CI failure in {failed_check}: {error_summary_truncated}"
 
-        # Issue #3567: Extract file path for SimpleCoder
+        # Issue #3675: Extract ALL file paths for GeneralCoder multi-file support
+        # This enables D-1b GeneralCoder to handle multi-file lint errors
+        extracted_file_paths = _extract_file_paths_from_error(error_summary)
+        if extracted_file_paths and not state.get("review_files"):
+            # Set review_files for GeneralCoder (multi-file support)
+            state["review_files"] = [{"path": fp} for fp in extracted_file_paths]
+            logger.info(
+                f"[Fixer] Extracted review_files from error_summary for GeneralCoder. "
+                f"file_count={len(extracted_file_paths)}, files={extracted_file_paths}, trace_id={trace_id}",
+                extra={
+                    "operation": "fixer_extract_review_files",
+                    "trace_id": trace_id,
+                    "file_count": len(extracted_file_paths),
+                    "file_paths": extracted_file_paths,
+                }
+            )
+
+        # Issue #3567: Extract single file path for SimpleCoder (backward compatibility)
         extracted_file_path = _extract_file_path_from_error(error_summary)
         if extracted_file_path and not state.get("review_file_path"):
             state["review_file_path"] = extracted_file_path
@@ -5084,6 +5174,7 @@ def _ensure_comment_body_for_ci_failure(state: dict, trace_id: str) -> None:
             "trace_id": trace_id,
             "failed_check": failed_check,
             "has_error_summary": bool(error_summary),
+            "review_files_count": len(state.get("review_files", [])),
         }
     )
 


### PR DESCRIPTION
## Summary

Fixes an EPIC D implementation gap where GeneralCoder was failing with "No files to fix" during CI failure scenarios. The root cause was that CI failure context only populated `review_file_path` (single file), but GeneralCoder requires `review_files` (list) for multi-file support.

**Changes:**
- Add `_extract_file_paths_from_error()` function to extract ALL file paths from CI error summaries using the same regex patterns as the existing single-file function
- Update `_ensure_comment_body_for_ci_failure()` to populate `review_files` state for GeneralCoder
- Maintain backward compatibility with `review_file_path` for SimpleCoder

## Review & Testing Checklist for Human

- [ ] Verify the `review_files` format `[{"path": fp}]` matches what `_attempt_general_coder_fix()` expects at line 4540-4548 (it iterates with `f.get("path", "")`)
- [ ] Test with actual CI lint output to ensure regex patterns extract file paths correctly
- [ ] Verify the 5-file limit aligns with D-1b specification elsewhere in the codebase
- [ ] Consider adding unit tests for `_extract_file_paths_from_error()` in a follow-up

**Recommended test plan:** Create a new Probe 1 test PR with multi-file lint errors and monitor staging logs for `[MULTI_FILE_EXTRACT_SUCCESS]` and `[Fixer] Extracted review_files` events.

### Notes
- The file order in `review_files` is non-deterministic due to set deduplication
- No unit tests included in this PR - recommend adding in follow-up
- This PR was requested by Ryan Chen (@RC918) and assisted by Devin
- Session: https://app.devin.ai/sessions/e77f2bd7d00d4fe6b1c47a63f2e812d2