### PR TITLE
feat(epic-d): add D-4 diagnostic logs in orchestrator for staging visibility (#3818)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -9630,6 +9630,26 @@ def run_orchestrator(
         # Issue #3510: Pass CiFailureContext for structured CI error propagation
         if context and (ci_context := context.get("ci_failure_context")):
             initial_state["ci_failure_context"] = ci_context
+            # Issue #3818: Diagnostic log for ci_failure_context to debug D-4 file path extraction
+            # This helps identify why error_summary might be empty
+            error_summary = ci_context.get("error_summary", "")
+            check_suite_id = ci_context.get("check_suite_id")
+            logger.info(
+                f"[D4_CI_CONTEXT_DIAGNOSTIC] ci_failure_context received. "
+                f"error_summary_len={len(error_summary) if error_summary else 0}, "
+                f"check_suite_id={check_suite_id}, trace_id={trace_id}",
+                extra={
+                    "operation": "d4_ci_context_diagnostic",
+                    "trace_id": trace_id,
+                    "pr_number": pr_number,
+                    "check_suite_id": check_suite_id,
+                    "check_suite_id_type": type(check_suite_id).__name__ if check_suite_id is not None else "NoneType",
+                    "error_summary_present": bool(error_summary),
+                    "error_summary_len": len(error_summary) if error_summary else 0,
+                    "error_summary_preview": error_summary[:200] if error_summary else "",
+                    "ci_context_keys": list(ci_context.keys()),
+                }
+            )
             # Issue #3695: Extract branch from ci_failure_context for GeneralCoder
             # Without this, GeneralCoder gate fails with "Missing repo or branch"
             # because branch is not passed from normalizer to initial_state


### PR DESCRIPTION
## Summary

Adds diagnostic logging in `langgraph_orchestrator.py` to debug why D-4 Self-Correction Loop is not extracting file paths from CI failures. 

**Background:** PR #3819 added diagnostic logs in `normalizer.py`, but those logs weren't visible in staging because the normalizer runs in a different service (API backend) than the orchestrator worker (`morningai-backend-v2-stg-worker`). This PR adds the diagnostic logs in the correct location where they will be visible.

**What's logged:**
- `error_summary` length and preview (first 200 chars)
- `check_suite_id` value and type
- All keys present in `ci_failure_context`

Search for `D4_CI_CONTEXT_DIAGNOSTIC` or `d4_ci_context_diagnostic` in staging logs after deployment.

## Review & Testing Checklist for Human

- [ ] Verify log format matches existing patterns in `langgraph_orchestrator.py`
- [ ] After deployment, trigger CI failure on test PR #3818 and search for `D4_CI_CONTEXT_DIAGNOSTIC` in `morningai-backend-v2-stg-worker` logs
- [ ] Confirm `error_summary_preview` truncation to 200 chars is sufficient for debugging without being too verbose

### Notes

This is a **temporary diagnostic log** to identify why `error_summary` is empty in `ci_failure_context`. Once the root cause is identified and fixed, this log should be removed or converted to DEBUG level.

**Requested by**: Ryan Chen (@RC918)
**Devin session**: https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167