### PR TITLE
fix(reviewer): add missing review_with_specialists function for B-9 integration

### DIFF
--- a/handoff/20250928/40_App/orchestrator/review_context/__init__.py
+++ b/handoff/20250928/40_App/orchestrator/review_context/__init__.py
@@ -17,6 +17,7 @@ from review_context.multi_specialist_reviewer import (
     ReviewSpecialist,
     SpecialistFindings,
     generate_multi_specialist_review,
+    review_with_specialists,
 )
 from review_context.test_coverage_analyzer import (
     TestCoverageAnalyzer,
@@ -38,6 +39,7 @@ __all__ = [
     "ReviewSpecialist",
     "SpecialistFindings",
     "generate_multi_specialist_review",
+    "review_with_specialists",
     # B-11: Test Coverage Flagging
     "TestCoverageAnalyzer",
     "CoverageGap",

--- a/handoff/20250928/40_App/orchestrator/review_context/multi_specialist_reviewer.py
+++ b/handoff/20250928/40_App/orchestrator/review_context/multi_specialist_reviewer.py
@@ -575,3 +575,34 @@ def generate_multi_specialist_review(
     )
 
     return findings.to_dict()
+
+
+def review_with_specialists(diff_content: str) -> SpecialistFindings:
+    """
+    Simplified synchronous wrapper for multi-specialist review.
+
+    This function provides a simple interface for the langgraph_orchestrator
+    reviewer_node integration. It returns SpecialistFindings directly (not dict)
+    to allow access to .findings attribute.
+
+    Args:
+        diff_content: The PR diff content to review
+
+    Returns:
+        SpecialistFindings object with review findings and metadata
+    """
+    reviewer = MultiSpecialistReviewer(trace_id="reviewer-node")
+
+    # Run async review in event loop
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+
+    # Use empty pr_context since langgraph_orchestrator only passes diff_content
+    findings = loop.run_until_complete(
+        reviewer.review(diff_content, pr_context={})
+    )
+
+    return findings


### PR DESCRIPTION
## Summary

Fixes a critical bug where MorningAI Reviewer Agent stopped working when `USE_MULTI_SPECIALIST_REVIEW=True`. 

**Root cause**: `langgraph_orchestrator.py` line 7066-7067 imports `review_with_specialists` from `multi_specialist_reviewer.py`, but this function did not exist, causing an `ImportError`. Although the error was caught by try/except (fail-open), it prevented B-9 functionality from working.

**Fix**: Add the missing `review_with_specialists()` wrapper function that:
- Takes `diff_content: str` as input (matching the caller's interface)
- Returns `SpecialistFindings` object (not dict) to allow access to `.findings` attribute
- Handles async-to-sync conversion for the `MultiSpecialistReviewer`

## Review & Testing Checklist for Human

- [ ] **Verify function signature matches caller**: Check `langgraph_orchestrator.py:7075` expects `review_with_specialists(diff_content)` returning object with `.findings` attribute
- [ ] **Test in staging with `USE_MULTI_SPECIALIST_REVIEW=True`**: Create a test PR and verify B-9 logs appear (`[Reviewer] B-9: Starting multi-specialist review`)
- [ ] **Consider trace_id**: Currently hardcoded as `"reviewer-node"` - acceptable for now but may want to parameterize later for better telemetry

**Test plan**: 
1. Deploy to staging
2. Set `USE_MULTI_SPECIALIST_REVIEW=True` in Dashboard
3. Create a test PR with code changes
4. Check worker logs for `[Reviewer] B-9:` entries (should no longer see ImportError)

### Notes

- The `pr_context` is passed as empty dict since the orchestrator only provides `diff_content`. This means specialist prompts won't have PR metadata, but this matches the existing caller interface.
- This PR was assisted by Devin: https://app.devin.ai/sessions/30d4ae86ad66455ab79bdcbd9a451467
- Requested by: Ryan Chen (@RC918)