### PR TITLE
fix(epic-d): pass ci_check_suite_id and ci_error_file_paths to task context

### DIFF
--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -1380,6 +1380,14 @@ class EventNormalizer:
             # Issue #3510: Pass CiFailureContext for structured CI error propagation
             if ci_context := event.metadata.get("ci_failure_context"):
                 context["ci_failure_context"] = ci_context
+            # Issue #3689: Pass ci_check_suite_id for Annotations API access in worker
+            # Without this, the worker cannot fetch annotations to extract file paths
+            if ci_check_suite_id := event.metadata.get("ci_check_suite_id"):
+                context["ci_check_suite_id"] = ci_check_suite_id
+            # Issue #3676: Pass ci_error_file_paths for GeneralCoder multi-file support
+            # These file paths are extracted from GitHub Annotations API in normalizer
+            if ci_error_file_paths := event.metadata.get("ci_error_file_paths"):
+                context["ci_error_file_paths"] = ci_error_file_paths
 
         return context
 


### PR DESCRIPTION
## Summary

Fixes the root cause of GeneralCoder multi-file extraction failure (EPIC D). The `ci_check_suite_id` and `ci_error_file_paths` were being extracted in `_handle_ci_check_completed()` and stored in `event.metadata`, but `_build_context()` was not passing them to the task context.

Without these fields in context:
- Worker cannot call GitHub Annotations API (needs `ci_check_suite_id`)
- GeneralCoder cannot know which files to fix (needs `ci_error_file_paths`)

This explains why Probe 1 v6 testing showed `review_files_count=0` and `ci_check_suite_id` was missing from `context_keys`.

## Review & Testing Checklist for Human

- [ ] Verify key names match: `ci_check_suite_id` and `ci_error_file_paths` should match what's set in `_handle_ci_check_completed()` (lines 2166, 2174)
- [ ] After merge & deploy, run Probe 1 v7 test PR to verify `ci_check_suite_id` appears in `context_keys` log
- [ ] Confirm `review_files_count > 0` in fixer_node diagnostic logs

### Notes

This PR was assisted by Devin. Requested by @RC918.

Link to Devin run: https://app.devin.ai/sessions/e77f2bd7d00d4fe6b1c47a63f2e812d2