### PR TITLE
fix(epic-d): remove pre-GeneralCoder file limit to enable HITL 6+ files escalation

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -4674,7 +4674,7 @@ def _attempt_general_coder_fix(
     # so it can detect "Too many files" and trigger HITL escalation (PR #3732).
     # Previously this was limited to settings.general_coder_max_files (5), which
     # prevented GeneralCoder from ever seeing 6+ files and triggering HITL.
-    # Use MAX_CI_ERROR_FILE_PATHS (20) as upper limit to prevent extreme edge cases.
+    # Use MAX_FILES_FOR_GENERAL_CODER (20) as upper limit to prevent extreme edge cases.
     MAX_FILES_FOR_GENERAL_CODER = 20
     files_to_fix = []
     if review_files:


### PR DESCRIPTION
## Summary

Fixes a bug where HITL 6+ files escalation (PR #3732) could never trigger because files were limited to `settings.general_coder_max_files` (5) **before** reaching GeneralCoder. This was a second limit discovered after PR #3737 fixed the first limit in `_fetch_failed_check_runs()`.

**Root cause:** Staging logs showed `review_files_count=7` (PR #3737 fix working) but `file_count=5` at GeneralCoder. The limit at line 4675 was truncating files before GeneralCoder could detect "Too many files" and trigger HITL escalation.

**Changes:**
- Replace `settings.general_coder_max_files` (5) with `MAX_FILES_FOR_GENERAL_CODER` (20)
- Add telemetry warning when files are truncated (Blueprint 4.2 observability)

## Updates since last revision

- Fixed comment inconsistency: corrected reference from `MAX_CI_ERROR_FILE_PATHS` to `MAX_FILES_FOR_GENERAL_CODER`

## Review & Testing Checklist for Human

- [ ] **Verify in staging**: Use test PR #3739 (still open) to confirm `[GENERAL_CODER_MULTI_FILE_HITL_ESCALATION]` event now appears in logs
- [ ] Verify `file_count=7` (not 5) appears in `[GENERAL_CODER_ATTEMPT]` log
- [ ] Consider if `MAX_FILES_FOR_GENERAL_CODER` should be centralized in `settings.py` (follow-up issue #3738 already tracks this for the other constant)

**Recommended test plan:**
1. After merge & deploy, check staging logs for test PR #3739
2. Search for `GENERAL_CODER_MULTI_FILE_HITL_ESCALATION` - should now appear
3. Verify `file_count=7` in `[GENERAL_CODER_ATTEMPT]` log (was 5 before fix)

### Notes

- Related: PR #3732 (HITL 6+ files feature), PR #3737 (first limit fix), Issue #3738 (centralize constants)
- Test PR #3739 is still open and can be used for verification
- Requested by: @RC918
- Devin run: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167