### PR TITLE
fix(epic-d): add loop_protection_triggered to AgentState for proper LangGraph propagation

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -2617,6 +2617,12 @@ class AgentState(TypedDict):
     # Used to establish parent-child relationships between node spans.
     # Each node creates a child span with this as parent_span_id, then updates this field.
     current_span_id: Optional[str]
+    # PR #3741: Loop Protection State Flag
+    # Set by fixer_node when AutoFixLoopProtection triggers (max retries exceeded).
+    # Read by should_proceed_after_fixer to route to finalizer instead of ci_monitor.
+    # CRITICAL: This field MUST be defined in AgentState for LangGraph to properly
+    # propagate it between nodes. Without this definition, the flag may be lost.
+    loop_protection_triggered: Optional[bool]
 
 
 def _get_learning_context_for_planner(goal: str, task_type: Optional[str] = None) -> str:


### PR DESCRIPTION
## Summary

Adds the `loop_protection_triggered` field to the `AgentState` TypedDict to ensure proper state propagation between LangGraph nodes.

**Root cause:** PR #3741 added logic to set `state["loop_protection_triggered"] = True` in `fixer_node` and check it in `should_proceed_after_fixer`, but the field was never defined in the `AgentState` TypedDict. Staging logs showed that even when loop protection triggered, the workflow still routed to `ci_monitor` instead of `finalizer` - likely because LangGraph wasn't properly propagating the undefined field.

## Review & Testing Checklist for Human

- [ ] **Verify staging behavior**: After deployment, trigger a loop protection scenario (PR with 3+ fix attempts) and confirm `[FIXER_LOOP_PROTECTION_TO_FINALIZER]` event appears instead of `[FIXER_ROUTING] CI failure auto-fix complete, routing to ci_monitor`
- [ ] **Confirm no recursion errors**: Verify no `Recursion limit of 100 reached` errors occur when loop protection triggers

### Notes

This is a follow-up fix to PR #3741 which added the loop protection routing logic but missed adding the field to the TypedDict schema.

**Requested by:** Ryan Chen (@RC918)  
**Link to Devin run:** https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167