### PR TITLE
fix(reviewer): use TaskType.REVIEW instead of non-existent TaskType.CODE_REVIEW

### DIFF
--- a/handoff/20250928/40_App/orchestrator/review_context/multi_specialist_reviewer.py
+++ b/handoff/20250928/40_App/orchestrator/review_context/multi_specialist_reviewer.py
@@ -340,7 +340,7 @@ class MultiSpecialistReviewer:
         )
 
         try:
-            client = get_client_for_task(TaskType.CODE_REVIEW)
+            client = get_client_for_task(TaskType.REVIEW)
 
             system_prompt = SPECIALIST_PROMPTS[specialist]
             user_prompt = self._build_user_prompt(diff_content, pr_context, specialist)


### PR DESCRIPTION
## Summary

Fixes `MultiSpecialistReviewer` failing immediately with `[MultiSpecialistReviewer] X review error` for all specialist reviews (security, performance, architecture).

**Root cause**: The code was using `TaskType.CODE_REVIEW` which doesn't exist in the `TaskType` enum. The enum only has `TaskType.REVIEW`. This caused an `AttributeError` when calling `get_client_for_task()`, making all 3 specialist reviews fail in <1ms.

**Fix**: Change `TaskType.CODE_REVIEW` to `TaskType.REVIEW`.

## Review & Testing Checklist for Human

- [ ] Verify `TaskType.REVIEW` is the correct task type for code review operations (check `core/routing/engine.py` TaskType enum)
- [ ] Deploy to Staging and verify MultiSpecialistReviewer errors stop appearing in logs
- [ ] Trigger a PR review and confirm specialist reviews complete successfully (should see "Review completed" with actual findings instead of immediate errors)

### Notes

Requested by: Ryan Chen (@RC918)
Link to Devin run: https://app.devin.ai/sessions/850aeb54acea496ab723b6d0144d9c2f