### PR TITLE
test(probe1-v7): EPIC D context validation - verify ci_check_suite_id and ci_error_file_paths

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/probe1_v7_main.py
+++ b/handoff/20250928/40_App/api-backend/src/probe1_v7_main.py
@@ -1,14 +1,19 @@
-from flask import Flask, request, jsonify
-import json
+"""
+Probe 1 v7 Test File - Main Module (v8 - Post PR #3693 fix)
+Purpose: Validate that review_files from Annotations is NOT overridden by error_summary
+This file contains an intentional lint error for testing GeneralCoder multi-file fix.
+"""
 
-app = Flask(__name__)
+import sys  # F401: unused import - intentional lint error for testing
 
-@app.route('/probe', methods=['POST'])
-def probe():
-    data = request.get_json()
-    result = process_data(data)
-    return jsonify(result)
 
-def process_data(data):
-    # Simulate processing
-    return {"status": "success", "data": data}
+def run_probe1_v7():
+    """Run the probe test."""
+    print("Probe 1 v7 (v8): Testing PR #3693 fix")
+    print("Expected: review_files from Annotations NOT overridden")
+    print("Expected: review_files_count = 2 (not 1)")
+    return True
+
+
+if __name__ == "__main__":
+    run_probe1_v7()

--- a/handoff/20250928/40_App/api-backend/src/probe1_v7_utils.py
+++ b/handoff/20250928/40_App/api-backend/src/probe1_v7_utils.py
@@ -1,10 +1,10 @@
 """
-Probe 1 v7 Test File - Utils Module
-Purpose: Validate ci_check_suite_id and ci_error_file_paths are passed to context
+Probe 1 v7 Test File - Utils Module (v8 - Post PR #3693 fix)
+Purpose: Validate that review_files from Annotations is NOT overridden by error_summary
 This file contains an intentional lint error for testing GeneralCoder multi-file fix.
 """
 
-import os  # F401: unused import - intentional lint error
+import os  # F401: unused import - intentional lint error for testing
 
 
 def get_probe1_v7_config():


### PR DESCRIPTION
## Summary

**⚠️ DO NOT MERGE - TEST VEHICLE ONLY ⚠️**

This test PR validates that PR #3691's fix is working correctly. It contains intentional lint errors (F401 unused imports) in 2 files to trigger CI failure and test the GeneralCoder multi-file fix flow.

**What we're testing:**
- `ci_check_suite_id` appears in `context_keys` (was missing in Probe 1 v6)
- `ci_error_file_paths` appears in `context_keys` (was missing in Probe 1 v6)
- `review_files_count > 0` in fixer_node diagnostic (was 0 in Probe 1 v6)
- GeneralCoder can fix both files using annotations data

## Review & Testing Checklist for Human

- [ ] **DO NOT MERGE** - Close this PR after validation is complete
- [ ] After CI fails, check staging logs for `context_keys` - should now include `ci_check_suite_id` and `ci_error_file_paths`
- [ ] Verify `review_files_count > 0` in fixer_node diagnostic logs
- [ ] Confirm AutoFixer attempts to fix both `probe1_v7_main.py` and `probe1_v7_utils.py`

**Test Plan:**
1. Wait for CI lint check to fail
2. Search staging logs for `Starting LangGraph orchestrator` with this PR number
3. Verify `ci_check_suite_id` and `ci_error_file_paths` are in `context_keys`
4. Check if GeneralCoder creates a fix commit

### Notes

This PR was assisted by Devin. Requested by @RC918.

Link to Devin run: https://app.devin.ai/sessions/e77f2bd7d00d4fe6b1c47a63f2e812d2