### PR TITLE
feat(reviewer): B-9.5 Multi-Line Statement Awareness to prevent false positives

### DIFF
--- a/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
+++ b/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
@@ -947,13 +947,13 @@ Seeing the complete call:
 Concluding: "analyze_test_coverage() receives all required arguments" <- CORRECT
 ```
 
-**Before claiming a function is missing arguments:**
-1. Find the opening parenthesis `(`
-2. Scan forward to find the closing parenthesis `)`
-3. List ALL arguments between them
+**Before claiming a function/list/dict is missing elements:**
+1. Find the opening delimiter (`(`, `[`, or `{`)
+2. Scan forward to find the matching closing delimiter (`)`, `]`, or `}`)
+3. List ALL elements between them
 4. ONLY THEN determine if any are missing
 
-If you cannot see the complete function call in the diff, DO NOT comment on missing arguments.
+If you cannot see the complete statement in the diff, DO NOT comment on missing elements.
 
 === STRICT MODE: ONLY COMMENT ON + LINES ===
 You may ONLY provide inline comments (with line numbers) on lines marked with "+".


### PR DESCRIPTION
# B-9.5: Multi-Line Statement Awareness

## Summary
Adds a new section to the LLM reviewer's system prompt to prevent false positives when analyzing multi-line statements. This addresses Issue #3881 where the reviewer incorrectly claimed arguments were missing when they were actually present on subsequent lines.

The change adds explicit instructions for the LLM to:
1. Look at complete statements (from opening to closing delimiter) before making claims
2. Not conclude elements are missing based on seeing only the first line
3. Scan forward to find all elements before determining if any are missing
4. Handle all delimiter types: parentheses `()`, brackets `[]`, and braces `{}`

## Updates since last revision
- Incorporated gemini-code-assist suggestion to generalize delimiter handling beyond just parentheses to include brackets and braces (for lists and dictionaries)

## Review & Testing Checklist for Human
- [ ] **Test with multi-line function call diffs** - Run the reviewer against a PR containing multi-line function calls to verify false positives are reduced
- [ ] **Test with multi-line list/dict diffs** - Verify the generalized delimiter handling works for lists and dictionaries
- [ ] **Verify existing review quality** - Ensure the additional prompt instructions don't cause the LLM to miss legitimate issues
- [ ] **Check token budget** - The system prompt is already long; verify this addition doesn't push it over token limits for smaller models

### Notes
This is a prompt engineering change, so effectiveness can only be verified through real-world testing. The LLM may or may not follow these instructions consistently.

Related: Issue #3881 (tracks the false positive bug and broader B-9.5/B-9.6/B-9.7 optimization plan)

---
Requested by: Ryan Chen (@RC918)
Link to Devin run: https://app.devin.ai/sessions/850aeb54acea496ab723b6d0144d9c2f