### PR TITLE
feat(epic-d): add P3 enhancements - unit tests, HITL refactor, and sensitive data sanitization

### DIFF
--- a/handoff/20250928/40_App/orchestrator/coder/senior_coder.py
+++ b/handoff/20250928/40_App/orchestrator/coder/senior_coder.py
@@ -118,9 +118,11 @@ _CONTROL_CHAR_PATTERN = re.compile(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]')
 # Sensitive data patterns for redaction (Issue #3749)
 # These patterns match common sensitive data formats that should not appear in logs
 _SENSITIVE_PATTERNS = [
-    # API keys (common formats: sk-xxx, api-xxx, key-xxx with 20+ chars)
+    # API keys (common formats: sk-xxx with 20+ chars, api_key=xxx with 16+ chars)
+    # sk- prefix is specific to OpenAI-style keys
     (re.compile(r'\b(sk-[a-zA-Z0-9]{20,})\b'), '[REDACTED_API_KEY]'),
-    (re.compile(r'\b(api[-_]?key[-_:]?\s*["\']?[a-zA-Z0-9]{16,})\b', re.IGNORECASE), '[REDACTED_API_KEY]'),
+    # Generic api_key pattern requires = or : separator to reduce false positives
+    (re.compile(r'(api[-_]?key\s*[:=]\s*["\']?)[a-zA-Z0-9_-]{16,}(["\']?)', re.IGNORECASE), r'\1[REDACTED_API_KEY]\2'),
     # Bearer tokens
     (re.compile(r'\b(Bearer\s+[a-zA-Z0-9._-]{20,})\b'), '[REDACTED_BEARER_TOKEN]'),
     # JWT tokens (three base64 parts separated by dots)
@@ -162,10 +164,9 @@ def redact_sensitive_data(text: str) -> tuple[str, bool]:
     was_redacted = False
 
     for pattern, replacement in _SENSITIVE_PATTERNS:
-        new_text = pattern.sub(replacement, redacted)
-        if new_text != redacted:
+        redacted, num_replacements = pattern.subn(replacement, redacted)
+        if num_replacements > 0:
             was_redacted = True
-            redacted = new_text
 
     return redacted, was_redacted
 

--- a/handoff/20250928/40_App/orchestrator/coder/tests/test_senior_coder.py
+++ b/handoff/20250928/40_App/orchestrator/coder/tests/test_senior_coder.py
@@ -968,6 +968,30 @@ class TestRedactSensitiveData:
         assert "[REDACTED_PRIVATE_KEY]" in result
         assert was_redacted is True
 
+    def test_api_key_with_equals_separator(self):
+        """Test api_key= format is redacted (requires = or : separator)."""
+        text = "api_key=abcdefghijklmnop1234"
+        result, was_redacted = redact_sensitive_data(text)
+        assert "abcdefghijklmnop1234" not in result
+        assert "[REDACTED_API_KEY]" in result
+        assert was_redacted is True
+
+    def test_api_key_with_colon_separator(self):
+        """Test api_key: format is redacted."""
+        text = "api_key: abcdefghijklmnop1234"
+        result, was_redacted = redact_sensitive_data(text)
+        assert "abcdefghijklmnop1234" not in result
+        assert "[REDACTED_API_KEY]" in result
+        assert was_redacted is True
+
+    def test_api_key_without_separator_not_redacted(self):
+        """Test api_key without = or : is not redacted (reduces false positives)."""
+        text = "apikey_somefunction_name"
+        result, was_redacted = redact_sensitive_data(text)
+        # This should NOT be redacted because it lacks = or : separator
+        assert result == text
+        assert was_redacted is False
+
     def test_multiple_sensitive_items(self):
         """Test multiple sensitive items in same text are all redacted."""
         text = "password=secret123 and api_key=sk-abcdefghijklmnopqrstuvwxyz"

--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -4714,7 +4714,7 @@ def _validate_design_doc_gate(
                 "Please review the SeniorCoder output and ensure proper architecture "
                 "planning before proceeding with implementation."
             ),
-            log_message=f"Invalid ArchitectureSpec triggers HITL gate. missing_fields={missing_fields},",
+            log_message=f"Invalid ArchitectureSpec triggers HITL gate. missing_fields={missing_fields}",
             extra_details={"missing_fields": missing_fields},
         )
 


### PR DESCRIPTION
## Summary

This PR implements three P3 enhancements for EPIC D (Autonomous Coder Agent Family), aligned with Blueprint Section 4.1 Safety Governor v2:

**#3749 - Sensitive Data Sanitization**: Added `redact_sensitive_data()` function that scans text for common sensitive patterns (API keys, passwords, JWT tokens, AWS keys, GitHub tokens, private keys) and replaces them with redaction markers. Integrated into `sanitize_llm_output()` with `redact_sensitive=True` default.

**#3750 - Design Doc Gate HITL Refactor**: Extracted `_escalate_design_doc_gate_failure()` helper to eliminate code duplication between the "missing spec" and "invalid spec" failure cases in `_validate_design_doc_gate()`.

**#3752 - Unit Tests**: Added 56 new tests covering `sanitize_llm_output()` (control chars, whitespace, truncation, type handling, sensitive data) and `redact_sensitive_data()` (all pattern types).

## Updates Since Last Revision

Addressed gemini-code-assist review feedback:
- **Improved API key pattern**: Now requires `=` or `:` separator (e.g., `api_key=xxx`) to reduce false positives on strings like `apikey_somefunction_name`
- **Used `re.subn()`**: More idiomatic and efficient than `pattern.sub()` + string comparison
- **Fixed trailing comma**: Removed stray comma in log_message f-string
- **Added 3 tests**: Verify new API key pattern behavior (with/without separator)

## Review & Testing Checklist for Human

- [ ] **Verify regex patterns** in `_SENSITIVE_PATTERNS` don't produce false positives on legitimate data (e.g., strings that look like but aren't API keys)
- [ ] **Confirm HITL refactor equivalence**: The `_escalate_design_doc_gate_failure()` helper should produce identical state changes as the original inline code
- [ ] **Validate order of operations**: Sensitive data is redacted BEFORE control character removal - confirm this is the correct sequence for security
- [ ] Run tests locally: `cd ~/repos/morningai && source .venv/bin/activate && pytest handoff/20250928/40_App/orchestrator/coder/tests/test_senior_coder.py -v`

### Notes

Requested by: Ryan Chen (@RC918)
Devin session: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167

Follow-up issues created:
- #3754 - Add detailed comments explaining regex pattern behavior
- #3755 - Expand private key patterns to cover more PEM formats

Pre-existing lint warnings (C901 complexity, E501 line length) are unrelated to this PR.