### PR TITLE
feat(d8): expand RESOURCE_NOT_FOUND patterns for edge cases

### DIFF
--- a/handoff/20250928/40_App/orchestrator/diagnostic_agent_node.py
+++ b/handoff/20250928/40_App/orchestrator/diagnostic_agent_node.py
@@ -272,6 +272,10 @@ class DiagnosticAgentNode:
             r"ENOENT",
             r"No such file",
             r"(?:file|path|resource|directory).*not found|not found.*(?:file|path|resource|directory)",
+            r"(?:file|path|directory).*(?:does not|doesn't) exist",
+            r"(?:file|path|resource|directory).*(?:was not|wasn't) found",
+            r"(?:file|path|resource|directory).*(?:is )?missing",
+            r"(?:file|path|resource|directory).*unavailable",
         ],
         ErrorCategory.PERMISSION_DENIED: [
             r"PermissionError",


### PR DESCRIPTION
## Summary

Expands the `RESOURCE_NOT_FOUND` error patterns in the D-8 Diagnostic Agent to cover additional error message variations that were previously missed. This addresses edge cases identified in Issue #3902.

**New patterns added:**
- `(?:file|path|directory).*(?:does not|doesn't) exist` - covers "directory does not exist" style messages
- `(?:file|path|resource|directory).*(?:was not|wasn't) found` - covers "path was not found" style messages
- `(?:file|path|resource|directory).*(?:is )?missing` - covers "file is missing" or "file missing" style messages
- `(?:file|path|resource|directory).*unavailable` - covers "resource unavailable" style messages

All patterns are scoped to file/path/resource/directory keywords to avoid false positives.

## Review & Testing Checklist for Human

- [ ] Verify regex patterns match intended error messages by testing with sample strings:
  - `"directory does not exist"` → should match
  - `"path was not found"` → should match
  - `"file is missing"` → should match
  - `"function does not exist"` → should NOT match (no resource keyword)
- [ ] Check if `.*` greedy matching could cause issues with very long error messages
- [ ] Consider if additional edge cases are missing (e.g., "cannot access file", "file inaccessible")

**Test plan:** Run the diagnostic agent with various error messages containing the new patterns and verify correct categorization as `RESOURCE_NOT_FOUND`.

### Notes

Fixes #3902

**Link to Devin run:** https://app.devin.ai/sessions/16834c21998741ca99953fee3b80910f
**Requested by:** Ryan Chen (@RC918)