### PR TITLE
fix(worker): use -m flag in os.execl to preserve module import paths

### DIFF
--- a/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
+++ b/handoff/20250928/40_App/orchestrator/redis_queue/worker.py
@@ -2342,9 +2342,16 @@ if __name__ == "__main__":
                     # Perform in-place restart using os.execl
                     # This replaces the current process with a fresh Python process
                     # Wrapped in try/except for graceful fallback if os.execl fails
+                    #
+                    # IMPORTANT: We use `-m redis_queue.worker` instead of sys.argv because:
+                    # When started with `python -m redis_queue.worker`, sys.argv[0] becomes
+                    # the path to the script file (e.g., /path/to/worker.py), not `-m ...`.
+                    # Using sys.argv would run the worker as a script, breaking module imports.
+                    # Using `-m` ensures Python sets up the module path correctly.
                     try:
                         python = sys.executable
-                        os.execl(python, python, *sys.argv)
+                        # Use -m to run as module, ensuring proper import path setup
+                        os.execl(python, python, "-m", "redis_queue.worker")
                         # Note: Code after os.execl never executes (process is replaced)
                     except OSError as e:
                         logger.critical(


### PR DESCRIPTION
## Summary

Fixes `ModuleNotFoundError: No module named 'persistence.db_writer'` that occurs after the worker's self-healing restart via `os.execl`.

**Root cause:** When Python runs `python -m redis_queue.worker`, `sys.argv[0]` becomes the path to the script file (e.g., `/path/to/worker.py`), not `-m redis_queue.worker`. The previous code used `os.execl(python, python, *sys.argv)`, which ran the worker as a script instead of as a module after restart, breaking relative imports.

**Fix:** Explicitly use `-m redis_queue.worker` in the os.execl call to ensure Python sets up the module path correctly.

## Review & Testing Checklist for Human

- [ ] Verify the Render Start Command sets working directory to `/opt/render/project/src/handoff/20250928/40_App/orchestrator` before running the worker (required for `-m redis_queue.worker` to resolve)
- [ ] Deploy to Staging and wait for self-healing restart to trigger (after `RQ_MAX_JOBS` jobs are processed)
- [ ] Check Staging logs for absence of `ModuleNotFoundError` after restart

**Test plan:** After merge, monitor Staging worker logs. When the worker processes 15 jobs (RQ_MAX_JOBS), it will trigger self-healing restart. Verify no `ModuleNotFoundError` appears in logs after the restart.

### Notes

- This is a minimal 1-line fix with added comments explaining the rationale
- The hardcoded `redis_queue.worker` module path matches the Render Start Command configuration

Requested by: Ryan Chen (@RC918)
Link to Devin run: https://app.devin.ai/sessions/850aeb54acea496ab723b6d0144d9c2f