### PR TITLE
test(probe1-v4): EPIC D GeneralCoder Multi-file Validation - Fresh test

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/probe1_main.py
+++ b/handoff/20250928/40_App/api-backend/src/probe1_main.py
@@ -1,0 +1,34 @@
+"""Probe 1 Test File - Main Module
+
+EPIC D GeneralCoder Multi-file Validation Test
+This file imports from probe1_utils.py to test GeneralCoder's import relationship understanding.
+
+DO NOT MERGE - This is a test vehicle for validating D-1b multi-file support.
+"""
+
+from probe1_utils import calculate_total, format_output
+
+
+def process_data(data):
+    """Process data using utility functions.
+    
+    Intentional lint error: F821 undefined name 'validator'
+    """
+    if validator.is_valid(data):
+        total = calculate_total(data)
+        return format_output(total)
+    return None
+
+
+def main():
+    """Main entry point.
+    
+    Intentional lint error: F821 undefined name 'config'
+    """
+    data = config.load_data()
+    result = process_data(data)
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/handoff/20250928/40_App/api-backend/src/probe1_utils.py
+++ b/handoff/20250928/40_App/api-backend/src/probe1_utils.py
@@ -1,0 +1,24 @@
+"""Probe 1 Test File - Utils Module
+
+EPIC D GeneralCoder Multi-file Validation Test
+This file contains intentional lint errors to test GeneralCoder's multi-file fix capability.
+
+DO NOT MERGE - This is a test vehicle for validating D-1b multi-file support.
+"""
+
+
+def calculate_total(items):
+    """Calculate total from items list.
+    
+    Intentional lint error: F821 undefined name 'sum_values'
+    """
+    result = sum_values(items)
+    return result
+
+
+def format_output(value):
+    """Format output value.
+    
+    Intentional lint error: F821 undefined name 'formatter'
+    """
+    return formatter.format(value)


### PR DESCRIPTION
## Summary

**DO NOT MERGE** - This is a test vehicle PR for validating EPIC D GeneralCoder multi-file fix capability after PR #3675.

Creates two Python files with intentional F821 lint errors and import relationships to test:
- `_extract_file_paths_from_error()` extracts both file paths from CI error output
- `review_files` state is populated for GeneralCoder
- GeneralCoder handles multi-file scenarios correctly

**Test files:**
- `probe1_utils.py`: 2 F821 errors (`sum_values`, `formatter`)
- `probe1_main.py`: 2 F821 errors (`validator`, `config`) + imports from probe1_utils

## Review & Testing Checklist for Human

- [ ] Confirm CI lint check fails with F821 errors in both files
- [ ] Monitor staging logs for `[MULTI_FILE_EXTRACT_SUCCESS]` event
- [ ] Monitor staging logs for `[Fixer] Extracted review_files` with file_count=2
- [ ] Verify GeneralCoder attempts fix (or defers to SimpleCoder appropriately)

**Test plan:** After CI fails, check Render staging logs for AutoFixer activity. Look for the new observability events added in PR #3675.

### Notes
- This PR should be closed after testing, not merged
- Previous Probe 1 tests (PR #3670, #3672, #3674) were blocked by import errors and loop protection - those issues are now fixed
- Requested by Ryan Chen (@RC918)
- Session: https://app.devin.ai/sessions/e77f2bd7d00d4fe6b1c47a63f2e812d2