### PR TITLE
feat(epic-f): Integrate F-4 AgentAssigner and F-5 SelfRefinementLoop into flow_integration

### DIFF
--- a/handoff/20250928/40_App/orchestrator/core/planner/flow_integration.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/flow_integration.py
@@ -70,12 +70,14 @@ class FlowIntegrationConfig:
         stop_on_failure: Whether to stop execution on task failure
         timeout_seconds: Timeout for task execution in seconds
         max_retries: Maximum number of retries for failed tasks
+        max_refinement_iterations: Maximum F-5 self-refinement iterations (default 3)
     """
     dry_run: bool = False
     max_parallel: int = 3
     stop_on_failure: bool = True
     timeout_seconds: int = 300
     max_retries: int = 2
+    max_refinement_iterations: int = 3
 
 
 class AgentStateUpdate(TypedDict, total=False):
@@ -473,7 +475,7 @@ def execute_with_flow_controller(
     replanner = Replanner() if use_refinement else None
     replan_history = []
     current_plan = plan
-    max_refinement_iterations = 3
+    max_refinement_iterations = config.max_refinement_iterations
 
     for iteration in range(max_refinement_iterations + 1):
         try:
@@ -526,8 +528,23 @@ def execute_with_flow_controller(
                 if len(failed_task_ids) == 1:
                     failed_task_id = failed_task_ids[0]
                     failed_feedback = next(
-                        f for f in feedbacks if f.task_id == failed_task_id
+                        (f for f in feedbacks if f.task_id == failed_task_id),
+                        None
                     )
+                    if failed_feedback is None:
+                        # Consistency error: failed task ID not found in feedback
+                        logger.warning(
+                            "[FlowIntegration] F-5 consistency error: failed task ID %s "
+                            "not found in feedback list. Escalating to HITL.",
+                            failed_task_id,
+                            extra={
+                                "trace_id": trace_id,
+                                "plan_id": current_plan.plan_id,
+                                "iteration": iteration,
+                                "operation": "execute_with_flow_controller",
+                            }
+                        )
+                        break
                     current_plan = replanner.replan_partial(
                         current_plan, failed_task_id, failed_feedback
                     )


### PR DESCRIPTION
## Summary

This PR wires the existing EPIC F modules (F-4 Agent Assignment and F-5 Self-Refinement Loop) into the `flow_integration.py` execution path. The code for these modules already existed but was not connected to the main flow.

**F-4 Integration (Agent Assignment):**
- After plan extraction, applies agent assignments and flow template selection via `assign_and_select()`
- Controlled by `USE_AGENT_ASSIGNMENT` feature flag (checked internally by the module)
- Non-critical: failures gracefully fall back to the default plan

**F-5 Integration (Self-Refinement Loop):**
- Wraps FlowController execution with a refinement loop (max 3 iterations)
- On execution failure, collects feedback and attempts replanning
- Supports both partial (single task) and full (multiple tasks) replanning
- Controlled by `USE_SELF_REFINEMENT` feature flag (checked internally)
- Escalates to HITL when replanning limits are exceeded

## Review & Testing Checklist for Human

- [ ] **Verify feature flags are enabled** in staging: `USE_AGENT_ASSIGNMENT=true` and `USE_SELF_REFINEMENT=true`
- [ ] **Test F-5 replanning behavior** - trigger a task failure and verify the self-refinement loop attempts replanning before escalating
- [ ] **Review the `next()` call on line 530-531** - could raise StopIteration if no matching feedback found (caught by try/except, but worth verifying)
- [ ] **Verify `max_refinement_iterations = 3` is appropriate** for your use case (hardcoded value)

**Recommended test plan:**
1. Deploy to staging with feature flags enabled
2. Submit a task that will fail on first attempt but succeed on retry
3. Check logs for `[FlowIntegration] F-5 replanned, continuing execution` messages
4. Verify the task eventually completes or properly escalates to HITL

### Notes

- Blueprint Reference: Section 3.1 (Planner v3)
- Pre-existing lint warnings (unused imports) were not addressed per project guidelines
- Link to Devin run: https://app.devin.ai/sessions/b08371b5aaa34b1a84cc84a1647ecd54
- Requested by: Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates EPIC F modules directly into the flow execution path for adaptive planning and execution.
> 
> - Applies F-4 agent assignment and flow template selection via `assign_and_select()` using optional `AssignmentContext`/`SelectionContext` from state (feature-flagged, non-fatal on error)
> - Wraps plan execution in F-5 self-refinement loop (max 3 iterations): collects feedback, decides `should_replan`, and performs partial or full replans via `Replanner`; escalates to HITL if replanning not allowed or fails
> - Execution now iterates on `current_plan`; updates logging (includes `replan_count`, iteration, replan type) and returns state based on the final `current_plan`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1bf93d8c7a02fbcb058892904badb0c08a157849. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->