### PR TITLE
test(f5): improve test isolation with @patch decorators

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tests/test_debate_engine.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_debate_engine.py
@@ -887,10 +887,10 @@ except ImportError:
 
 
 @pytest.mark.skipif(not HAS_LLM_MODULE, reason="llm module not available")
+@patch("debate_engine.DEBATE_ENGINE_ENABLE_LLM", True)
 class TestLLMIntegration:
     """Tests for LLM integration (mocked). Requires llm module in path."""
 
-    @patch("debate_engine.DEBATE_ENGINE_ENABLE_LLM", True)
     @patch("llm.client.get_client_for_task")
     def test_debate_agent_llm_success(self, mock_get_client):
         """Test successful LLM-based argument generation."""
@@ -920,7 +920,6 @@ class TestLLMIntegration:
         assert arg.reasoning == "LLM reasoning"
         assert arg.confidence == 0.9
 
-    @patch("debate_engine.DEBATE_ENGINE_ENABLE_LLM", True)
     @patch("llm.client.get_client_for_task")
     def test_debate_agent_llm_failure_fallback(self, mock_get_client):
         """Test fallback to template when LLM fails."""
@@ -939,7 +938,6 @@ class TestLLMIntegration:
         assert arg.role == DebateRole.LEFT
         assert "conventional" in arg.position.lower()
 
-    @patch("debate_engine.DEBATE_ENGINE_ENABLE_LLM", True)
     @patch("llm.client.get_client_for_task")
     def test_judge_agent_llm_success(self, mock_get_client):
         """Test successful LLM-based judge decision."""


### PR DESCRIPTION
## Summary

Improves test isolation in F-5 Debate Engine tests by replacing direct module-level variable modifications with `@patch` decorators. This ensures proper cleanup after each test and prevents potential test pollution.

**Changes:**
- `TestShouldTriggerDebate`: 8 tests updated to use `@patch("debate_engine.USE_DEBATE_ENGINE", True/False)`
- `TestLLMIntegration`: 3 tests updated to add `@patch("debate_engine.DEBATE_ENGINE_ENABLE_LLM", True)`

Fixes #3909

## Review & Testing Checklist for Human

- [ ] Verify decorator order is correct in `TestLLMIntegration` tests (outer `DEBATE_ENGINE_ENABLE_LLM` patch, inner `get_client_for_task` patch)
- [ ] Run tests locally to confirm all 62 tests still pass

**Test plan:** Run `pytest handoff/20250928/40_App/orchestrator/tests/test_debate_engine.py -v` and verify all tests pass.

### Notes

This PR was requested by @RC918 and assisted by Devin.
Link to Devin run: https://app.devin.ai/sessions/16834c21998741ca99953fee3b80910f