### PR TITLE
feat(reviewer): B-9.7 False Positive Telemetry for continuous improvement

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -8658,7 +8658,9 @@ def publisher_node(state: AgentState) -> AgentState:
                 pass
             except Exception as emit_err:
                 logger.debug(
-                    f"[Publisher] B-9.7: Failed to emit false positive telemetry: {emit_err}"
+                    "[Publisher] B-9.7: Failed to emit false positive telemetry. Error: %s",
+                    type(emit_err).__name__,
+                    exc_info=True
                 )
 
         # DIAGNOSTIC: Log allowed_lines_map summary for 422 debugging


### PR DESCRIPTION
## Summary
Implements SSOT TelemetryRecordV3 emission for the B-9.6 Comment Validator's false positive detection metrics. This completes the B-9 optimization plan for Issue #3881.

The change emits a `reviewer.comment_validation` telemetry event with metrics including `total_comments`, `validated_comments`, `filtered_false_positives`, and `false_positive_rate`. This enables tracking false positive rates over time for continuous improvement of the reviewer system.

**Blueprint Alignment:** Section 9.1 "Deterministic Guarantee" - "All behavior can be reconstructed via Telemetry + Memory"

**Behavior Change:** The `comment_validation` stats are now always stored in `publish_result`, not just when false positives are filtered. This provides complete telemetry even when the validator passes all comments through.

## Updates since last revision
- **Security fix**: Sanitized exception logging per Gemini Code Assist suggestion. Now uses `type(emit_err).__name__` instead of logging full exception message, with `exc_info=True` for proper stack traces. Aligns with Blueprint Section 9.2 "Safe by Design".

## Review & Testing Checklist for Human
- [ ] **Verify behavior change is acceptable**: `state["publish_result"]["comment_validation"]` is now always set (previously only when `filtered_false_positives > 0`). Check if any downstream code depends on this key only existing conditionally.
- [ ] **Test telemetry emission**: Set `ENABLE_SSOT_TELEMETRY=true` and trigger a PR review to verify the `reviewer.comment_validation` event is emitted correctly.
- [ ] **Verify metrics format**: Confirm the float casting for metrics values is compatible with TelemetryRecordV3 schema.

### Notes
- This completes the B-9 optimization plan: B-9.5 (PR #3882), B-9.6 (PR #3883), B-9.7 (this PR)
- No unit tests included for telemetry emission (follows existing pattern in codebase where telemetry is tested via integration)
- refs #3881

---
Requested by: Ryan Chen (@RC918)
Link to Devin run: https://app.devin.ai/sessions/850aeb54acea496ab723b6d0144d9c2f