### PR TITLE
fix(epic-b): Add observability log before B-13 _save_review_feedback() call

### DIFF
--- a/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
+++ b/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
@@ -670,6 +670,17 @@ class LLMReviewerAdapter:
             )
 
             # EPIC B-13: Save review feedback to Memory v2 for learning
+            # Observability: Log before calling to diagnose if this code path is reached
+            logger.info(
+                "[LLM Reviewer] B-13: About to save review feedback",
+                extra={
+                    "operation": "save_review_feedback_entry",
+                    "trace_id": self.trace_id,
+                    "pr_number": pr_number,
+                    "repo": repo,
+                    "has_result": result is not None,
+                }
+            )
             self._save_review_feedback(
                 pr_number=pr_number,
                 repo=repo,


### PR DESCRIPTION
## Summary

Adds a diagnostic log statement immediately before calling `_save_review_feedback()` to help diagnose why B-13 Feedback Loop logs are not appearing in staging.

**Background:** Staging logs show B-9, B-11, B-12 modules are running correctly, but B-13 logs (both "disabled" and "saved" variants) are completely absent. This suggests `_save_review_feedback()` may not be getting called at all, despite being positioned right after `_run_enhanced_review_modules()` in the code flow.

**Change:** Adds `[LLM Reviewer] B-13: About to save review feedback` log with trace_id, pr_number, repo, and has_result fields.

## Review & Testing Checklist for Human

- [ ] After deployment, search staging logs for `B-13: About to save review feedback` to confirm the code path is reached
- [ ] If this log appears but subsequent B-13 logs don't, the issue is inside `_save_review_feedback()`
- [ ] If this log does NOT appear, the issue is likely a deployment/code version problem

### Notes

This is a diagnostic-only change to help troubleshoot the B-13 observability issue. Once the root cause is identified, this log can be kept for ongoing observability or removed if deemed too verbose.

**Devin run:** https://app.devin.ai/sessions/b08371b5aaa34b1a84cc84a1647ecd54
**Requested by:** Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a targeted diagnostic to verify the B-13 feedback save path is reached during reviews.
> 
> - Inserts `logger.info` immediately before calling `'_save_review_feedback'` with `operation='save_review_feedback_entry'`, `trace_id`, `pr_number`, `repo`, and `has_result` for observability
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4196bb5006689c2f879ac8e04cc6cc51fcfd396c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->