### PR TITLE
test(epic-d): add comprehensive unit tests for syntax safety guardrail (Probe 3)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/coder/tests/test_syntax_safety_guardrail.py
+++ b/handoff/20250928/40_App/orchestrator/coder/tests/test_syntax_safety_guardrail.py
@@ -15,6 +15,7 @@ The syntax validation is the last line of defense before code is committed.
 If an LLM generates syntactically invalid Python, this guardrail catches it.
 """
 import json
+import logging
 import pytest
 from unittest.mock import patch
 
@@ -329,13 +330,10 @@ def process_data(items):
 
     def test_catches_mixed_indentation(self):
         """Should catch mixed tabs/spaces (common LLM failure)."""
-        code = "def foo():\n\tif True:\n        pass"
-        # Note: This might pass in some Python versions, but the test
-        # documents the expected behavior
+        code = "def foo():\n\tif True:\n        pass"  # Mixed tab and spaces
         is_valid, error = validate_python_syntax(code)
-        # Mixed indentation may or may not be a syntax error depending on context
-        # The important thing is that we test it
-        assert isinstance(is_valid, bool)
+        assert is_valid is False
+        assert "TabError" in error
 
     def test_catches_incomplete_string(self):
         """Should catch incomplete string literal."""
@@ -352,13 +350,12 @@ def process_data(items):
         assert "SyntaxError" in error
 
     def test_catches_invalid_escape_sequence(self):
-        """Should catch invalid escape in non-raw string."""
-        # Note: Invalid escape sequences are warnings in Python 3.6+,
-        # but may become errors in future versions
-        code = r'x = "\q"'  # \q is not a valid escape
+        """Should catch invalid escape sequence that is a SyntaxError."""
+        # An unterminated unicode escape like '\u' is a hard SyntaxError.
+        code = "'\\u'"
         is_valid, error = validate_python_syntax(code)
-        # This is actually valid syntax (just a warning), so it should pass
-        assert is_valid is True
+        assert is_valid is False
+        assert "SyntaxError" in error
 
     def test_catches_mismatched_brackets(self):
         """Should catch mismatched brackets."""
@@ -431,7 +428,6 @@ def format_nested(outer, inner):
             })
         }
 
-        import logging
         with caplog.at_level(logging.WARNING):
             result = coder.generate_fix(
                 file_path="test.py",
@@ -515,7 +511,6 @@ class TestGeneralCoderSyntaxIntegration:
             })
         }
 
-        import logging
         with caplog.at_level(logging.WARNING):
             result = coder.generate_multi_file_fix(
                 files=[{"path": "bad.py", "content": "# bad"}],


### PR DESCRIPTION
## Summary

Adds a comprehensive test suite (42 tests) for the `validate_python_syntax()` function, which is the syntax safety guardrail that prevents coder agents from committing syntactically invalid Python code. This is part of EPIC D Probe 3 validation.

The test suite covers:
- **Basic syntax validation**: Valid/invalid code detection (unclosed parens, brackets, braces, indentation errors)
- **Complex Python patterns**: Nested f-strings, walrus operators, match-case (3.10+), lambda with lambda defaults, async comprehensions, metaclasses, decorator chains, raw strings, mixed quotes
- **Edge cases**: Empty strings, whitespace-only, unicode identifiers, deeply nested structures, very long lines
- **LLM failure modes**: Truncated code, incomplete strings/f-strings, mismatched brackets
- **Integration tests**: SimpleCoder and GeneralCoder rejection of invalid syntax patches, event logging verification

### Updates since last revision

Addressed Gemini Code Assist reviewer feedback:
- **test_catches_mixed_indentation**: Strengthened assertion to explicitly verify `TabError` is caught (was using weak `isinstance` check)
- **test_catches_invalid_escape_sequence**: Changed to test unterminated unicode escape (`'\u'`) which is a hard SyntaxError, instead of `'\q'` which is only a warning
- **PEP 8 compliance**: Moved `import logging` to top-level imports

## Review & Testing Checklist for Human

- [ ] Verify `test_catches_mixed_indentation` correctly expects `TabError` in the error message - confirm `validate_python_syntax()` returns error strings containing "TabError" for mixed tabs/spaces
- [ ] Verify `test_catches_invalid_escape_sequence` with `'\u'` actually raises a SyntaxError (unterminated unicode escape)
- [ ] Confirm the `[CODER_SYNTAX_ABORT]` and `[GENERAL_CODER_SYNTAX_ABORT]` event codes in the tests match the actual implementation in `simple_coder.py` and `general_coder.py`
- [ ] Run the tests locally: `PYTHONPATH="$PWD/handoff/20250928/40_App/orchestrator:$PYTHONPATH" pytest handoff/20250928/40_App/orchestrator/coder/tests/test_syntax_safety_guardrail.py -v`

### Notes

This PR is test-only and does not modify any production code. The tests validate the existing syntax guardrail mechanism that was implemented as part of Issue #3697.

Link to Devin run: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167
Requested by: Ryan Chen (@RC918)