### PR TITLE
fix(planner): Intentional syntax error for D-4 pilot verification

### DIFF
--- a/handoff/20250928/40_App/orchestrator/core/planner/__init__.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/__init__.py
@@ -16,7 +16,8 @@ Components:
 # FIX: Intentional syntax error to trigger D-4 pilot verification
 # D-4 should auto-fix this when CI fails
 # Close PR after verification (do not merge)
-syntax_error_for_d4_pilot = 
+# Trigger #2: Re-trigger CI after staging worker restart (17:11 UTC)
+syntax_error_for_d4_pilot =
 
 from .planner_types import (
     TaskType,


### PR DESCRIPTION
## Summary

⚠️ **DO NOT MERGE THIS PR** ⚠️

This PR intentionally introduces a Python syntax error to trigger CI failure. The purpose is to verify that the D-4 (CI failure auto-fix) system correctly triggers with the 50% FlowController v3 pilot configuration in staging.

**Background**: A previous test PR using `test:` prefix was filtered out by the Smart Filter (`SKIP_TITLE_PREFIXES`). This PR uses `fix:` prefix to bypass that filter.

**The intentional error:**
```python
syntax_error_for_d4_pilot = 
```

## Review & Testing Checklist for Human

- [ ] **DO NOT MERGE** - Close this PR after verification is complete
- [ ] Verify CI fails with Python syntax error (Orchestrator Tests, Redis Queue Integration Tests)
- [ ] After CI failure, check staging worker logs for `run_orchestrator_task` entries
- [ ] Search for `FlowExecutor` logs - should appear for ~50% of jobs if pilot is working
- [ ] Verify no `LangGraph orchestrator failed: 'executor'` errors appear
- [ ] Close this PR without merging after verification

### Notes

This is a test PR for D-4 pilot verification only. After confirming FlowExecutor logs appear in staging, close this PR without merging.

**Requested by**: @RC918  
**Devin run**: https://app.devin.ai/sessions/9f0a68d997e846df9666cd64a2b32e76