### PR TITLE
feat(d4): improve Context Extraction for Python SyntaxError format

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -5779,8 +5779,10 @@ def _extract_file_path_from_error(error_summary: str) -> str:
     - "path/to/file.py:123:45: E501 line too long"
     - "path/to/file.py(123): error"
     - "Error in path/to/file.py"
+    - 'File "path/to/file.py", line 10' (Python SyntaxError)
 
     Issue #3567: Enable SimpleCoder for CI failures by extracting file path
+    Issue #3890: D-4 Context Extraction - Support Python SyntaxError format
 
     Args:
         error_summary: CI error output text
@@ -5809,9 +5811,20 @@ def _extract_file_path_from_error(error_summary: str) -> str:
     if match:
         return match.group(1)
 
-    # Pattern 3: "Error in path/file.py" or "File path/file.py"
+    # Pattern 3: "Error in path/file.py" or "File path/file.py" (with optional quotes)
+    # Issue #3890: Support quoted paths like 'File "path/to/file.py"'
     match = re.search(
-        fr'(?:Error in|File|in file)\s+([^\s:]+\.(?:{_SUPPORTED_SOURCE_EXTENSIONS}))',
+        fr'(?:Error in|File|in file)\s+"?([^\s":,]+\.(?:{_SUPPORTED_SOURCE_EXTENSIONS}))"?',
+        error_summary,
+        re.IGNORECASE
+    )
+    if match:
+        return match.group(1)
+
+    # Pattern 4: Python SyntaxError format - 'File "path/to/file.py", line 10'
+    # Issue #3890: D-4 Context Extraction - Handle Python parse-time errors
+    match = re.search(
+        r'File\s+"([^"]+\.py)"',
         error_summary,
         re.IGNORECASE
     )
@@ -5825,6 +5838,7 @@ def _extract_file_paths_from_error(error_summary: str) -> list:
     """Extract ALL file paths from CI error summary for multi-file support.
 
     Issue #3675: D-1b GeneralCoder needs multiple file paths for multi-file fixes.
+    Issue #3890: D-4 Context Extraction - Support Python SyntaxError format.
     This function extracts all unique file paths from CI error output, enabling
     GeneralCoder to handle multi-file lint errors.
 
@@ -5832,6 +5846,7 @@ def _extract_file_paths_from_error(error_summary: str) -> list:
     - "path/to/file.py:123:45: E501 line too long"
     - "path/to/file.py(123): error"
     - "Error in path/to/file.py"
+    - 'File "path/to/file.py", line 10' (Python SyntaxError)
 
     Args:
         error_summary: CI error output text
@@ -5866,13 +5881,23 @@ def _extract_file_paths_from_error(error_summary: str) -> list:
     )
     file_paths.update(pattern2_matches)
 
-    # Pattern 3: "Error in path/file.py" or "File path/file.py"
+    # Pattern 3: "Error in path/file.py" or "File path/file.py" (with optional quotes)
+    # Issue #3890: Support quoted paths like 'File "path/to/file.py"'
     pattern3_matches = re.findall(
-        fr'(?:Error in|File|in file)\s+([^\s:]+\.(?:{_SUPPORTED_SOURCE_EXTENSIONS}))',
+        fr'(?:Error in|File|in file)\s+"?([^\s":,]+\.(?:{_SUPPORTED_SOURCE_EXTENSIONS}))"?',
         error_summary,
         re.IGNORECASE
     )
     file_paths.update(pattern3_matches)
+
+    # Pattern 4: Python SyntaxError format - 'File "path/to/file.py", line 10'
+    # Issue #3890: D-4 Context Extraction - Handle Python parse-time errors
+    pattern4_matches = re.findall(
+        r'File\s+"([^"]+\.py)"',
+        error_summary,
+        re.IGNORECASE
+    )
+    file_paths.update(pattern4_matches)
 
     # Convert to list and limit to configurable max files (D-1b default: 5)
     result = list(file_paths)[:settings.general_coder_max_files]


### PR DESCRIPTION
## Summary

Improves D-4 Self-Correction Loop's ability to extract file paths from Python syntax errors. Previously, D-4 failed with "No files available" when encountering syntax errors because the regex patterns didn't match Python's SyntaxError output format (`File "path/to/file.py", line 10`).

**Changes:**
- Add Pattern 4 to match Python SyntaxError format: `File "path/to/file.py", line 10`
- Update Pattern 3 to support quoted paths: `File "path/file.py"`
- Apply same improvements to both single-file (`_extract_file_path_from_error`) and multi-file (`_extract_file_paths_from_error`) extraction functions

## Review & Testing Checklist for Human

- [ ] **Verify regex correctness**: Test Pattern 4 (`r'File\s+"([^"]+\.py)"'`) against real Python SyntaxError output
- [ ] **Check for regression**: Ensure Pattern 3's character class change (`[^\s":,]` vs `[^\s:]`) doesn't break existing lint error formats (flake8, eslint, etc.)
- [ ] **Test end-to-end**: Create a PR with intentional syntax error on a non-devin/* branch and verify D-4 can now extract the file path and attempt a fix

**Recommended test plan:**
1. Create a test branch (not `devin/*` to avoid skip logic)
2. Introduce a Python syntax error (e.g., missing parenthesis)
3. Push and let CI fail
4. Check logs for `[MULTI_FILE_EXTRACT_*]` events to verify file path extraction

### Notes

- Issue #3890: D-4 Context Extraction improvements
- Root cause identified from staging pilot PR #3887 analysis
- Pattern 3 and Pattern 4 may have overlap for `.py` files - Pattern 3 runs first and should catch most cases

Requested by: @RC918
Link to Devin run: https://app.devin.ai/sessions/16834c21998741ca99953fee3b80910f