### PR TITLE
fix(epic-d): fetch CI logs from GitHub Actions for D-4 Self-Correction (#3803)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -4909,6 +4909,69 @@ def _attempt_self_correction_fix(
     # Extract test output from CI context
     # CI context may contain: error_summary, failed_check_name, log_excerpt, etc.
     test_output = ci_context.get("log_excerpt", "") or ci_context.get("error_summary", "")
+
+    # Issue #3803: Fetch CI logs from GitHub Actions if error_summary is empty
+    # GitHub Actions annotations (source of error_summary) are not automatically
+    # created by pytest. We need to fetch the actual CI logs using get_ci_test_logs().
+    if not test_output:
+        pr_number = ci_context.get("pr_number")
+        head_sha = ci_context.get("head_sha")
+        if pr_number:
+            try:
+                from tools.github_api import get_ci_test_logs, get_repo
+                repo = get_repo()
+                if repo:
+                    logger.info(
+                        f"[SELF_CORRECTION_INTEGRATION_FETCH_LOGS] Fetching CI logs from GitHub Actions. "
+                        f"pr_number={pr_number}, trace_id={trace_id}",
+                        extra={
+                            "operation": "self_correction_fetch_logs",
+                            "trace_id": trace_id,
+                            "event_code": "SELF_CORRECTION_INTEGRATION_FETCH_LOGS",
+                            "pr_number": pr_number,
+                        }
+                    )
+                    ci_logs_result = get_ci_test_logs(
+                        repo=repo,
+                        pr_number=pr_number,
+                        head_sha=head_sha,
+                        trace_id=trace_id
+                    )
+                    if ci_logs_result.get("success"):
+                        test_output = ci_logs_result.get("logs", "")
+                        logger.info(
+                            f"[SELF_CORRECTION_INTEGRATION_LOGS_FETCHED] Successfully fetched CI logs. "
+                            f"logs_length={len(test_output)}, trace_id={trace_id}",
+                            extra={
+                                "operation": "self_correction_logs_fetched",
+                                "trace_id": trace_id,
+                                "event_code": "SELF_CORRECTION_INTEGRATION_LOGS_FETCHED",
+                                "logs_length": len(test_output),
+                            }
+                        )
+                    else:
+                        logger.warning(
+                            f"[SELF_CORRECTION_INTEGRATION_LOGS_FETCH_FAILED] Failed to fetch CI logs. "
+                            f"error={ci_logs_result.get('error', 'unknown')}, trace_id={trace_id}",
+                            extra={
+                                "operation": "self_correction_logs_fetch_failed",
+                                "trace_id": trace_id,
+                                "event_code": "SELF_CORRECTION_INTEGRATION_LOGS_FETCH_FAILED",
+                                "error": ci_logs_result.get("error", "unknown"),
+                            }
+                        )
+            except Exception as fetch_err:
+                logger.warning(
+                    f"[SELF_CORRECTION_INTEGRATION_LOGS_FETCH_ERROR] Error fetching CI logs: {fetch_err}. "
+                    f"trace_id={trace_id}",
+                    extra={
+                        "operation": "self_correction_logs_fetch_error",
+                        "trace_id": trace_id,
+                        "event_code": "SELF_CORRECTION_INTEGRATION_LOGS_FETCH_ERROR",
+                        "error": str(fetch_err)[:100],
+                    }
+                )
+
     if not test_output:
         logger.info(
             f"[SELF_CORRECTION_INTEGRATION_NO_TEST_OUTPUT] No test output in CI context. "


### PR DESCRIPTION
## Summary

Fixes D-4 Self-Correction Loop not receiving test output when `error_summary` is empty. 

**Root cause**: GitHub Actions annotations (the source of `error_summary`) are not automatically created by pytest test failures. The `CiFailureContext` had a `logs_url` field but the actual log content was never fetched.

**Fix**: When `error_summary` is empty, call the existing `get_ci_test_logs()` function (already used by Discovery Audit) to fetch actual CI logs from GitHub Actions API.

New telemetry event codes:
- `[SELF_CORRECTION_INTEGRATION_FETCH_LOGS]` - Starting log fetch
- `[SELF_CORRECTION_INTEGRATION_LOGS_FETCHED]` - Successfully fetched logs  
- `[SELF_CORRECTION_INTEGRATION_LOGS_FETCH_FAILED]` - Failed to fetch logs
- `[SELF_CORRECTION_INTEGRATION_LOGS_FETCH_ERROR]` - Error during fetch

## Review & Testing Checklist for Human

- [ ] **Verify API rate limits**: This adds a GitHub API call when error_summary is empty. Check if this could cause rate limiting issues in high-volume scenarios.
- [ ] **End-to-end test**: Create a test PR with intentional pytest failure (non-devin branch) and verify staging logs show `[SELF_CORRECTION_INTEGRATION_LOGS_FETCHED]` followed by `[SELF_CORRECTION_INTEGRATION_START]`
- [ ] **Verify log content quality**: Check that the fetched logs contain enough context for TestLogParser to extract failure information

**Recommended test plan**: 
1. Merge this PR
2. Use test PR #3802 (or create new one) with intentional test failure
3. Check staging logs for the new `FETCH_LOGS` event codes
4. Confirm D-4 Self-Correction now proceeds past the `NO_TEST_OUTPUT` error

### Notes

Related to investigation of why test_output was empty in PR #3802 verification.

Link to Devin run: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167
Requested by: Ryan Chen (@RC918)