### PR TITLE
test(d4): final D-4 Self-Correction Loop verification after PR #3817 fix

### DIFF
--- a/handoff/20250928/40_App/api-backend/tests/test_d4_final_verify/test_intentional_failure.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_d4_final_verify/test_intentional_failure.py
@@ -22,4 +22,4 @@ def test_intentional_failure_for_d4_verification():
     D-4 should detect this failure and attempt to fix it by changing
     the assertion from `assert False` to `assert True`.
     """
-    assert False, "Intentional failure to verify D-4 Self-Correction Loop after PR #3819 diagnostic logs"
+    assert False, "Intentional failure to verify D-4 Self-Correction Loop after PR #3820 orchestrator diagnostic logs"


### PR DESCRIPTION
## Summary

Intentional test failure to verify D-4 Self-Correction Loop is working correctly after PR #3817 fix. The fix ensured Loop Protection counter only increments for CI failure events (`ci_failure_trigger=True`), not PR_OPENED events.

**DO NOT MERGE** - This PR is for verification purposes only.

## Review & Testing Checklist for Human

- [ ] Wait for CI to fail on this PR
- [ ] Check staging logs for `[D4_SELF_CORRECTION_START]` event - this confirms D-4 triggered
- [ ] Verify `[AutoFixLoopProtection] Attempt recorded after fix` only appears AFTER CI failure event, not after PR_OPENED events
- [ ] If D-4 triggers successfully, close this PR without merging

### Expected Behavior

1. CI fails due to `assert False` in test
2. D-4 detects CI failure (branch is `test/*`, not `devin/*`)
3. D-4 attempts to fix by changing `assert False` to `assert True`
4. Loop Protection counter increments only once (for CI failure event)

### Notes

This verifies the fix from PR #3817 which addressed the "resource cannibalization" issue where PR_OPENED events were consuming Loop Protection attempts before CI failure events arrived.

**Requested by**: Ryan Chen (@RC918)
**Devin session**: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167