### PR TITLE
fix(checkpointer): inherit from BaseCheckpointSaver to fix LangGraph validation

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -110,6 +110,7 @@ from datetime import datetime
 
 from langgraph.graph import StateGraph, END
 from langgraph.checkpoint.memory import MemorySaver
+from langgraph.checkpoint.base import BaseCheckpointSaver
 from langgraph.types import interrupt
 from langchain_core.messages import BaseMessage, HumanMessage, AIMessage, SystemMessage
 
@@ -1731,7 +1732,7 @@ class ResilientPostgresSaver:
         return getattr(self._inner, name)
 
 
-class DegradedPersistenceCheckpointer:
+class DegradedPersistenceCheckpointer(BaseCheckpointSaver):
     """
     A failover checkpointer that implements 'soft landing' resilience.
 


### PR DESCRIPTION
## Summary

Fixes `TypeError: Invalid checkpointer provided` errors in Staging worker by making `DegradedPersistenceCheckpointer` inherit from `BaseCheckpointSaver`.

**Root cause:** LangGraph validates that checkpointers are instances of `BaseCheckpointSaver`. The custom `DegradedPersistenceCheckpointer` class wasn't inheriting from it, causing all tasks to fail immediately after checkpointer initialization.

**Error observed:**
```
TypeError: Invalid checkpointer provided. Expected an instance of `BaseCheckpointSaver`, 
`True`, `False`, or `None`. Received DegradedPersistenceCheckpointer.
```

## Review & Testing Checklist for Human

- [ ] Deploy to Staging and verify tasks no longer fail with TypeError
- [ ] Confirm `BaseCheckpointSaver` doesn't require abstract methods that aren't implemented (the class already implements get, put, list, get_tuple, put_writes, get_next_version, setup and has `__getattr__` fallback)
- [ ] Check if `OOMProtectedMemorySaver` and `ResilientPostgresSaver` also need this inheritance fix (they may be wrapped by `DegradedPersistenceCheckpointer` so might be fine)

**Test plan:** After merge, monitor Staging worker logs for the TypeError. If resolved, tasks should progress past the checkpointer initialization phase.

### Notes

- This is a minimal 2-line fix
- There's a separate PYTHONPATH issue with `os.execl` self-healing restart that causes `ModuleNotFoundError` - that's a different issue to address

Requested by: Ryan Chen (@RC918)
Link to Devin run: https://app.devin.ai/sessions/850aeb54acea496ab723b6d0144d9c2f