### PR TITLE
test(d4): verify D-4 Self-Correction Loop fix using non-devin branch (PR #3793)

### DIFF
--- a/handoff/20250928/40_App/api-backend/tests/test_d4_non_devin_branch/test_intentional_failure.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_d4_non_devin_branch/test_intentional_failure.py
@@ -1,0 +1,26 @@
+"""
+D-4 Self-Correction Loop Verification Test (Non-Devin Branch)
+
+This test intentionally fails to verify that the D-4 Self-Correction Loop
+is triggered correctly after the race condition fix in PR #3793.
+
+IMPORTANT: This test uses a `test/*` branch instead of `devin/*` because
+the normalizer skips CI failures from `devin/*` and `orchestrator/*` branches
+to prevent self-trigger loops. See normalizer.py _handle_ci_check_completed():
+
+    if branch_lower.startswith("orchestrator/") or branch_lower.startswith("devin/"):
+        return False  # Skip to prevent self-trigger loops
+
+Expected behavior after fix:
+1. PR_OPENED webhook should NOT exhaust loop protection counter
+2. CI_FAILURE webhook should trigger D-4 with [SELF_CORRECTION_INTEGRATION_START]
+3. Loop protection counter should only increment AFTER actual fix attempt
+
+Issue: #3792, #3793
+"""
+
+
+def test_d4_verification_intentional_failure():
+    """This test intentionally fails to trigger D-4 Self-Correction Loop."""
+    # Intentional failure to trigger CI failure and D-4
+    assert 1 == 2, "Intentional failure to verify D-4 fix from PR #3793 (non-devin branch)"


### PR DESCRIPTION
## Summary

This is a **verification test PR** (DO NOT MERGE) to confirm that the D-4 Self-Correction Loop fix from PR #3793 is working correctly.

**Why a non-devin branch?** Previous test PRs using `devin/*` branches were being skipped because the normalizer filters out CI failures from `devin/*` and `orchestrator/*` branches to prevent self-trigger loops. This PR uses a `test/*` branch to bypass that filter.

**Expected behavior after CI fails:**
- Staging logs should show `[SELF_CORRECTION_INTEGRATION_START]` event
- D-4 should be triggered (not `NO_CI_CONTEXT`)
- Loop protection counter should only increment after actual fix attempt

## Review & Testing Checklist for Human

- [ ] **DO NOT MERGE** - Close this PR after verification
- [ ] Check staging logs (DataDog: morningai-backend-v2-stg-worker) for `[SELF_CORRECTION_INTEGRATION_START]` event after CI fails
- [ ] Verify the event appears (confirming PR #3793 fix is working) instead of `NO_CI_CONTEXT`

### Test Plan
1. Wait for CI to fail (API Backend Tests should fail with `assert 1 == 2`)
2. Check staging logs for D-4 trigger event
3. Close this PR after verification

### Notes

- Related Issues: #3792, #3793
- This PR documents the discovery that `devin/*` branches are filtered by the normalizer's self-trigger loop prevention
- Link to Devin run: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167
- Requested by: Ryan Chen (@RC918)