### PR TITLE
fix(epic-d): prevent recursion limit error when loop protection triggers

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -5528,6 +5528,9 @@ def fixer_node(state: AgentState) -> AgentState:
             state["messages"] = state.get("messages", []) + [
                 AIMessage(content=f"AutoFixer stopped by loop protection after {current_attempts} attempts")
             ]
+            # Set flag to signal should_proceed_after_fixer to route to finalizer
+            # This prevents infinite recursion: fixer → ci_monitor → reviewer → fixer → ...
+            state["loop_protection_triggered"] = True
             latency_ms = (time.time() - start_time) * 1000
             metrics.record_fixer_attempt(trace_id, retry_count, success=False)
             metrics.record_node_complete("fixer", trace_id, success=False, latency_ms=latency_ms)
@@ -7260,6 +7263,7 @@ def should_proceed_after_fixer(state: AgentState) -> str:
     EPIC D Issue #3487: SeniorCoder HITL Gate
 
     Routes based on HITL requirement:
+    - finalizer: If loop_protection_triggered is True (prevents infinite recursion)
     - hitl_gate: If requires_hitl_approval is True and hitl_approved is False
       (SeniorCoder determined task complexity is too high)
     - ci_monitor: If ci_failure_trigger is True (CI failure auto-fix flow)
@@ -7280,7 +7284,24 @@ def should_proceed_after_fixer(state: AgentState) -> str:
     hitl_approved = state.get("hitl_approved") is True
     hitl_reason = state.get("hitl_reason", "")
     ci_failure_trigger = state.get("ci_failure_trigger") is True
+    loop_protection_triggered = state.get("loop_protection_triggered") is True
     metrics = _get_metrics()
+
+    # CRITICAL: Route to finalizer if loop protection triggered
+    # This prevents infinite recursion: fixer → ci_monitor → reviewer → fixer → ...
+    if loop_protection_triggered:
+        logger.warning(
+            f"[FIXER_ROUTING] Loop protection triggered, routing to finalizer to prevent recursion. "
+            f"trace_id={trace_id}",
+            extra={
+                "operation": "fixer_routing",
+                "trace_id": trace_id,
+                "event_code": "FIXER_LOOP_PROTECTION_TO_FINALIZER",
+                "loop_protection_triggered": True,
+            }
+        )
+        metrics.record_transition("fixer", "finalizer", trace_id)
+        return "finalizer"
 
     # Route to HITL gate if approval is required and not yet approved
     if requires_hitl and not hitl_approved:
@@ -8619,19 +8640,21 @@ def create_orchestrator_graph(entry_point: str = "planner", checkpointer=None):
         }
     )
 
-    # fixer → (executor | hitl_gate | ci_monitor)
+    # fixer → (executor | hitl_gate | ci_monitor | finalizer)
     # EPIC D Issue #3487: SeniorCoder HITL Gate
     # Changed from direct edge to conditional edge to support HITL escalation
     # when SeniorCoder determines task complexity is too high
     # Issue #3541: Added ci_monitor route for CI failure auto-fix to bypass
     # executor_node (which calls graph.execute with ValueGate)
+    # Fix: Added finalizer route for loop protection to prevent infinite recursion
     workflow.add_conditional_edges(
         "fixer",
         should_proceed_after_fixer,
         {
             "executor": "executor",
             "hitl_gate": "hitl_gate",
-            "ci_monitor": "ci_monitor"
+            "ci_monitor": "ci_monitor",
+            "finalizer": "finalizer"
         }
     )
 


### PR DESCRIPTION
## Summary

Fixes a critical bug where LangGraph hits recursion limit (100) when AutoFixLoopProtection triggers. When max retries were exceeded, the fixer node was still routing to `ci_monitor`, causing an infinite loop:

```
fixer → ci_monitor → reviewer → decision → fixer → (loop protection) → ci_monitor → ...
```

This fix adds a `loop_protection_triggered` flag that signals `should_proceed_after_fixer()` to route directly to `finalizer`, terminating the workflow gracefully.

**Changes:**
1. Set `loop_protection_triggered=True` in state when loop protection triggers (line 5533)
2. Check flag in `should_proceed_after_fixer()` and route to `finalizer` (lines 7290-7304)
3. Add `finalizer` to fixer's conditional edges map (line 8657)

## Review & Testing Checklist for Human

- [ ] **Verify routing logic**: Confirm that routing to `finalizer` (bypassing `publisher`) is correct behavior when loop protection triggers. The workflow terminates without posting any review comments.
- [ ] **Test in staging**: Trigger a PR that exceeds max_retries (3) and verify:
  - `[FIXER_LOOP_PROTECTION_TO_FINALIZER]` event appears in logs
  - No recursion limit error occurs
  - Workflow terminates gracefully
- [ ] **Check for side effects**: Verify no other code paths could accidentally set `loop_protection_triggered=True`

### Notes

This bug was discovered while verifying the HITL 6+ files escalation feature (PR #3740). The recursion error was blocking staging verification.

**Requested by:** Ryan Chen (@RC918)  
**Link to Devin run:** https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167