### PR TITLE
feat(planner): add Phase F-1 adapter layer for unified PlannerOutput

### DIFF
--- a/handoff/20250928/40_App/orchestrator/core/planner/__init__.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/__init__.py
@@ -34,6 +34,12 @@ from .consumer import (
     DryRunPlanConsumer,
 )
 
+from .adapters import (
+    adapt_llm_planner_output,
+    adapt_task_planner_output,
+    adapt_pm_agent_output,
+)
+
 __all__ = [
     # Planner types
     "TaskType",
@@ -54,4 +60,8 @@ __all__ = [
     "PlanConsumer",
     "BasePlanConsumer",
     "DryRunPlanConsumer",
+    # Adapters (Phase F-1)
+    "adapt_llm_planner_output",
+    "adapt_task_planner_output",
+    "adapt_pm_agent_output",
 ]

--- a/handoff/20250928/40_App/orchestrator/core/planner/adapters.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/adapters.py
@@ -1,0 +1,433 @@
+"""
+Planner Adapters - Phase F-1 Unified Output Conversion
+
+EPIC F Phase F-1: Planner Adapter Layer
+
+This module provides adapter functions to convert output from existing planners
+(LLMPlannerAdapter, TaskPlanner, PMAgent) to the unified PlannerOutput format
+defined in Phase F-0.
+
+Blueprint Reference: Section 3.1 (Planner v3 - Unified Planning Interface)
+"""
+
+import logging
+import uuid
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from .planner_types import (
+    CostEstimate,
+    EdgeType,
+    PlannerMetadata,
+    PlannerOutput,
+    PlanType,
+    RiskLevel,
+    RiskMetadata,
+    TaskEdge,
+    TaskNode,
+    TaskTree,
+    TaskType,
+)
+
+if TYPE_CHECKING:
+    from orchestrator.meta_agent.task_planner import TaskPlan
+    from orchestrator.pm_agent.agent import PMAdvisory
+
+logger = logging.getLogger(__name__)
+
+
+# Mapping from TaskPlanner SubTaskType to unified TaskType
+SUBTASK_TYPE_TO_TASK_TYPE: Dict[str, TaskType] = {
+    "setup_environment": TaskType.SETUP,
+    "analyze_code": TaskType.ANALYZE,
+    "write_code": TaskType.CODE,
+    "write_test": TaskType.TEST,
+    "run_test": TaskType.TEST,
+    "code_review": TaskType.REVIEW,
+    "documentation": TaskType.DOCUMENT,
+    "deployment": TaskType.DEPLOY,
+    "verification": TaskType.VERIFY,
+    "cleanup": TaskType.CLEANUP,
+}
+
+# Mapping from PMAgent task types to unified TaskType
+PM_TASK_TYPE_TO_TASK_TYPE: Dict[str, TaskType] = {
+    "documentation": TaskType.DOCUMENT,
+    "bug_fix": TaskType.CODE,
+    "feature": TaskType.CODE,
+    "refactor": TaskType.CODE,
+    "test": TaskType.TEST,
+    "config": TaskType.SETUP,
+    "security": TaskType.CODE,
+    "performance": TaskType.CODE,
+    "unknown": TaskType.CODE,
+}
+
+# Mapping from PMRisk to RiskLevel
+PM_RISK_TO_RISK_LEVEL: Dict[str, RiskLevel] = {
+    "critical": RiskLevel.CRITICAL,
+    "high": RiskLevel.HIGH,
+    "medium": RiskLevel.MEDIUM,
+    "low": RiskLevel.LOW,
+    "info": RiskLevel.LOW,
+}
+
+# Effort to duration mapping (minutes)
+EFFORT_TO_DURATION: Dict[str, int] = {
+    "small": 15,
+    "medium": 30,
+    "large": 60,
+}
+
+
+def adapt_llm_planner_output(
+    llm_result: Dict[str, Any],
+    goal: str = "",
+    trace_id: Optional[str] = None,
+) -> PlannerOutput:
+    """
+    Convert LLMPlannerAdapter output to unified PlannerOutput format.
+
+    Args:
+        llm_result: Output from LLMPlannerAdapter.generate_plan()
+            Expected keys: plan, plan_details, planner_type, task_type,
+                          planning_time_ms, provider
+        goal: Original goal/request
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        PlannerOutput with converted task tree
+    """
+    trace_id = trace_id or str(uuid.uuid4())
+    plan_id = str(uuid.uuid4())
+
+    logger.info(
+        "[Adapter] Converting LLMPlannerAdapter output to PlannerOutput",
+        extra={"operation": "adapt_llm_planner", "trace_id": trace_id}
+    )
+
+    # Extract plan steps
+    plan_steps = llm_result.get("plan", [])
+    plan_details = llm_result.get("plan_details", [])
+
+    # Build TaskNodes from plan steps
+    nodes: List[TaskNode] = []
+    edges: List[TaskEdge] = []
+
+    for i, step in enumerate(plan_steps):
+        task_id = f"task-{i + 1}"
+
+        # Get details if available
+        detail = plan_details[i] if i < len(plan_details) else {}
+        estimated_minutes = detail.get("estimated_minutes", 10)
+
+        # Infer task type from step description
+        task_type = _infer_task_type_from_description(step)
+
+        node = TaskNode(
+            task_id=task_id,
+            task_type=task_type,
+            description=step,
+            estimated_duration_minutes=estimated_minutes,
+            inputs={},
+            outputs={},
+            requires_approval=False,
+            metadata={"original_detail": detail} if detail else {},
+        )
+        nodes.append(node)
+
+        # Create sequential dependency edges (each task depends on previous)
+        if i > 0:
+            edge = TaskEdge(
+                source_id=f"task-{i}",
+                target_id=task_id,
+                edge_type=EdgeType.DEPENDS_ON,
+            )
+            edges.append(edge)
+
+    # Build TaskTree
+    task_tree = TaskTree(nodes=nodes, edges=edges)
+
+    # Build metadata
+    planner_metadata = PlannerMetadata(
+        planner_type=llm_result.get("planner_type", "llm"),
+        planning_time_ms=llm_result.get("planning_time_ms", 0.0),
+        confidence_score=0.8,  # LLM plans have moderate confidence
+        trace_id=trace_id,
+        provider=llm_result.get("provider"),
+    )
+
+    # Determine flow template based on task type
+    task_type_str = llm_result.get("task_type", "unknown")
+    flow_template = _determine_flow_template(task_type_str)
+
+    return PlannerOutput(
+        plan_id=plan_id,
+        plan_type=PlanType.DETAILED,
+        goal=goal,
+        task_tree=task_tree,
+        flow_template=flow_template,
+        model_tier_hints={},
+        risk_metadata=RiskMetadata(overall_risk=RiskLevel.MEDIUM),
+        cost_estimate=CostEstimate(),
+        planner_metadata=planner_metadata,
+    )
+
+
+def adapt_task_planner_output(
+    task_plan: "TaskPlan",
+    trace_id: Optional[str] = None,
+) -> PlannerOutput:
+    """
+    Convert TaskPlanner output to unified PlannerOutput format.
+
+    Args:
+        task_plan: Output from TaskPlanner.create_plan()
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        PlannerOutput with converted task tree
+    """
+    trace_id = trace_id or str(uuid.uuid4())
+
+    logger.info(
+        "[Adapter] Converting TaskPlanner output to PlannerOutput",
+        extra={"operation": "adapt_task_planner", "trace_id": trace_id}
+    )
+
+    # Build TaskNodes from subtasks
+    nodes: List[TaskNode] = []
+    edges: List[TaskEdge] = []
+
+    for subtask in task_plan.subtasks:
+        # Map SubTaskType to TaskType
+        task_type_str = subtask.task_type.value if hasattr(subtask.task_type, 'value') else str(subtask.task_type)
+        task_type = SUBTASK_TYPE_TO_TASK_TYPE.get(task_type_str, TaskType.CODE)
+
+        node = TaskNode(
+            task_id=subtask.task_id,
+            task_type=task_type,
+            description=subtask.description,
+            estimated_duration_minutes=subtask.estimated_duration_minutes,
+            inputs=subtask.inputs,
+            outputs=subtask.outputs,
+            requires_approval=subtask.requires_approval,
+            metadata={
+                "agent_type": subtask.agent_type,
+                "priority": subtask.priority,
+            },
+        )
+        nodes.append(node)
+
+        # Create dependency edges
+        for dep_id in subtask.dependencies:
+            edge = TaskEdge(
+                source_id=dep_id,
+                target_id=subtask.task_id,
+                edge_type=EdgeType.DEPENDS_ON,
+            )
+            edges.append(edge)
+
+    # Build TaskTree
+    task_tree = TaskTree(nodes=nodes, edges=edges)
+
+    # Extract goal summary
+    goal_summary = ""
+    if hasattr(task_plan.goal, 'summary'):
+        goal_summary = task_plan.goal.summary
+    elif hasattr(task_plan.goal, 'raw_input'):
+        goal_summary = task_plan.goal.raw_input
+
+    # Determine flow template from goal type
+    flow_template = "full_pipeline"
+    if hasattr(task_plan.goal, 'goal_type'):
+        goal_type = task_plan.goal.goal_type.value if hasattr(task_plan.goal.goal_type, 'value') else str(task_plan.goal.goal_type)
+        flow_template = _determine_flow_template(goal_type)
+
+    # Build metadata
+    planner_metadata = PlannerMetadata(
+        planner_type="task_planner",
+        planning_time_ms=0.0,  # TaskPlanner doesn't track this
+        confidence_score=0.9,  # Template-based plans have high confidence
+        trace_id=trace_id,
+    )
+
+    return PlannerOutput(
+        plan_id=task_plan.plan_id,
+        plan_type=PlanType.DETAILED,
+        goal=goal_summary,
+        task_tree=task_tree,
+        flow_template=flow_template,
+        model_tier_hints={},
+        risk_metadata=RiskMetadata(overall_risk=RiskLevel.LOW),
+        cost_estimate=CostEstimate(
+            estimated_total_minutes=task_plan.total_estimated_minutes
+        ),
+        planner_metadata=planner_metadata,
+    )
+
+
+def adapt_pm_agent_output(
+    pm_advisory: "PMAdvisory",
+    trace_id: Optional[str] = None,
+) -> PlannerOutput:
+    """
+    Convert PMAgent output to unified PlannerOutput format.
+
+    Args:
+        pm_advisory: Output from PMAgent.decompose_goal()
+        trace_id: Optional trace ID for logging
+
+    Returns:
+        PlannerOutput with converted task tree
+    """
+    trace_id = trace_id or str(uuid.uuid4())
+    plan_id = str(uuid.uuid4())
+
+    logger.info(
+        "[Adapter] Converting PMAgent output to PlannerOutput",
+        extra={"operation": "adapt_pm_agent", "trace_id": trace_id}
+    )
+
+    # Build TaskNodes from sub_tasks
+    nodes: List[TaskNode] = []
+    edges: List[TaskEdge] = []
+
+    sub_tasks = pm_advisory.sub_tasks if hasattr(pm_advisory, 'sub_tasks') else []
+
+    for subtask in sub_tasks:
+        # Map PM task type to TaskType
+        task_type_str = subtask.task_type if hasattr(subtask, 'task_type') else "unknown"
+        task_type = PM_TASK_TYPE_TO_TASK_TYPE.get(task_type_str, TaskType.CODE)
+
+        # Convert effort to duration
+        effort = subtask.estimated_effort if hasattr(subtask, 'estimated_effort') else "medium"
+        estimated_minutes = EFFORT_TO_DURATION.get(effort, 30)
+
+        node = TaskNode(
+            task_id=subtask.task_id,
+            task_type=task_type,
+            description=subtask.description,
+            estimated_duration_minutes=estimated_minutes,
+            inputs={},
+            outputs={},
+            requires_approval=False,
+            metadata={
+                "title": subtask.title if hasattr(subtask, 'title') else "",
+                "affected_files": subtask.affected_files if hasattr(subtask, 'affected_files') else [],
+                "priority": subtask.priority if hasattr(subtask, 'priority') else 0,
+            },
+        )
+        nodes.append(node)
+
+        # Create dependency edges
+        dependencies = subtask.dependencies if hasattr(subtask, 'dependencies') else []
+        for dep_id in dependencies:
+            edge = TaskEdge(
+                source_id=dep_id,
+                target_id=subtask.task_id,
+                edge_type=EdgeType.DEPENDS_ON,
+            )
+            edges.append(edge)
+
+    # Build TaskTree
+    task_tree = TaskTree(nodes=nodes, edges=edges)
+
+    # Map PMRisk to RiskLevel
+    overall_risk_str = pm_advisory.overall_risk.value if hasattr(pm_advisory.overall_risk, 'value') else str(pm_advisory.overall_risk)
+    overall_risk = PM_RISK_TO_RISK_LEVEL.get(overall_risk_str.lower(), RiskLevel.MEDIUM)
+
+    # Build risk metadata from findings
+    risk_factors = []
+    if hasattr(pm_advisory, 'findings'):
+        for finding in pm_advisory.findings:
+            risk_factors.append(finding.title if hasattr(finding, 'title') else str(finding))
+
+    risk_metadata = RiskMetadata(
+        overall_risk=overall_risk,
+        risk_factors=risk_factors[:5],  # Limit to top 5
+        mitigation_suggestions=pm_advisory.recommendations if hasattr(pm_advisory, 'recommendations') else [],
+    )
+
+    # Build metadata
+    planner_metadata = PlannerMetadata(
+        planner_type="pm_agent",
+        planning_time_ms=pm_advisory.metadata.get("latency_ms", 0.0) if hasattr(pm_advisory, 'metadata') and pm_advisory.metadata else 0.0,
+        confidence_score=pm_advisory.confidence_score if hasattr(pm_advisory, 'confidence_score') else 0.7,
+        trace_id=trace_id,
+    )
+
+    return PlannerOutput(
+        plan_id=plan_id,
+        plan_type=PlanType.DETAILED,
+        goal=pm_advisory.goal if hasattr(pm_advisory, 'goal') else "",
+        task_tree=task_tree,
+        flow_template="full_pipeline",
+        model_tier_hints={},
+        risk_metadata=risk_metadata,
+        cost_estimate=CostEstimate(),
+        planner_metadata=planner_metadata,
+    )
+
+
+def _infer_task_type_from_description(description: str) -> TaskType:
+    """
+    Infer TaskType from step description using keyword matching.
+
+    Args:
+        description: Step description text
+
+    Returns:
+        Inferred TaskType
+    """
+    description_lower = description.lower()
+
+    # Check for keywords in order of specificity
+    if any(kw in description_lower for kw in ["setup", "install", "configure", "environment"]):
+        return TaskType.SETUP
+    if any(kw in description_lower for kw in ["analyze", "investigate", "examine", "review code", "understand"]):
+        return TaskType.ANALYZE
+    if any(kw in description_lower for kw in ["test", "spec", "coverage", "unit test", "integration test"]):
+        return TaskType.TEST
+    if any(kw in description_lower for kw in ["review", "code review", "self-review", "peer review"]):
+        return TaskType.REVIEW
+    if any(kw in description_lower for kw in ["document", "readme", "comment", "doc"]):
+        return TaskType.DOCUMENT
+    if any(kw in description_lower for kw in ["deploy", "release", "publish"]):
+        return TaskType.DEPLOY
+    if any(kw in description_lower for kw in ["verify", "validate", "check", "confirm"]):
+        return TaskType.VERIFY
+    if any(kw in description_lower for kw in ["cleanup", "clean up", "remove", "delete"]):
+        return TaskType.CLEANUP
+    if any(kw in description_lower for kw in ["implement", "code", "write", "create", "add", "fix", "modify"]):
+        return TaskType.CODE
+
+    # Default to CODE for unrecognized descriptions
+    return TaskType.CODE
+
+
+def _determine_flow_template(task_type: str) -> str:
+    """
+    Determine appropriate flow template based on task type.
+
+    Args:
+        task_type: Task type string from classifier
+
+    Returns:
+        Flow template name
+    """
+    task_type_lower = task_type.lower()
+
+    if task_type_lower in ["documentation", "doc"]:
+        return "doc_only"
+    if task_type_lower in ["test", "testing"]:
+        return "test_heavy"
+    if task_type_lower in ["bug_fix", "bugfix"]:
+        return "review_heavy"
+    if task_type_lower in ["refactor", "refactoring"]:
+        return "review_heavy"
+    if task_type_lower in ["feature", "feature_development"]:
+        return "full_pipeline"
+    if task_type_lower in ["investigation"]:
+        return "analysis_only"
+
+    return "full_pipeline"

--- a/handoff/20250928/40_App/orchestrator/tests/test_planner_adapters.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_planner_adapters.py
@@ -1,0 +1,317 @@
+"""
+Unit tests for Planner Adapters (Phase F-1)
+
+Tests the adapter functions that convert output from existing planners
+(LLMPlannerAdapter, TaskPlanner, PMAgent) to the unified PlannerOutput format.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from core.planner.adapters import (
+    adapt_llm_planner_output,
+    adapt_task_planner_output,
+    adapt_pm_agent_output,
+    _infer_task_type_from_description,
+    _determine_flow_template,
+)
+from core.planner.planner_types import (
+    PlannerOutput,
+    PlanType,
+    TaskType,
+    EdgeType,
+    RiskLevel,
+)
+
+
+class TestAdaptLLMPlannerOutput:
+    """Tests for adapt_llm_planner_output function"""
+
+    def test_basic_conversion(self):
+        """Test basic LLM planner output conversion"""
+        llm_result = {
+            "plan": ["Analyze the codebase", "Implement the feature", "Write tests"],
+            "plan_details": [
+                {"step": "Analyze the codebase", "estimated_minutes": 10},
+                {"step": "Implement the feature", "estimated_minutes": 30},
+                {"step": "Write tests", "estimated_minutes": 15},
+            ],
+            "planner_type": "llm",
+            "task_type": "feature",
+            "planning_time_ms": 1500.0,
+            "provider": "openai",
+        }
+
+        result = adapt_llm_planner_output(llm_result, goal="Add new feature")
+
+        assert isinstance(result, PlannerOutput)
+        assert result.plan_type == PlanType.DETAILED
+        assert result.goal == "Add new feature"
+        assert len(result.task_tree.nodes) == 3
+        assert result.planner_metadata.planner_type == "llm"
+        assert result.planner_metadata.planning_time_ms == 1500.0
+        assert result.planner_metadata.provider == "openai"
+
+    def test_sequential_dependencies(self):
+        """Test that sequential dependencies are created correctly"""
+        llm_result = {
+            "plan": ["Step 1", "Step 2", "Step 3"],
+            "plan_details": [],
+            "planner_type": "llm",
+            "task_type": "unknown",
+            "planning_time_ms": 100.0,
+        }
+
+        result = adapt_llm_planner_output(llm_result)
+
+        # Should have 2 edges: task-1 -> task-2, task-2 -> task-3
+        assert len(result.task_tree.edges) == 2
+        assert result.task_tree.edges[0].source_id == "task-1"
+        assert result.task_tree.edges[0].target_id == "task-2"
+        assert result.task_tree.edges[1].source_id == "task-2"
+        assert result.task_tree.edges[1].target_id == "task-3"
+
+    def test_empty_plan(self):
+        """Test handling of empty plan"""
+        llm_result = {
+            "plan": [],
+            "plan_details": [],
+            "planner_type": "llm",
+            "task_type": "unknown",
+            "planning_time_ms": 0.0,
+        }
+
+        result = adapt_llm_planner_output(llm_result)
+
+        assert len(result.task_tree.nodes) == 0
+        assert len(result.task_tree.edges) == 0
+
+    def test_flow_template_selection(self):
+        """Test flow template is selected based on task type"""
+        llm_result = {
+            "plan": ["Write documentation"],
+            "plan_details": [],
+            "planner_type": "llm",
+            "task_type": "documentation",
+            "planning_time_ms": 100.0,
+        }
+
+        result = adapt_llm_planner_output(llm_result)
+
+        assert result.flow_template == "doc_only"
+
+
+class TestAdaptTaskPlannerOutput:
+    """Tests for adapt_task_planner_output function"""
+
+    def test_basic_conversion(self):
+        """Test basic TaskPlanner output conversion"""
+        # Create mock SubTask and TaskPlan
+        mock_subtask_type = MagicMock()
+        mock_subtask_type.value = "write_code"
+
+        mock_subtask = MagicMock()
+        mock_subtask.task_id = "task-1"
+        mock_subtask.task_type = mock_subtask_type
+        mock_subtask.description = "Implement the feature"
+        mock_subtask.estimated_duration_minutes = 30
+        mock_subtask.inputs = {}
+        mock_subtask.outputs = {}
+        mock_subtask.requires_approval = False
+        mock_subtask.agent_type = "dev_agent"
+        mock_subtask.priority = 0
+        mock_subtask.dependencies = []
+
+        mock_goal = MagicMock()
+        mock_goal.summary = "Add new feature"
+        mock_goal.goal_type = MagicMock()
+        mock_goal.goal_type.value = "feature_development"
+
+        mock_task_plan = MagicMock()
+        mock_task_plan.plan_id = "plan-123"
+        mock_task_plan.subtasks = [mock_subtask]
+        mock_task_plan.total_estimated_minutes = 30
+        mock_task_plan.goal = mock_goal
+        mock_task_plan.metadata = {"planner_version": "1.1.0"}
+
+        result = adapt_task_planner_output(mock_task_plan)
+
+        assert isinstance(result, PlannerOutput)
+        assert result.plan_id == "plan-123"
+        assert result.goal == "Add new feature"
+        assert len(result.task_tree.nodes) == 1
+        assert result.task_tree.nodes[0].task_type == TaskType.CODE
+        assert result.planner_metadata.planner_type == "task_planner"
+
+    def test_dependency_conversion(self):
+        """Test that dependencies are converted to edges"""
+        mock_subtask_type = MagicMock()
+        mock_subtask_type.value = "write_code"
+
+        mock_subtask1 = MagicMock()
+        mock_subtask1.task_id = "task-1"
+        mock_subtask1.task_type = mock_subtask_type
+        mock_subtask1.description = "Step 1"
+        mock_subtask1.estimated_duration_minutes = 10
+        mock_subtask1.inputs = {}
+        mock_subtask1.outputs = {}
+        mock_subtask1.requires_approval = False
+        mock_subtask1.agent_type = "dev_agent"
+        mock_subtask1.priority = 0
+        mock_subtask1.dependencies = []
+
+        mock_subtask2 = MagicMock()
+        mock_subtask2.task_id = "task-2"
+        mock_subtask2.task_type = mock_subtask_type
+        mock_subtask2.description = "Step 2"
+        mock_subtask2.estimated_duration_minutes = 20
+        mock_subtask2.inputs = {}
+        mock_subtask2.outputs = {}
+        mock_subtask2.requires_approval = False
+        mock_subtask2.agent_type = "dev_agent"
+        mock_subtask2.priority = 0
+        mock_subtask2.dependencies = ["task-1"]
+
+        mock_goal = MagicMock()
+        mock_goal.summary = "Test goal"
+        mock_goal.goal_type = MagicMock()
+        mock_goal.goal_type.value = "feature"
+
+        mock_task_plan = MagicMock()
+        mock_task_plan.plan_id = "plan-456"
+        mock_task_plan.subtasks = [mock_subtask1, mock_subtask2]
+        mock_task_plan.total_estimated_minutes = 30
+        mock_task_plan.goal = mock_goal
+        mock_task_plan.metadata = {}
+
+        result = adapt_task_planner_output(mock_task_plan)
+
+        assert len(result.task_tree.edges) == 1
+        assert result.task_tree.edges[0].source_id == "task-1"
+        assert result.task_tree.edges[0].target_id == "task-2"
+        assert result.task_tree.edges[0].edge_type == EdgeType.DEPENDS_ON
+
+
+class TestAdaptPMAgentOutput:
+    """Tests for adapt_pm_agent_output function"""
+
+    def test_basic_conversion(self):
+        """Test basic PMAgent output conversion"""
+        mock_subtask = MagicMock()
+        mock_subtask.task_id = "pm-task-1"
+        mock_subtask.task_type = "feature"
+        mock_subtask.description = "Implement feature"
+        mock_subtask.title = "Feature Implementation"
+        mock_subtask.estimated_effort = "medium"
+        mock_subtask.affected_files = ["src/main.py"]
+        mock_subtask.priority = 1
+        mock_subtask.dependencies = []
+
+        mock_risk = MagicMock()
+        mock_risk.value = "medium"
+
+        mock_finding = MagicMock()
+        mock_finding.title = "Complexity risk"
+
+        mock_advisory = MagicMock()
+        mock_advisory.goal = "Add new feature"
+        mock_advisory.sub_tasks = [mock_subtask]
+        mock_advisory.overall_risk = mock_risk
+        mock_advisory.confidence_score = 0.85
+        mock_advisory.findings = [mock_finding]
+        mock_advisory.recommendations = ["Consider breaking into smaller tasks"]
+        mock_advisory.metadata = {"latency_ms": 500.0}
+
+        result = adapt_pm_agent_output(mock_advisory)
+
+        assert isinstance(result, PlannerOutput)
+        assert result.goal == "Add new feature"
+        assert len(result.task_tree.nodes) == 1
+        assert result.task_tree.nodes[0].task_type == TaskType.CODE
+        assert result.task_tree.nodes[0].estimated_duration_minutes == 30  # medium effort
+        assert result.risk_metadata.overall_risk == RiskLevel.MEDIUM
+        assert result.planner_metadata.planner_type == "pm_agent"
+        assert result.planner_metadata.confidence_score == 0.85
+
+    def test_effort_to_duration_mapping(self):
+        """Test effort levels are mapped to correct durations"""
+        for effort, expected_minutes in [("small", 15), ("medium", 30), ("large", 60)]:
+            mock_subtask = MagicMock()
+            mock_subtask.task_id = "task-1"
+            mock_subtask.task_type = "feature"
+            mock_subtask.description = "Task"
+            mock_subtask.title = "Task"
+            mock_subtask.estimated_effort = effort
+            mock_subtask.affected_files = []
+            mock_subtask.priority = 0
+            mock_subtask.dependencies = []
+
+            mock_risk = MagicMock()
+            mock_risk.value = "low"
+
+            mock_advisory = MagicMock()
+            mock_advisory.goal = "Test"
+            mock_advisory.sub_tasks = [mock_subtask]
+            mock_advisory.overall_risk = mock_risk
+            mock_advisory.confidence_score = 0.9
+            mock_advisory.findings = []
+            mock_advisory.recommendations = []
+            mock_advisory.metadata = {}
+
+            result = adapt_pm_agent_output(mock_advisory)
+
+            assert result.task_tree.nodes[0].estimated_duration_minutes == expected_minutes
+
+
+class TestInferTaskTypeFromDescription:
+    """Tests for _infer_task_type_from_description helper"""
+
+    @pytest.mark.parametrize("description,expected_type", [
+        ("Setup the development environment", TaskType.SETUP),
+        ("Install dependencies", TaskType.SETUP),
+        ("Configure the project", TaskType.SETUP),
+        ("Analyze the codebase", TaskType.ANALYZE),
+        ("Investigate the bug", TaskType.ANALYZE),
+        ("Write unit tests", TaskType.TEST),
+        ("Run integration tests", TaskType.TEST),
+        ("Code review the changes", TaskType.REVIEW),
+        ("Self-review the implementation", TaskType.REVIEW),
+        ("Document the API", TaskType.DOCUMENT),
+        ("Update the README", TaskType.DOCUMENT),
+        ("Deploy to production", TaskType.DEPLOY),
+        ("Release the new version", TaskType.DEPLOY),
+        ("Verify the fix works", TaskType.VERIFY),
+        ("Validate the implementation", TaskType.VERIFY),
+        ("Cleanup temporary files", TaskType.CLEANUP),
+        ("Implement the feature", TaskType.CODE),
+        ("Fix the bug", TaskType.CODE),
+        ("Create new component", TaskType.CODE),
+        ("Unknown task description", TaskType.CODE),  # Default
+    ])
+    def test_task_type_inference(self, description, expected_type):
+        """Test task type is correctly inferred from description"""
+        result = _infer_task_type_from_description(description)
+        assert result == expected_type
+
+
+class TestDetermineFlowTemplate:
+    """Tests for _determine_flow_template helper"""
+
+    @pytest.mark.parametrize("task_type,expected_template", [
+        ("documentation", "doc_only"),
+        ("doc", "doc_only"),
+        ("test", "test_heavy"),
+        ("testing", "test_heavy"),
+        ("bug_fix", "review_heavy"),
+        ("bugfix", "review_heavy"),
+        ("refactor", "review_heavy"),
+        ("refactoring", "review_heavy"),
+        ("feature", "full_pipeline"),
+        ("feature_development", "full_pipeline"),
+        ("investigation", "analysis_only"),
+        ("unknown", "full_pipeline"),  # Default
+    ])
+    def test_flow_template_selection(self, task_type, expected_template):
+        """Test flow template is correctly selected based on task type"""
+        result = _determine_flow_template(task_type)
+        assert result == expected_template


### PR DESCRIPTION
# feat(planner): add Phase F-1 adapter layer for unified PlannerOutput

## Summary

EPIC F Phase F-1 implementation: Adds adapter functions to convert output from existing planners (LLMPlannerAdapter, TaskPlanner, PMAgent) to the unified PlannerOutput format defined in Phase F-0 (PR #3831).

**New adapters:**
- `adapt_llm_planner_output()`: Converts LLMPlannerAdapter.generate_plan() Dict output
- `adapt_task_planner_output()`: Converts TaskPlanner.create_plan() TaskPlan output  
- `adapt_pm_agent_output()`: Converts PMAgent.decompose_goal() PMAdvisory output

**Key conversions:**
- TaskType mapping from SubTaskType and PM task types to unified TaskType enum
- Dependency lists converted to TaskEdge with EdgeType.DEPENDS_ON
- PMRisk mapped to RiskLevel
- Effort levels (small/medium/large) converted to duration minutes (15/30/60)
- Flow template selection based on task type

## Review & Testing Checklist for Human

- [ ] **Verify type mappings are complete**: Check that `SUBTASK_TYPE_TO_TASK_TYPE` and `PM_TASK_TYPE_TO_TASK_TYPE` cover all existing task types in TaskPlanner and PMAgent. Missing types default to `TaskType.CODE`.

- [ ] **Review sequential dependency assumption**: The LLM adapter creates sequential dependencies (task-1 → task-2 → task-3). Verify this is acceptable or if parallel task support is needed.

- [ ] **Integration test with real planner outputs**: Unit tests use mocks. Manually test adapters with actual LLMPlannerAdapter, TaskPlanner, and PMAgent outputs to verify field mappings work correctly.

- [ ] **Review hardcoded confidence scores**: LLM plans default to 0.8, TaskPlanner to 0.9. Verify these defaults are appropriate.

**Recommended test plan:**
1. Import adapters in a Python shell with orchestrator context
2. Call each existing planner and pass output through corresponding adapter
3. Verify resulting PlannerOutput.validate() returns no errors

### Notes

Blueprint Reference: Section 3.1 (Planner v3 - Unified Planning Interface)

Requested by: @RC918
Link to Devin run: https://app.devin.ai/sessions/639f210ad15f44db88d1dccaf0c0aef8