### PR TITLE
refactor(f5): use centralized settings and add max_rounds validation

### DIFF
--- a/common/config/settings.py
+++ b/common/config/settings.py
@@ -1817,8 +1817,10 @@ class Settings(BaseSettings):
 
     debate_engine_max_rounds: int = Field(
         default=3,
+        ge=1,
+        le=10,
         alias="DEBATE_ENGINE_MAX_ROUNDS",
-        description="Maximum debate rounds before Judge makes final decision (F-5). Higher values allow deeper exploration but increase latency and cost."
+        description="Maximum debate rounds before Judge makes final decision (F-5). Higher values allow deeper exploration but increase latency and cost. Valid range: 1-10."
     )
 
     senior_coder_strict_schema_validation: bool = Field(

--- a/handoff/20250928/40_App/orchestrator/core/planner/debate_engine.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/debate_engine.py
@@ -34,22 +34,21 @@ Usage:
 
 import asyncio
 import logging
-import os
 import time
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
 
+from common.config.settings import settings
+
 logger = logging.getLogger(__name__)
 
 
-# Feature flags for Debate Engine
-USE_DEBATE_ENGINE = os.getenv("USE_DEBATE_ENGINE", "false").lower() == "true"
-DEBATE_ENGINE_ENABLE_LLM = os.getenv(
-    "DEBATE_ENGINE_ENABLE_LLM", "true"
-).lower() == "true"
-DEBATE_ENGINE_MAX_ROUNDS = int(os.getenv("DEBATE_ENGINE_MAX_ROUNDS", "3"))
+# Feature flags for Debate Engine (from centralized settings)
+USE_DEBATE_ENGINE = settings.use_debate_engine
+DEBATE_ENGINE_ENABLE_LLM = settings.debate_engine_enable_llm
+DEBATE_ENGINE_MAX_ROUNDS = settings.debate_engine_max_rounds
 
 
 class DebateRole(Enum):

--- a/handoff/20250928/40_App/orchestrator/tests/test_debate_engine.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_debate_engine.py
@@ -733,7 +733,6 @@ class TestDebateEngine:
 class TestShouldTriggerDebate:
     """Tests for should_trigger_debate function."""
 
-    @patch.dict(os.environ, {"USE_DEBATE_ENGINE": "false"})
     def test_disabled_returns_false(self):
         """Test that disabled engine returns False."""
         import debate_engine
@@ -743,7 +742,6 @@ class TestShouldTriggerDebate:
 
         assert result is False
 
-    @patch.dict(os.environ, {"USE_DEBATE_ENGINE": "true"})
     def test_high_risk_triggers_debate(self):
         """Test that high risk triggers debate."""
         import debate_engine
@@ -753,7 +751,6 @@ class TestShouldTriggerDebate:
 
         assert result is True
 
-    @patch.dict(os.environ, {"USE_DEBATE_ENGINE": "true"})
     def test_critical_risk_triggers_debate(self):
         """Test that critical risk triggers debate."""
         import debate_engine
@@ -763,7 +760,6 @@ class TestShouldTriggerDebate:
 
         assert result is True
 
-    @patch.dict(os.environ, {"USE_DEBATE_ENGINE": "true"})
     def test_architecture_category_triggers_debate(self):
         """Test that architecture category triggers debate."""
         import debate_engine
@@ -776,7 +772,6 @@ class TestShouldTriggerDebate:
 
         assert result is True
 
-    @patch.dict(os.environ, {"USE_DEBATE_ENGINE": "true"})
     def test_security_category_triggers_debate(self):
         """Test that security category triggers debate."""
         import debate_engine
@@ -789,7 +784,6 @@ class TestShouldTriggerDebate:
 
         assert result is True
 
-    @patch.dict(os.environ, {"USE_DEBATE_ENGINE": "true"})
     def test_privacy_category_triggers_debate(self):
         """Test that privacy category triggers debate."""
         import debate_engine
@@ -802,7 +796,6 @@ class TestShouldTriggerDebate:
 
         assert result is True
 
-    @patch.dict(os.environ, {"USE_DEBATE_ENGINE": "true"})
     def test_force_debate_triggers(self):
         """Test that force_debate=True triggers debate."""
         import debate_engine
@@ -815,7 +808,6 @@ class TestShouldTriggerDebate:
 
         assert result is True
 
-    @patch.dict(os.environ, {"USE_DEBATE_ENGINE": "true"})
     def test_low_risk_no_category_no_trigger(self):
         """Test that low risk without special category doesn't trigger."""
         import debate_engine


### PR DESCRIPTION
## Summary

Refactors F-5 Debate Engine to use the centralized Pydantic settings object instead of reading environment variables directly via `os.getenv()`. Also adds validation constraints to `debate_engine_max_rounds`.

**Changes:**
- `debate_engine.py`: Import feature flags from `common.config.settings` instead of `os.getenv()`
- `settings.py`: Add `ge=1, le=10` validation to `debate_engine_max_rounds`
- `test_debate_engine.py`: Remove `@patch.dict(os.environ, ...)` decorators (tests now modify module-level variables directly)

## Review & Testing Checklist for Human

- [ ] Verify that existing deployments don't have `DEBATE_ENGINE_MAX_ROUNDS` set to values outside 1-10 range (would cause validation error on startup)
- [ ] Confirm the settings import works correctly in production environment (module-level import timing)

### Notes

Fixes #3907

This PR was requested by @RC918 and assisted by Devin.
Link to Devin run: https://app.devin.ai/sessions/16834c21998741ca99953fee3b80910f