### PR TITLE
fix(test): make mixed indentation test compatible with Python 3.12+

### DIFF
--- a/handoff/20250928/40_App/orchestrator/coder/tests/test_syntax_safety_guardrail.py
+++ b/handoff/20250928/40_App/orchestrator/coder/tests/test_syntax_safety_guardrail.py
@@ -333,7 +333,9 @@ def process_data(items):
         code = "def foo():\n\tif True:\n        pass"  # Mixed tab and spaces
         is_valid, error = validate_python_syntax(code)
         assert is_valid is False
-        assert "TabError" in error
+        # Python 3.12+ reports this as SyntaxError with "inconsistent use of tabs and spaces"
+        # Earlier versions report it as TabError
+        assert "TabError" in error or "inconsistent use of tabs and spaces" in error
 
     def test_catches_incomplete_string(self):
         """Should catch incomplete string literal."""


### PR DESCRIPTION
## Summary

Fixes CI failure in `test_catches_mixed_indentation` test caused by Python version differences in error reporting.

Python 3.12+ reports mixed tabs/spaces indentation as `SyntaxError` with message "inconsistent use of tabs and spaces in indentation", while earlier versions report it as `TabError`. The test assertion now accepts either error type for cross-version compatibility.

## Review & Testing Checklist for Human

- [ ] Verify the assertion logic correctly identifies mixed indentation errors in both Python versions
- [ ] Confirm CI passes after merge

### Notes

This fixes the Orchestrator Tests CI failure that was blocking PR #3732.

---
Link to Devin run: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167
Requested by: Ryan Chen (@RC918)