### PR TITLE
fix(epic-d): extract branch from ci_failure_context for GeneralCoder

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -8585,6 +8585,20 @@ def run_orchestrator(
         # Issue #3510: Pass CiFailureContext for structured CI error propagation
         if context and (ci_context := context.get("ci_failure_context")):
             initial_state["ci_failure_context"] = ci_context
+            # Issue #3695: Extract branch from ci_failure_context for GeneralCoder
+            # Without this, GeneralCoder gate fails with "Missing repo or branch"
+            # because branch is not passed from normalizer to initial_state
+            if head_branch := ci_context.get("head_branch"):
+                initial_state["branch"] = head_branch
+                logger.info(
+                    f"[Orchestrator] Set branch from ci_failure_context for GeneralCoder. "
+                    f"branch={head_branch}, trace_id={trace_id}",
+                    extra={
+                        "operation": "set_branch_from_ci_context",
+                        "trace_id": trace_id,
+                        "branch": head_branch,
+                    }
+                )
         # Issue #3676: Pass ci_error_file_paths for D-1b GeneralCoder multi-file support
         # These file paths are extracted from GitHub Annotations API in normalizer
         if context and (ci_error_file_paths := context.get("ci_error_file_paths")):


### PR DESCRIPTION
## Summary

Fixes GeneralCoder gate failure with "Missing repo or branch" error during CI failure auto-fix flow.

**Root cause:** `ci_failure_context` contains `head_branch` (extracted from GitHub webhook in normalizer), but `run_orchestrator()` was not extracting it to `initial_state["branch"]`. GeneralCoder's gate check requires `branch` to fetch file contents from GitHub.

**Fix:** Extract `head_branch` from `ci_failure_context` when setting up CI failure workflow, enabling GeneralCoder to access the branch for file operations.

## Review & Testing Checklist for Human

- [ ] Deploy to staging and trigger a CI failure on a test PR with 2+ lint errors
- [ ] Search staging logs for `[Orchestrator] Set branch from ci_failure_context` to confirm branch extraction
- [ ] Verify GeneralCoder no longer fails with `[GENERAL_CODER_GATE_FAIL] Missing repo or branch`
- [ ] Confirm GeneralCoder attempts to fix files (look for `[GENERAL_CODER_ATTEMPT]` log)

### Notes

This is part of EPIC D D-1b GeneralCoder multi-file support. Previous PRs (#3691, #3693) fixed `review_files` propagation, but GeneralCoder was still blocked by missing `branch` in state.

This PR was assisted by Devin. Requested by @RC918.

Link to Devin run: https://app.devin.ai/sessions/e77f2bd7d00d4fe6b1c47a63f2e812d2