### PR TITLE
fix(epic-d): add check_run event support for annotations extraction

### DIFF
--- a/handoff/20250928/40_App/orchestrator/webhooks/handlers/github_handler.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/handlers/github_handler.py
@@ -474,6 +474,14 @@ class GitHubWebhookHandler(BaseWebhookHandler):
                     int(raw_check_run_id) if raw_check_run_id is not None else None
                 )
             except (ValueError, TypeError):
+                logger.warning(
+                    "[GitHubWebhookHandler] Invalid check_run_id in check_run event",
+                    extra={
+                        "event_id": event_id,
+                        "repo": f"{repo_owner}/{repo_name}",
+                        "raw_check_run_id": str(raw_check_run_id)[:50],
+                    },
+                )
                 metadata["ci_check_run_id"] = None
             # Extract check_suite_id from nested check_suite for dedup and annotations
             raw_check_suite_id = check_suite.get("id")


### PR DESCRIPTION
## Summary

Adds support for GitHub `check_run` webhook events to enable annotations extraction for GeneralCoder multi-file CI failure fixes.

**Root Cause:** Previously, `ci_check_suite_id` was only extracted for `check_suite` events. GitHub also sends `check_run` events for individual CI jobs (e.g., lint), which contain the `check_suite_id` in a nested path (`check_run.check_suite.id`). Without this ID, `_fetch_failed_check_runs()` was being skipped due to the `if check_suite_id:` condition, preventing annotations extraction.

**Changes:**
- Add `check_run` event to `GITHUB_EVENT_MAP` (completed action → `CI_CHECK_COMPLETED`)
- Extract resource info (PR number, branch, title) from `check_run` events
- Extract CI metadata including `ci_check_suite_id` from nested `check_run.check_suite.id`
- Add `ci_check_run_id` and `ci_check_run_name` for better observability
- Add warning logging for invalid `ci_check_run_id` (consistent with `ci_check_suite_id` handling)

## Updates since last revision

- Added warning logging when `ci_check_run_id` parsing fails, addressing Gemini Code Assist feedback for consistent error handling

## Review & Testing Checklist for Human

- [ ] **Verify GitHub payload structure**: Confirm that `check_run.check_suite.id` and `check_run.check_suite.head_sha` exist in actual GitHub `check_run` webhook payloads
- [ ] **Check for duplicate event processing**: Both `check_suite` and `check_run` events now map to `CI_CHECK_COMPLETED` - verify the existing dedup logic (using `check_suite_id` in dedup key) handles this correctly
- [ ] **Test end-to-end**: Create a test PR with lint errors and verify:
  - `ci_check_suite_id` appears in logs
  - `fetch_annotations_success` log appears
  - `ci_error_file_paths` is populated
  - GeneralCoder receives multi-file context

**Recommended test plan:** Deploy to staging, create a new Probe 1 test PR with intentional lint errors in 2 files, and verify annotations extraction logs appear.

### Notes

- flake8 reports C901 complexity warning (22) for `parse_event` - this is a pre-existing issue exacerbated by the new code path
- Follow-up issue #3686 created for refactoring `check_suite`/`check_run` handlers to reduce code duplication
- No unit tests added - consider adding tests for `check_run` event parsing

Link to Devin run: https://app.devin.ai/sessions/e77f2bd7d00d4fe6b1c47a63f2e812d2
Requested by: Ryan Chen (@RC918)