### PR TITLE
feat(worker): implement self-healing restart using os.execl

### DIFF
--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -2327,18 +2327,10 @@ if __name__ == "__main__":
                     
                     # Clean up threads and Redis state before restart
                     # This is important because os.execl doesn't trigger atexit handlers
+                    # cleanup_heartbeat() already handles heartbeat_thread.join() with timeout
                     cleanup_heartbeat()
                     
-                    # Wait for heartbeat thread to stop
-                    if heartbeat_thread and heartbeat_thread.is_alive():
-                        heartbeat_thread.join(timeout=5)
-                        if heartbeat_thread.is_alive():
-                            logger.warning(
-                                "Heartbeat thread did not stop within timeout before restart",
-                                extra={"operation": "self_healing_restart", "heartbeat_id": HEARTBEAT_ID}
-                            )
-                    
-                    # Wait for VM cleanup thread to stop
+                    # Wait for VM cleanup thread to stop (not handled by cleanup_heartbeat)
                     if vm_cleanup_thread and vm_cleanup_thread.is_alive():
                         vm_cleanup_thread.join(timeout=5)
                         if vm_cleanup_thread.is_alive():
@@ -2349,9 +2341,23 @@ if __name__ == "__main__":
                     
                     # Perform in-place restart using os.execl
                     # This replaces the current process with a fresh Python process
-                    python = sys.executable
-                    os.execl(python, python, *sys.argv)
-                    # Note: Code after os.execl never executes (process is replaced)
+                    # Wrapped in try/except for graceful fallback if os.execl fails
+                    try:
+                        python = sys.executable
+                        os.execl(python, python, *sys.argv)
+                        # Note: Code after os.execl never executes (process is replaced)
+                    except OSError as e:
+                        logger.critical(
+                            "Self-healing restart with os.execl failed. Falling back to normal exit.",
+                            extra={
+                                "operation": "self_healing_restart_failed",
+                                "error": str(e),
+                                "heartbeat_id": HEARTBEAT_ID,
+                                "rq_worker_name": RQ_WORKER_NAME
+                            },
+                            exc_info=True
+                        )
+                        # Fall through to normal exit, allowing Render to restart
                 
                 should_exit = True
                 break


### PR DESCRIPTION
## Summary

Implements a self-healing restart mechanism for the RQ worker to address recurring Staging worker failures where the worker would shut down after reaching `RQ_MAX_JOBS` but Render wouldn't reliably restart it, leaving jobs stuck in the queue.

**Root cause:** With `RQ_MAX_JOBS=15`, the worker exits after processing 15 jobs, expecting Render to restart the container. However, Render's restart mechanism proved unreliable, causing the worker to stay down.

**Solution:** Use `os.execl` to replace the current process with a fresh Python process when max_jobs is reached. This:
- Completely clears memory (including LangGraph MemorySaver checkpoints)
- Keeps the same PID so Render doesn't see it as a crash
- Doesn't rely on external container orchestrator for restart
- Falls back gracefully to normal exit if `os.execl` fails (allowing Render to restart)

The code properly cleans up heartbeat and VM cleanup threads before restart, since `os.execl` doesn't trigger atexit handlers.

## Updates since last revision

Addressed Gemini Code Assist review feedback:
- **Critical fix**: Wrapped `os.execl` in try/except OSError for graceful fallback instead of crashing
- **Code cleanup**: Removed redundant `heartbeat_thread.join()` since `cleanup_heartbeat()` already handles it

## Review & Testing Checklist for Human

- [ ] **Verify `os.execl` behavior in staging**: Deploy to staging with `RQ_MAX_JOBS=15` and monitor logs for `self_healing_restart` operation after 15 jobs are processed
- [ ] **Check thread cleanup**: Verify heartbeat thread stops cleanly (no "did not stop within timeout" warnings in logs)
- [ ] **Verify Redis state**: After restart, confirm worker re-registers heartbeat in Redis and starts processing jobs from queue
- [ ] **Test fallback**: Simulate `os.execl` failure to verify graceful fallback to normal exit (look for `self_healing_restart_failed` log)

**Recommended test plan:**
1. Deploy to staging
2. Submit 20+ test jobs to the queue
3. Watch logs for "Worker finished 15 jobs. Performing self-healing restart..."
4. Confirm worker continues processing remaining jobs after restart
5. Check Redis for proper heartbeat registration

### Notes

This change aligns with Blueprint principles:
- **Self-Healing**: Worker manages its own lifecycle instead of depending on flaky infrastructure
- **Resource Governance**: Complete memory cleanup via process replacement
- **Determinism**: Clean state on each restart

Link to Devin run: https://app.devin.ai/sessions/850aeb54acea496ab723b6d0144d9c2f
Requested by: Ryan Chen (@RC918)