### PR TITLE
fix(planner): address Phase F-0 follow-up issues (#3833, #3834, #3835)

### DIFF
--- a/.github/workflows/orchestrator-integration-tests.yml
+++ b/.github/workflows/orchestrator-integration-tests.yml
@@ -84,6 +84,17 @@ jobs:
           cd ../api-backend
           pip install -r requirements.txt
       
+      - name: Run orchestrator unit tests
+        run: |
+          pytest handoff/20250928/40_App/orchestrator/tests/ \
+            -v --tb=short --disable-warnings \
+            --timeout=60 \
+            --junitxml=unit-test-results.xml
+        env:
+          PYTHONPATH: ${{ github.workspace }}/handoff/20250928/40_App/orchestrator:${{ github.workspace }}/handoff/20250928/40_App/api-backend/src:${{ github.workspace }}
+          REDIS_URL: redis://localhost:6379/0
+          TESTING: true
+      
       - name: Run redis_queue integration tests
         run: |
           pytest handoff/20250928/40_App/orchestrator/redis_queue/tests/ \
@@ -114,6 +125,7 @@ jobs:
         with:
           name: integration-test-results
           path: |
+            unit-test-results.xml
             integration-test-results.xml
             fault-injection-test-results.xml
           retention-days: 30

--- a/handoff/20250928/40_App/orchestrator/core/planner/consumer.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/consumer.py
@@ -19,6 +19,29 @@ from typing import Any, Dict, List, Optional, Protocol, Set
 from .planner_types import PlannerOutput, TaskNode
 
 
+def _sanitize_for_log(value: str, max_length: int = 200) -> str:
+    """
+    Sanitize untrusted data for safe inclusion in log messages.
+
+    Prevents log injection by:
+    - Replacing newlines and carriage returns
+    - Truncating to max_length
+
+    Args:
+        value: The untrusted string to sanitize
+        max_length: Maximum length of output (default 200)
+
+    Returns:
+        Sanitized string safe for logging
+    """
+    if not value:
+        return ""
+    sanitized = value.replace('\n', '\\n').replace('\r', '\\r')
+    if len(sanitized) > max_length:
+        sanitized = sanitized[:max_length] + "..."
+    return sanitized
+
+
 class ExecutionStatus(Enum):
     """Status of task or plan execution"""
     PENDING = "pending"
@@ -229,7 +252,7 @@ class BasePlanConsumer(ABC):
                 plan_id=plan.plan_id,
                 status=ExecutionStatus.FAILED,
                 task_results=[],
-                error_summary=f"Plan validation failed: {'; '.join(errors)}",
+                error_summary=f"Plan validation failed: {'; '.join(_sanitize_for_log(e) for e in errors)}",
             )
 
         completed: Set[str] = set()
@@ -247,16 +270,22 @@ class BasePlanConsumer(ABC):
 
                 if result.status == ExecutionStatus.COMPLETED:
                     completed.add(task.task_id)
+                elif result.status == ExecutionStatus.SKIPPED:
+                    # Skipped tasks should not block dependents (Issue #3834)
+                    completed.add(task.task_id)
                 elif result.status == ExecutionStatus.FAILED:
                     # Stop on failure (could be configurable)
                     end_time = datetime.now(timezone.utc)
                     duration = int((end_time - start_time).total_seconds() / 60)
+                    # Sanitize task_id and error_message to prevent log injection (Issue #3833)
+                    safe_task_id = _sanitize_for_log(task.task_id)
+                    safe_error = _sanitize_for_log(result.error_message or "")
                     return ExecutionResult(
                         plan_id=plan.plan_id,
                         status=ExecutionStatus.FAILED,
                         task_results=task_results,
                         total_duration_minutes=duration,
-                        error_summary=f"Task {task.task_id} failed: {result.error_message}",
+                        error_summary=f"Task {safe_task_id} failed: {safe_error}",
                     )
 
         end_time = datetime.now(timezone.utc)

--- a/handoff/20250928/40_App/orchestrator/core/planner/planner_types.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/planner_types.py
@@ -24,6 +24,29 @@ from typing import Any, Dict, List, Optional, Set
 import uuid
 
 
+def _sanitize_task_id(task_id: str, max_length: int = 100) -> str:
+    """
+    Sanitize task_id for safe inclusion in error messages.
+
+    Prevents log injection by:
+    - Replacing newlines and carriage returns
+    - Truncating to max_length
+
+    Args:
+        task_id: The task_id to sanitize
+        max_length: Maximum length of output (default 100)
+
+    Returns:
+        Sanitized string safe for error messages
+    """
+    if not task_id:
+        return ""
+    sanitized = task_id.replace('\n', '\\n').replace('\r', '\\r')
+    if len(sanitized) > max_length:
+        sanitized = sanitized[:max_length] + "..."
+    return sanitized
+
+
 class TaskType(Enum):
     """
     Types of tasks in a plan
@@ -276,9 +299,13 @@ class TaskTree:
         node_ids = {node.task_id for node in self.nodes}
         for edge in self.edges:
             if edge.from_task not in node_ids:
-                errors.append(f"Edge references unknown source task: {edge.from_task}")
+                # Sanitize task_id to prevent log injection (Issue #3833)
+                safe_from = _sanitize_task_id(edge.from_task)
+                errors.append(f"Edge references unknown source task: {safe_from}")
             if edge.to_task not in node_ids:
-                errors.append(f"Edge references unknown target task: {edge.to_task}")
+                # Sanitize task_id to prevent log injection (Issue #3833)
+                safe_to = _sanitize_task_id(edge.to_task)
+                errors.append(f"Edge references unknown target task: {safe_to}")
 
         # Check for cycles using DFS
         if not errors:


### PR DESCRIPTION
## Summary

This PR addresses three follow-up issues identified during the Phase F-0 (Planner v3 unified schema) code review:

1. **Security Fix (#3833)**: Added sanitization for untrusted data in error messages to prevent log injection attacks. Task IDs and error messages from LLM-generated plans could contain newlines that forge log entries.

2. **Bug Fix (#3834)**: Fixed SKIPPED task handling in `BasePlanConsumer.execute_plan()`. Previously, SKIPPED tasks were not added to the `completed` set, causing dependent tasks to never become executable.

3. **CI Fix (#3835)**: Added orchestrator unit tests (`tests/`) to the CI pipeline. The `test_planner_types.py` tests were not being executed because only `redis_queue/tests/` was configured.

## Review & Testing Checklist for Human

- [ ] **Verify SKIPPED task behavior change is intentional**: The fix treats SKIPPED tasks as "completed" for dependency resolution. Confirm this aligns with expected semantics (SKIPPED = "processed, can proceed" vs "failed, should block").

- [ ] **Review sanitization completeness**: The sanitization only handles `\n` and `\r`. Consider if other control characters or escape sequences need handling for your security requirements.

- [ ] **Test CI workflow**: Verify the new "Run orchestrator unit tests" step executes correctly and doesn't break existing integration tests.

**Recommended Test Plan:**
1. Merge and observe CI - the new unit test step should run and pass
2. Manually verify that a plan with SKIPPED tasks allows dependent tasks to execute

### Notes

- Two similar sanitization functions were added (`_sanitize_for_log` in consumer.py, `_sanitize_task_id` in planner_types.py) - could be consolidated in a future refactor
- No unit tests were added for the sanitization functions themselves

---
*Link to Devin run: https://app.devin.ai/sessions/639f210ad15f44db88d1dccaf0c0aef8*
*Requested by: Ryan Chen (@RC918)*