### PR TITLE
refactor(f5): use lazy evaluation for settings and improve Replanner docs

### DIFF
--- a/handoff/20250928/40_App/orchestrator/core/planner/self_refinement.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/self_refinement.py
@@ -53,9 +53,22 @@ def _get_settings():
         return None
 
 
-USE_SELF_REFINEMENT = _get_settings().use_self_refinement if _get_settings() else False
-MAX_TASK_REPLANS = _get_settings().self_refinement_max_task_replans if _get_settings() else 3
-MAX_FULL_REPLANS = _get_settings().self_refinement_max_full_replans if _get_settings() else 2
+def _use_self_refinement() -> bool:
+    """Lazy evaluation for USE_SELF_REFINEMENT setting."""
+    settings = _get_settings()
+    return settings.use_self_refinement if settings else False
+
+
+def _max_task_replans() -> int:
+    """Lazy evaluation for MAX_TASK_REPLANS setting."""
+    settings = _get_settings()
+    return settings.self_refinement_max_task_replans if settings else 3
+
+
+def _max_full_replans() -> int:
+    """Lazy evaluation for MAX_FULL_REPLANS setting."""
+    settings = _get_settings()
+    return settings.self_refinement_max_full_replans if settings else 2
 
 
 class FeedbackStatus(Enum):
@@ -292,6 +305,12 @@ class Replanner:
     - Determining if replanning is needed
     - Partial replan (single task and dependents)
     - Full replan with failure context
+
+    State Isolation Note:
+        This class maintains replan counts as instance variables. When using
+        Replanner directly (not via SelfRefinementLoop), call reset() before
+        each new plan execution to prevent state leakage between executions.
+        SelfRefinementLoop handles this automatically in execute_with_refinement().
     """
 
     def __init__(self, max_task_replans: int = 3, max_full_replans: int = 2):
@@ -625,8 +644,8 @@ class SelfRefinementLoop:
         self.executor = executor
         self.feedback_collector = FeedbackCollector()
         self.replanner = Replanner(
-            max_task_replans=max_task_replans or MAX_TASK_REPLANS,
-            max_full_replans=max_full_replans or MAX_FULL_REPLANS,
+            max_task_replans=max_task_replans or _max_task_replans(),
+            max_full_replans=max_full_replans or _max_full_replans(),
         )
         self._replan_history: List[Dict[str, Any]] = []
         self._consecutive_partial_failures: int = 0
@@ -647,7 +666,7 @@ class SelfRefinementLoop:
         Returns:
             RefinementResult with execution result and replan history
         """
-        if not USE_SELF_REFINEMENT:
+        if not _use_self_refinement():
             logger.debug(
                 "[SelfRefinementLoop] Self-refinement disabled, executing without refinement"
             )

--- a/handoff/20250928/40_App/orchestrator/tests/test_self_refinement.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_self_refinement.py
@@ -408,8 +408,8 @@ class TestSelfRefinementLoop:
         executor.execute.side_effect = results
         return executor
 
-    @patch("core.planner.self_refinement.USE_SELF_REFINEMENT", False)
-    def test_execute_without_refinement_disabled(self):
+    @patch("core.planner.self_refinement._use_self_refinement", return_value=False)
+    def test_execute_without_refinement_disabled(self, mock_use_self_refinement):
         """Test execution when self-refinement is disabled"""
         plan = self._create_test_plan()
         executor = self._create_mock_executor([
@@ -427,8 +427,8 @@ class TestSelfRefinementLoop:
         assert result.total_replans == 0
         assert result.escalated_to_hitl is False
 
-    @patch("core.planner.self_refinement.USE_SELF_REFINEMENT", True)
-    def test_execute_with_refinement_success(self):
+    @patch("core.planner.self_refinement._use_self_refinement", return_value=True)
+    def test_execute_with_refinement_success(self, mock_use_self_refinement):
         """Test successful execution with refinement enabled"""
         plan = self._create_test_plan()
         executor = self._create_mock_executor([
@@ -445,8 +445,8 @@ class TestSelfRefinementLoop:
         assert result.execution_result.status == ExecutionStatus.COMPLETED
         assert result.total_replans == 0
 
-    @patch("core.planner.self_refinement.USE_SELF_REFINEMENT", True)
-    def test_execute_with_refinement_failure_escalates(self):
+    @patch("core.planner.self_refinement._use_self_refinement", return_value=True)
+    def test_execute_with_refinement_failure_escalates(self, mock_use_self_refinement):
         """Test that non-recoverable failure escalates to HITL"""
         plan = self._create_test_plan()
         executor = self._create_mock_executor([


### PR DESCRIPTION
## Summary

Refactors the F-5 Self-refinement Loop settings pattern from module-level constants to lazy evaluation functions, addressing Issue #3912.

**Changes:**
1. **Lazy evaluation for settings** - Replaced `USE_SELF_REFINEMENT`, `MAX_TASK_REPLANS`, `MAX_FULL_REPLANS` constants with `_use_self_refinement()`, `_max_task_replans()`, `_max_full_replans()` functions that evaluate settings at runtime rather than import time
2. **Replanner documentation** - Added State Isolation Note to the `Replanner` class docstring explaining that `reset()` should be called before new plan executions when using Replanner directly
3. **Test updates** - Updated `@patch` decorators to use `return_value` pattern for mocking the new functions

## Review & Testing Checklist for Human

- [ ] **Verify no other code references old constants** - Search codebase for `USE_SELF_REFINEMENT`, `MAX_TASK_REPLANS`, `MAX_FULL_REPLANS` to ensure no broken references
- [ ] **Verify lazy evaluation behavior** - Confirm that changing settings at runtime (e.g., via environment variables) now takes effect without module reload

**Recommended test plan:**
1. Run `pytest handoff/20250928/40_App/orchestrator/tests/test_self_refinement.py -v` to verify all 28 tests pass
2. Optionally test runtime configuration by modifying `USE_SELF_REFINEMENT` setting between calls

### Notes

This is a low-risk refactoring that improves configurability without changing core behavior. The lazy evaluation pattern allows runtime configuration changes, which was not possible with the previous import-time constant evaluation.

Fixes #3912

Link to Devin run: https://app.devin.ai/sessions/16834c21998741ca99953fee3b80910f
Requested by: Ryan Chen (@RC918)