### PR TITLE
feat(reviewer): expand review coverage to include docs: and chore: PRs

### DIFF
--- a/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/normalizer.py
@@ -310,7 +310,7 @@ def should_skip_orchestrator_pr_event(event: "WebhookEvent") -> bool:
 # Smart PR Filtering - Trigger Threshold Layer (Dec 2025, Updated Jan 2026)
 # =============================================================================
 # These filters determine if a PR event is "worth documenting" based on:
-# 1. Semantic title prefix (ci/test/style/build = skip)
+# 1. Semantic title prefix (ci/test/tests/style/build = skip)
 # 2. File path patterns (config/docs/tests/CI only = skip)
 #
 # This is separate from the "orchestrator self-loop prevention" layer above.
@@ -326,7 +326,7 @@ def should_skip_orchestrator_pr_event(event: "WebhookEvent") -> bool:
 
 # Title prefixes that indicate non-actionable changes (skip review)
 # Blueprint alignment: docs: and chore: are now reviewed (removed from skip list)
-# Only ci/test/style/build PRs are skipped as they are typically auto-generated or trivial
+# Only ci/test/tests/style/build PRs are skipped as they are typically auto-generated or trivial
 SKIP_TITLE_PREFIXES = (
     "ci:",
     "ci(",

--- a/handoff/20250928/40_App/orchestrator/webhooks/tests/test_garbage_pr_fix.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/tests/test_garbage_pr_fix.py
@@ -609,11 +609,15 @@ from ..normalizer import (  # noqa: E402
 class TestTitleIsNonActionable:
     """Tests for _title_is_non_actionable() semantic title filter"""
 
-    def test_chore_prefix_is_non_actionable(self):
-        """Test that chore: prefix is non-actionable"""
-        assert _title_is_non_actionable("chore: update dependencies") is True
-        assert _title_is_non_actionable("chore(deps): bump version") is True
-        assert _title_is_non_actionable("Chore: Update something") is True
+    def test_chore_prefix_is_actionable(self):
+        """Test that chore: prefix is actionable (Blueprint alignment Jan 2026)
+        
+        chore: PRs are now reviewed because they can contain security-sensitive
+        configuration changes. See: MorningAI_Ecosystem_Blueprint_2025_Final.md
+        """
+        assert _title_is_non_actionable("chore: update dependencies") is False
+        assert _title_is_non_actionable("chore(deps): bump version") is False
+        assert _title_is_non_actionable("Chore: Update something") is False
 
     def test_ci_prefix_is_non_actionable(self):
         """Test that ci: prefix is non-actionable"""
@@ -627,10 +631,14 @@ class TestTitleIsNonActionable:
         assert _title_is_non_actionable("tests: improve coverage") is True
         assert _title_is_non_actionable("test(api): add integration tests") is True
 
-    def test_docs_prefix_is_non_actionable(self):
-        """Test that docs: prefix is non-actionable"""
-        assert _title_is_non_actionable("docs: update README") is True
-        assert _title_is_non_actionable("docs(api): add examples") is True
+    def test_docs_prefix_is_actionable(self):
+        """Test that docs: prefix is actionable (Blueprint alignment Jan 2026)
+        
+        docs: PRs are now reviewed because they can contain bugs like incorrect
+        line references or outdated API docs. See: MorningAI_Ecosystem_Blueprint_2025_Final.md
+        """
+        assert _title_is_non_actionable("docs: update README") is False
+        assert _title_is_non_actionable("docs(api): add examples") is False
 
     def test_style_prefix_is_non_actionable(self):
         """Test that style: prefix is non-actionable"""
@@ -830,15 +838,19 @@ class TestShouldSkipPrBySmartFilters:
         assert should_skip is False
         assert reason == "not_pr_event"
 
-    def test_pr_opened_with_chore_title_skipped(self):
-        """Test that PR_OPENED with chore: title is skipped"""
+    def test_pr_opened_with_chore_title_not_skipped(self):
+        """Test that PR_OPENED with chore: title is NOT skipped (Blueprint alignment Jan 2026)
+        
+        chore: PRs are now reviewed because they can contain security-sensitive
+        configuration changes. See: MorningAI_Ecosystem_Blueprint_2025_Final.md
+        """
         event = create_mock_event(
             event_type=WebhookEventType.PR_OPENED,
             title="chore: update dependencies",
         )
         should_skip, reason, details = should_skip_pr_by_smart_filters(event)
-        assert should_skip is True
-        assert reason == "semantic_title_skip"
+        # chore: is no longer skipped - it will either pass all filters or fail open on API error
+        assert should_skip is False or "api_error" in reason
 
     def test_pr_merged_with_ci_title_skipped(self):
         """Test that PR_MERGED with ci: title is skipped"""
@@ -876,23 +888,31 @@ class TestShouldSkipPrBySmartFilters:
 class TestSmartFilterIntegration:
     """Integration tests for smart filtering in is_actionable()"""
 
-    def test_pr_opened_with_chore_title_not_actionable(self, event_normalizer):
-        """Test that PR_OPENED with chore: title is not actionable"""
+    def test_pr_opened_with_chore_title_is_actionable(self, event_normalizer):
+        """Test that PR_OPENED with chore: title IS actionable (Blueprint alignment Jan 2026)
+        
+        chore: PRs are now reviewed because they can contain security-sensitive
+        configuration changes. See: MorningAI_Ecosystem_Blueprint_2025_Final.md
+        """
         event = create_mock_event(
             event_type=WebhookEventType.PR_OPENED,
             title="chore: update dependencies",
             raw_payload={"pull_request": {"head": {"ref": "feature/update-deps"}}},
         )
-        assert event_normalizer.is_actionable(event) is False
+        assert event_normalizer.is_actionable(event) is True
 
-    def test_pr_merged_with_docs_title_not_actionable(self, event_normalizer):
-        """Test that PR_MERGED with docs: title is not actionable"""
+    def test_pr_merged_with_docs_title_is_actionable(self, event_normalizer):
+        """Test that PR_MERGED with docs: title IS actionable (Blueprint alignment Jan 2026)
+        
+        docs: PRs are now reviewed because they can contain bugs like incorrect
+        line references or outdated API docs. See: MorningAI_Ecosystem_Blueprint_2025_Final.md
+        """
         event = create_mock_event(
             event_type=WebhookEventType.PR_MERGED,
             title="docs: update README",
             raw_payload={"pull_request": {"head": {"ref": "docs/update-readme"}}},
         )
-        assert event_normalizer.is_actionable(event) is False
+        assert event_normalizer.is_actionable(event) is True
 
     def test_pr_opened_with_test_title_not_actionable(self, event_normalizer):
         """Test that PR_OPENED with test: title is not actionable"""
@@ -926,13 +946,16 @@ class TestSmartFilterLogging:
     """Tests for smart filter logging"""
 
     def test_semantic_title_skip_logging(self, caplog):
-        """Test that semantic title skip logs contain required fields"""
+        """Test that semantic title skip logs contain required fields
+        
+        Note: Using ci: prefix since chore: is no longer skipped (Blueprint alignment Jan 2026)
+        """
         import logging
         caplog.set_level(logging.INFO)
 
         event = create_mock_event(
             event_type=WebhookEventType.PR_OPENED,
-            title="chore: update dependencies",
+            title="ci: update workflow",  # Changed from chore: to ci: since chore: is no longer skipped
         )
         event.resource_id = "123"
 


### PR DESCRIPTION
## Summary

Removes `docs:` and `chore:` from `SKIP_TITLE_PREFIXES` in the Smart PR Filtering mechanism to align with the Blueprint North Star vision: "讓 AI 自己規劃、自己寫程式、**自己審查**、自己測試、自己部屬、自己監控、自己修復"

**Rationale**: 
- `docs:` PRs can contain bugs (e.g., incorrect line references, outdated API docs) - as demonstrated by PR #3824 which had a line reference error
- `chore:` PRs can contain security-sensitive configuration changes

**What still gets skipped**: `ci:`, `test:`, `tests:`, `style:`, `build:` PRs (typically auto-generated or trivial)

## Updates since last revision

- **Comment consistency fix** (gemini-code-assist suggestion): Updated comments to include `tests:` prefix in the skip list documentation
- **Test updates**: Updated 6 tests that expected `docs:` and `chore:` PRs to be skipped - they now verify these PRs are actionable (Blueprint alignment)

## Review & Testing Checklist for Human

- [ ] **Verify Blueprint alignment**: Confirm this change matches the intended architectural direction for MorningAI Reviewer Agent coverage
- [ ] **Cost/noise assessment**: Consider the increased API costs and potential noise from reviewing more PRs - is this acceptable?
- [ ] **Verify test logic**: Review the updated tests to ensure they correctly verify the new behavior (chore:/docs: PRs should now be actionable)

**Test plan**: Create a test PR with `docs:` or `chore:` prefix and verify MorningAI Reviewer Agent appears on it.

### Notes

This change was prompted by investigating why MorningAI Reviewer Agent didn't appear on PR #3824 (a `docs:` PR). The investigation revealed Smart PR Filtering was intentionally skipping docs: PRs, which conflicts with the Blueprint's "self-review" vision.

**Note on CI**: The `validate` job failure is an infrastructure issue (502 on `/api/business-intelligence/summary`) unrelated to this PR.

**Link to Devin run**: https://app.devin.ai/sessions/30d4ae86ad66455ab79bdcbd9a451467
**Requested by**: Ryan Chen (@RC918)