### PR TITLE
test(hitl): verify HITL 6+ files escalation after PR #3737 fix

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_1.py
+++ b/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_1.py
@@ -1,27 +1,7 @@
-# Corrected code for test_file_1.py
-def test_example_1():
-    assert True
+"""Test file 1 for HITL 6+ files verification after PR #3740 fix."""
+import os  # F401: unused import - intentional lint error for re-verification
 
-# Corrected code for test_file_2.py
-def test_example_2():
-    assert True
 
-# Corrected code for test_file_3.py
-def test_example_3():
-    assert True
-
-# Corrected code for test_file_4.py
-def test_example_4():
-    assert True
-
-# Corrected code for test_file_5.py
-def test_example_5():
-    assert True
-
-# Corrected code for test_file_6.py
-def test_example_6():
-    assert True
-
-# Corrected code for test_file_7.py
-def test_example_7():
-    assert True
+def placeholder_function_1():
+    """Placeholder function."""
+    return "test_1"

--- a/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_2.py
+++ b/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_2.py
@@ -1,6 +1,7 @@
-"""Test file for HITL 6+ files verification after PR #3737 fix."""
-import sys  # F401: unused import - intentional lint error
+"""Test file 2 for HITL 6+ files verification after PR #3740 fix."""
+import os  # F401: unused import - intentional lint error for re-verification
 
-def placeholder_function():
+
+def placeholder_function_2():
     """Placeholder function."""
-    return "test"
+    return "test_2"

--- a/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_3.py
+++ b/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_3.py
@@ -1,6 +1,7 @@
-"""Test file for HITL 6+ files verification after PR #3737 fix."""
-import sys  # F401: unused import - intentional lint error
+"""Test file 3 for HITL 6+ files verification after PR #3740 fix."""
+import os  # F401: unused import - intentional lint error for re-verification
 
-def placeholder_function():
+
+def placeholder_function_3():
     """Placeholder function."""
-    return "test"
+    return "test_3"

--- a/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_4.py
+++ b/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_4.py
@@ -1,6 +1,7 @@
-"""Test file for HITL 6+ files verification after PR #3737 fix."""
-import sys  # F401: unused import - intentional lint error
+"""Test file 4 for HITL 6+ files verification after PR #3740 fix."""
+import os  # F401: unused import - intentional lint error for re-verification
 
-def placeholder_function():
+
+def placeholder_function_4():
     """Placeholder function."""
-    return "test"
+    return "test_4"

--- a/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_5.py
+++ b/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_5.py
@@ -1,6 +1,7 @@
-"""Test file for HITL 6+ files verification after PR #3737 fix."""
-import sys  # F401: unused import - intentional lint error
+"""Test file 5 for HITL 6+ files verification after PR #3740 fix."""
+import os  # F401: unused import - intentional lint error for re-verification
 
-def placeholder_function():
+
+def placeholder_function_5():
     """Placeholder function."""
-    return "test"
+    return "test_5"

--- a/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_6.py
+++ b/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_6.py
@@ -1,6 +1,7 @@
-"""Test file for HITL 6+ files verification after PR #3737 fix."""
-import sys  # F401: unused import - intentional lint error
+"""Test file 6 for HITL 6+ files verification after PR #3740 fix."""
+import os  # F401: unused import - intentional lint error for re-verification
 
-def placeholder_function():
+
+def placeholder_function_6():
     """Placeholder function."""
-    return "test"
+    return "test_6"

--- a/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_7.py
+++ b/handoff/20250928/40_App/api-backend/src/test_hitl_6plus_verification/test_file_7.py
@@ -1,6 +1,7 @@
-"""Test file for HITL 6+ files verification after PR #3737 fix."""
-import sys  # F401: unused import - intentional lint error
+"""Test file 7 for HITL 6+ files verification after PR #3740 fix."""
+import os  # F401: unused import - intentional lint error for re-verification
 
-def placeholder_function():
+
+def placeholder_function_7():
     """Placeholder function."""
-    return "test"
+    return "test_7"


### PR DESCRIPTION
## Summary

**⚠️ TEST PR - DO NOT MERGE - CLOSE AFTER VERIFICATION**

Creates 7 test files with intentional F401 lint errors to verify that the HITL 6+ files escalation feature works correctly after PR #3737 fix was deployed.

**What this tests:**
- PR #3737 increased `MAX_CI_ERROR_FILE_PATHS` from 5 to 20
- With 7 files having lint errors, all 7 should now be passed to GeneralCoder
- GeneralCoder should detect "Too many files: 7 > 5" and trigger HITL escalation
- `[GENERAL_CODER_MULTI_FILE_HITL_ESCALATION]` event should appear in staging logs

**Why `test-hitl/*` branch prefix:**
The CI failure workflow skips `devin/*` branches to prevent self-trigger loops. Using `test-hitl/*` ensures the workflow processes this PR.

## Review & Testing Checklist for Human

- [ ] **DO NOT MERGE** - Close this PR after verification is complete
- [ ] Wait for lint CI to fail (expected: 7 F401 errors)
- [ ] Check staging logs for `ci_failure_trigger=True`
- [ ] Verify `review_files_count=7` (was 5 before fix)
- [ ] Confirm `[GENERAL_CODER_MULTI_FILE_HITL_ESCALATION]` event appears

### Notes

- Related: PR #3737 (fix), PR #3732 (HITL 6+ files feature)
- Previous test PR #3736 revealed the bug (only 5 files were passed due to `[:5]` limit)
- Requested by: @RC918
- Devin run: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167