### PR TITLE
docs: Update CHANGELOG and EPIC I roadmap for Week 3 PR 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **EPIC I Encapsulation Improvements** (PR #4009, Issues #3958, #3961)
+  - **Date**: 2026-01-15
+  - **Tag**: `week3-pr3-epic-i-encapsulation`
+  - **Changes**:
+    - Added `_extract_task_type()` helper method to `CapabilityScoreManager` with robust validation
+    - Handles edge cases: empty task_id, missing underscore, malformed formats
+    - Added `set_provider_state()` public method to `DegradationAdvisor` for controlled state updates
+    - Updated `RoutingPolicyEvolver._apply_to_routing_engine()` to use public method instead of direct private attribute access
+    - Added structured logging fields for better log parsing and monitoring
+  - **Blueprint Alignment**: Section 4.4 (Autonomous Provisioning v2), EPIC I Phase I-3/I-4
+
 ### Removed
 - **Simple Mode Orchestrator Deprecated** (Issue #2651, PR #2767)
   - **Date**: 2025-12-15

--- a/docs/EPIC_I_GOVERNANCE_ROADMAP.md
+++ b/docs/EPIC_I_GOVERNANCE_ROADMAP.md
@@ -3,7 +3,25 @@
 **Issue**: [#3342](https://github.com/RC918/morningai/issues/3342)  
 **Blueprint Reference**: Section 4.3 (Model Governance Framework v2) + Section 4.4 (Autonomous Provisioning v2)  
 **Status**: Phase I-1 Complete, Phase I-2a Complete (observe-only), Phase I-2b+ gated by #3249  
-**Last Updated**: 2026-01-09
+**Last Updated**: 2026-01-15
+
+## Recent Updates
+
+### 2026-01-15: Encapsulation Improvements (PR #4009)
+
+**Issues Closed**: #3958, #3961  
+**Tag**: `week3-pr3-epic-i-encapsulation`
+
+| Component | Change | Benefit |
+|-----------|--------|---------|
+| `CapabilityScoreManager` | Added `_extract_task_type()` helper with validation | Robust task_id parsing, handles edge cases |
+| `DegradationAdvisor` | Added `set_provider_state()` public method | Clean encapsulation, no direct private attribute access |
+| `RoutingPolicyEvolver` | Uses public method instead of `_provider_states` | Better maintainability, follows Blueprint Section 4.4 |
+
+**Code Quality**:
+- Structured logging with `extra={}` fields for programmatic log parsing
+- Comprehensive validation for malformed task_id inputs
+- Thread-safe state updates via existing `_lock` mechanism
 
 ## Executive Summary
 


### PR DESCRIPTION
## Summary

Documentation updates to reflect the EPIC I Encapsulation Improvements completed in PR #4009.

**Changes:**
- Added CHANGELOG entry for PR #4009 (Issues #3958, #3961)
- Added "Recent Updates" section to EPIC I Governance Roadmap
- Updated roadmap "Last Updated" date to 2026-01-15
- Referenced tag: `week3-pr3-epic-i-encapsulation`

## Review & Testing Checklist for Human

- [ ] Verify tag `week3-pr3-epic-i-encapsulation` exists: `git tag -l | grep week3-pr3`
- [ ] Confirm PR #4009 is merged and issues #3958, #3961 are closed

### Notes

This is a documentation-only PR with no code changes. The documentation reflects the encapsulation improvements made to `CapabilityScoreManager`, `DegradationAdvisor`, and `RoutingPolicyEvolver` in PR #4009.

---
**Link to Devin run**: https://app.devin.ai/sessions/99bde2b561764eb39a0608b93621ddeb  
**Requested by**: Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Documentation sync for EPIC I Encapsulation Improvements**
> 
> - Update `CHANGELOG.md` (Unreleased → Changed) with PR #4009 details: `_extract_task_type()` validation in `CapabilityScoreManager`, `set_provider_state()` in `DegradationAdvisor`, `RoutingPolicyEvolver` using public method, and structured logging notes; include tag `week3-pr3-epic-i-encapsulation` and date 2026-01-15.
> - Extend `docs/EPIC_I_GOVERNANCE_ROADMAP.md` with a new "Recent Updates" section (2026-01-15) summarizing the same encapsulation changes and code-quality points; bump "Last Updated" to 2026-01-15.
> 
> *Docs-only; no code changes.*
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3718a181a482e5b0baceee1470cc7864ea48d0e9. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->