### PR TITLE
fix(epic-d): skip auth header for Azure Blob Storage logs URLs (#3805)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -2151,8 +2151,24 @@ def get_ci_test_logs(
 
             # Sanity check: ensure logs_url is a valid HTTP(S) URL string
             if logs_url and isinstance(logs_url, str) and logs_url.startswith(("http://", "https://")):
-                # Download logs using GitHub token
-                headers = {"Authorization": f"token {GITHUB_TOKEN}"}
+                # Issue #3805: Azure Blob Storage URLs don't need GitHub token
+                # GitHub Actions logs_url may point to Azure Blob Storage with pre-signed SAS token.
+                # Sending GitHub token to Azure causes HTTP 403 "AuthenticationFailed" error.
+                # Only include Authorization header for GitHub API URLs.
+                is_azure_blob = "blob.core.windows.net" in logs_url
+                if is_azure_blob:
+                    headers = {}
+                    logger.debug(
+                        "[GitHub] get_ci_test_logs: Using Azure Blob Storage URL (no auth header)",
+                        extra={
+                            "operation": "get_ci_test_logs",
+                            "trace_id": trace_id,
+                            "pr_number": pr_number,
+                            "url_type": "azure_blob"
+                        }
+                    )
+                else:
+                    headers = {"Authorization": f"token {GITHUB_TOKEN}"}
                 response = requests.get(logs_url, headers=headers, timeout=30)
 
                 if response.status_code == 200:


### PR DESCRIPTION
## Summary

Fixes HTTP 403 "AuthenticationFailed" error when D-4 Self-Correction Loop tries to fetch CI logs from GitHub Actions.

**Root cause:** GitHub Actions `logs_url` points to Azure Blob Storage with a pre-signed SAS token. The code was unconditionally adding `Authorization: token {GITHUB_TOKEN}` header, but Azure Blob Storage doesn't understand GitHub tokens and returns 403.

**Fix:** Check if the URL contains `blob.core.windows.net` and skip the Authorization header for Azure Blob Storage URLs (they authenticate via SAS token in the query string).

**Verified locally:** PR #3804 logs now download successfully (230KB).

## Review & Testing Checklist for Human

- [ ] Verify the Azure Blob Storage URL detection (`blob.core.windows.net`) is sufficient for all GitHub-hosted runners
- [ ] After merging, trigger a new CI failure on test PR #3804 and check staging logs for `[SELF_CORRECTION_INTEGRATION_LOGS_FETCHED]` event with successful log content

### Notes

This is a follow-up fix to PR #3803 which added the CI logs fetch capability. The fetch logic was working but failing due to this authentication issue.

**Staging log evidence (before fix):**
```
[SELF_CORRECTION_INTEGRATION_LOGS_FETCH_FAILED] Failed to fetch CI logs. error=Failed to download logs: HTTP 403
```

Link to Devin run: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167
Requested by: Ryan Chen (@RC918)