### PR TITLE
feat(telemetry): make epic_tag configurable in node_metrics decorator

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -213,22 +213,32 @@ def node_metrics(node_name: str, epic_tag: str = "EPIC-C") -> Callable:
     categorization per node. Defaults to "EPIC-C" for backward compatibility.
 
     Args:
-        node_name: Name of the node for metrics identification
-        epic_tag: Epic tag for telemetry categorization (default: "EPIC-C")
+        node_name: Name of the node for metrics identification.
+        epic_tag: Epic tag for telemetry categorization (default: "EPIC-C").
 
-    Usage:
-        @node_metrics("pm_advisor")
-        def pm_advisor_node(state: AgentState) -> AgentState:
-            # Node logic here - set success[0] = True on success
-            return state
+    Returns:
+        Callable: A decorator that wraps the node function.
 
-        # With custom epic tag:
-        @node_metrics("review_node", epic_tag="EPIC-D")
-        def review_node(state: AgentState) -> AgentState:
-            return state
+    Examples:
+        The decorated function must accept a `success` keyword argument, which is a
+        mutable list `[False]`. The function should set `success[0] = True` upon
+        successful execution.
 
-    The decorated function receives an additional 'success' parameter
-    (a mutable list [False]) that should be set to [True] on success.
+        Basic usage::
+
+            @node_metrics("pm_advisor")
+            def pm_advisor_node(state: AgentState, success: list) -> AgentState:
+                # Node logic here
+                success[0] = True
+                return state
+
+        With a custom epic tag::
+
+            @node_metrics("review_node", epic_tag="EPIC-D")
+            def review_node(state: AgentState, success: list) -> AgentState:
+                # Node logic here
+                success[0] = True
+                return state
     """
     def decorator(func: Callable) -> Callable:
         @functools.wraps(func)


### PR DESCRIPTION
## Summary

Makes the `epic_tag` parameter configurable in the `node_metrics` decorator, addressing Issue #3706 from gemini-code-assist review feedback on PR #3705.

Previously, `epic_tag` was hardcoded to `"EPIC-C"` in the telemetry span creation. This change adds an optional `epic_tag` parameter with a default value of `"EPIC-C"` for backward compatibility, allowing different nodes to specify different epic tags for more granular telemetry categorization.

**Changes:**
- Add `epic_tag: str = "EPIC-C"` parameter to `node_metrics()` signature
- Update `TelemetryRecordV3.create()` to use the configurable parameter
- Add documentation and usage examples in docstring

## Review & Testing Checklist for Human

- [ ] Verify existing `@node_metrics("node_name")` usages still work (backward compatibility)
- [ ] Confirm telemetry records use custom epic_tag when specified (e.g., `@node_metrics("review_node", epic_tag="EPIC-D")`)

**Recommended test plan:**
1. Deploy to staging with `ENABLE_SSOT_TELEMETRY=true`
2. Trigger a workflow and verify telemetry spans show `epic_tag: "EPIC-C"` by default
3. (Optional) Add a test node with custom epic_tag and verify it appears correctly in telemetry

### Notes
- Backward compatible - all existing usages continue to work unchanged
- Aligns with Blueprint Section 9.1: "All behavior can be reconstructed via Telemetry + Memory"
- Requested by: @RC918
- Devin run: https://app.devin.ai/sessions/32556f9957a64d1aa6f326e1b9abc339

Fixes #3706