### PR TITLE
fix(epic-d): only increment loop protection counter for CI failure events (#3816)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -6503,9 +6503,12 @@ def fixer_node(state: AgentState) -> AgentState:
     # Issue #3792: Increment loop protection counter AFTER actual fix attempt
     # This prevents race condition where PR_OPENED webhook exhausts counter
     # before CI_FAILURE webhook arrives with proper context
+    # Issue #3816: Only increment counter for CI failure events (ci_failure_trigger=True)
+    # to prevent PR_OPENED events from consuming D-4 Self-Correction Loop attempts
+    ci_failure_trigger = state.get("ci_failure_trigger")
     _loop_protection = state.get("_loop_protection")
     _loop_protection_pr_id = state.get("_loop_protection_pr_id")
-    if _loop_protection and _loop_protection_pr_id:
+    if ci_failure_trigger and _loop_protection and _loop_protection_pr_id:
         try:
             new_count = _loop_protection.increment(_loop_protection_pr_id)
             logger.info(


### PR DESCRIPTION
## Summary

Fixes D-4 Self-Correction Loop being blocked by Loop Protection counter exhaustion. The root cause was that PR_OPENED events were incrementing the loop protection counter before CI failure events arrived, consuming all 3 allowed attempts.

**Before**: Counter incremented for ALL events entering `fixer_node` (PR_OPENED, PR_REVIEWED, CI_CHECK_COMPLETED)
**After**: Counter only incremented when `ci_failure_trigger=True` (actual CI failure events)

## Review & Testing Checklist for Human

- [ ] Verify `ci_failure_trigger` is correctly set for CI failure events (depends on PR #3815 fix)
- [ ] Deploy to staging and create a fresh test PR with intentional CI failure
- [ ] Check staging logs for `[AutoFixLoopProtection] Attempt recorded after fix` - should only appear for CI failure events, not PR_OPENED events
- [ ] Verify D-4 Self-Correction Loop triggers successfully (look for `[D4_SELF_CORRECTION_START]` in logs)

### Notes

This is a minimal fix that addresses the resource cannibalization issue identified in the analysis report. The change adds one condition check to ensure only CI failure events consume loop protection attempts.

**Requested by**: Ryan Chen (@RC918)
**Devin session**: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167