### PR TITLE
fix(reviewer): use LLMClient.generate() instead of OpenAI SDK style API

### DIFF
--- a/handoff/20250928/40_App/orchestrator/review_context/multi_specialist_reviewer.py
+++ b/handoff/20250928/40_App/orchestrator/review_context/multi_specialist_reviewer.py
@@ -347,11 +347,13 @@ class MultiSpecialistReviewer:
 
             # Use LLMClient.generate() API instead of OpenAI SDK style
             # LLMClient provides a unified interface across all providers
+            # json_mode=True ensures LLM outputs valid JSON for _parse_specialist_response
             response = client.generate(
                 prompt=user_prompt,
                 system_prompt=system_prompt,
                 temperature=0.1,
                 max_tokens=2000,
+                json_mode=True,
             )
 
             response_text = response.content or "[]"


### PR DESCRIPTION
## Summary

Fixes a bug in `MultiSpecialistReviewer` where the code was using OpenAI SDK style API (`client.chat.completions.create()`) on an `LLMClient` instance, which doesn't have a `chat` attribute.

The `get_client_for_task()` function returns an `LLMClient` wrapper that provides a unified `generate()` interface across all providers (OpenAI, Gemini, AliCloud). The previous code would fail with:
```
AttributeError: 'LLMClient' object has no attribute 'chat'
```

This error was silently caught because the feature is gated by `use_multi_specialist_review` flag and errors are logged as "non-blocking".

## Updates since last revision

- Added `json_mode=True` parameter to ensure LLM outputs valid JSON for `_parse_specialist_response` (addresses gemini-code-assist suggestion)

## Review & Testing Checklist for Human

- [ ] Verify that `LLMClient.generate()` returns an `LLMResponse` object with `.content` attribute containing the expected JSON format
- [ ] Verify `json_mode=True` works correctly across all providers (Gemini, AliCloud, OpenAI)
- [ ] Enable `use_multi_specialist_review=True` in staging and trigger a PR review to verify the fix works end-to-end
- [ ] Search codebase for other instances of `client.chat.completions.create()` that might have the same issue

**Recommended test plan:** Enable the multi-specialist review feature in staging (`USE_MULTI_SPECIALIST_REVIEW=true`), create a test PR, and verify that the review completes without errors and produces valid JSON findings.

### Notes

- Link to Devin run: https://app.devin.ai/sessions/850aeb54acea496ab723b6d0144d9c2f
- Requested by: Ryan Chen (@RC918)