### PR TITLE
test(d4): add unit tests for Context Extraction regex patterns

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_fixer_node_unit.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_fixer_node_unit.py
@@ -1174,8 +1174,8 @@ src/file5.py:1:1: error
 src/file6.py:1:1: error
 src/file7.py:1:1: error"""
         result = _extract_file_paths_from_error(error)
-        # Should be limited to 5 files (general_coder_max_files default)
-        assert len(result) <= 5
+        # Should be limited to 5 files (general_coder_max_files in FakeSettings)
+        assert len(result) == 5
 
     def test_extracts_compiler_format(self):
         """Test extraction from compiler format: path/file.py(line): error."""


### PR DESCRIPTION
## Summary

Closes #3890. Adds comprehensive unit tests for the D-4 Context Extraction regex patterns that were improved in PR #3889.

**New tests for `_extract_file_path_from_error()`** (5 tests):
- Python SyntaxError format: `File "path/file.py", line N`
- Nested paths in SyntaxError
- Python tracebacks with multiple File entries
- Quoted file paths
- Case-insensitive File keyword matching

**New tests for `_extract_file_paths_from_error()`** (13 tests):
- Single and multiple file extraction (flake8, compiler formats)
- Deduplication of repeated file paths
- Mixed error formats in same output
- Python SyntaxError and traceback formats
- Edge cases: empty input, no matches, max files limit
- Various file extensions (.py, .js, .ts, .go, .rs)

Also adds `general_coder_max_files = 5` to `FakeSettings` for test compatibility.

## Updates since last revision

- Changed `test_limits_to_max_files` assertion from `len(result) <= 5` to `len(result) == 5` for stricter validation (addresses Gemini Code Assist review feedback)

## Review & Testing Checklist for Human

- [ ] Run the full test suite locally: `cd handoff/20250928/40_App/orchestrator && pytest tests/test_fixer_node_unit.py -v -k "TestExtractFilePathFromError or TestExtractFilePathsFromError"`
- [ ] Verify all 28 tests pass (15 for single-file extraction, 13 for multi-file extraction)

### Notes

Requested by: @RC918
Link to Devin run: https://app.devin.ai/sessions/16834c21998741ca99953fee3b80910f