### PR TITLE
fix(epic-d): add check_suite_id to CiFailureContext for D-4 (#3821)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/core/flow/schema.py
+++ b/handoff/20250928/40_App/orchestrator/core/flow/schema.py
@@ -202,6 +202,9 @@ class CiFailureContext:
     logs_url: Optional[str] = None  # URL to CI logs for reference
     error_summary: Optional[str] = None  # Top N error lines/annotations (if available)
     check_run_id: Optional[int] = None  # GitHub check_run ID for API lookups
+    # Issue #3821: Add check_suite_id for D-4 Self-Correction Loop
+    # This is needed to fetch failed check runs from GitHub API to extract error_summary
+    check_suite_id: Optional[int] = None  # GitHub check_suite ID for API lookups
 
     def to_dict(self) -> dict:
         """Convert to JSON-serializable dict for RQ queue serialization.
@@ -219,6 +222,7 @@ class CiFailureContext:
             "logs_url": self.logs_url,
             "error_summary": self.error_summary,
             "check_run_id": self.check_run_id,
+            "check_suite_id": self.check_suite_id,  # Issue #3821
         }
 
     @classmethod
@@ -241,6 +245,7 @@ class CiFailureContext:
             logs_url=data.get("logs_url"),
             error_summary=data.get("error_summary"),
             check_run_id=data.get("check_run_id"),
+            check_suite_id=data.get("check_suite_id"),  # Issue #3821
         )
 
 

--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -2241,6 +2241,7 @@ class EventNormalizer:
                 logs_url=metadata.get("ci_logs_url"),
                 error_summary=ci_error_summary,
                 check_run_id=metadata.get("ci_check_run_id"),
+                check_suite_id=check_suite_id,  # Issue #3821: Pass check_suite_id for D-4
             )
             # Use to_dict() for JSON serialization compatibility with RQ queue
             # The worker will use CiFailureContext.from_dict() to reconstruct


### PR DESCRIPTION
## Summary

Fixes the root cause of D-4 Self-Correction Loop not being triggered. Diagnostic logs from PR #3820 revealed that `check_suite_id=None` was being passed to the orchestrator, which prevented `_fetch_failed_check_runs` from being called, resulting in empty `error_summary` and D-4 failing to extract file paths.

**Root cause:** `CiFailureContext` dataclass was missing the `check_suite_id` field, so even though `check_suite_id` was available in normalizer (line 2030), it was never passed to the dataclass constructor.

**Changes:**
- Add `check_suite_id: Optional[int] = None` field to `CiFailureContext`
- Update `to_dict()` and `from_dict()` for serialization
- Pass `check_suite_id` to `CiFailureContext` constructor in normalizer

## Review & Testing Checklist for Human

- [ ] Verify `check_suite_id` is populated at line 2030 in normalizer before `CiFailureContext` is constructed (line 2235)
- [ ] After deployment, trigger CI failure on test PR #3818 and check staging logs for `[D4_CI_CONTEXT_DIAGNOSTIC]` - `check_suite_id` should NOT be None
- [ ] Verify `error_summary_len` is > 0 in diagnostic logs (confirms `_fetch_failed_check_runs` was called)

### Notes

This is a low-risk change - just wiring through an existing variable that was already available but not being passed. Backward compatible with `Optional[int] = None` default.

**Devin run:** https://app.devin.ai/sessions/45c687b0030a46e78cb181beee726167
**Requested by:** @RC918