### PR TITLE
feat(security): Add input validation and sanitization for review feedback (#4007, #3857)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/core/planner/agent_task_executor.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/agent_task_executor.py
@@ -26,6 +26,7 @@ Usage:
 """
 
 import logging
+import re
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -35,6 +36,66 @@ from .consumer import ExecutionStatus, TaskResult
 from .planner_types import TaskNode, TaskType
 
 logger = logging.getLogger(__name__)
+
+
+# Issue #3857: Input validation constants for TaskNode
+# Blueprint Section 4.7: Defense in Depth - validate inputs before dispatch
+MAX_TASK_ID_LENGTH = 256
+MAX_DESCRIPTION_LENGTH = 10000
+# Pattern for valid task_id: alphanumeric, hyphens, underscores, colons, dots
+VALID_TASK_ID_PATTERN = re.compile(r'^[a-zA-Z0-9_\-:.]+$')
+
+
+class TaskValidationError(ValueError):
+    """Raised when TaskNode validation fails."""
+    pass
+
+
+def validate_task_node(task: TaskNode) -> None:
+    """
+    Validate TaskNode before dispatching to agent.
+
+    Issue #3857: Add input validation for TaskNode in AgentTaskExecutor.
+    Blueprint Section 4.7: Defense in Depth - validate inputs before dispatch.
+
+    This is defense-in-depth validation since TaskNode is already a typed
+    dataclass with validated fields, and tasks come from FlowController
+    which validates PlannerOutput.
+
+    Args:
+        task: The TaskNode to validate
+
+    Raises:
+        TaskValidationError: If validation fails
+    """
+    # Validate task_id: non-empty, sanitized, reasonable length
+    if not task.task_id:
+        raise TaskValidationError("task_id cannot be empty")
+
+    if len(task.task_id) > MAX_TASK_ID_LENGTH:
+        raise TaskValidationError(
+            f"task_id exceeds maximum length ({len(task.task_id)} > {MAX_TASK_ID_LENGTH})"
+        )
+
+    if not VALID_TASK_ID_PATTERN.match(task.task_id):
+        raise TaskValidationError(
+            f"task_id contains invalid characters: {task.task_id[:50]}"
+        )
+
+    # Validate task_type: must be a valid TaskType enum value
+    if not isinstance(task.task_type, TaskType):
+        raise TaskValidationError(
+            f"task_type must be a TaskType enum, got {type(task.task_type).__name__}"
+        )
+
+    # Validate description: non-empty, reasonable length
+    if not task.description:
+        raise TaskValidationError("description cannot be empty")
+
+    if len(task.description) > MAX_DESCRIPTION_LENGTH:
+        raise TaskValidationError(
+            f"description exceeds maximum length ({len(task.description)} > {MAX_DESCRIPTION_LENGTH})"
+        )
 
 
 class AgentDispatcher(Protocol):
@@ -288,6 +349,8 @@ class AgentTaskExecutor:
 
         This method implements the TaskExecutor protocol from flow_controller.py.
 
+        Issue #3857: Added defense-in-depth input validation before dispatch.
+
         Args:
             task: The TaskNode to execute
             context: Execution context from FlowController
@@ -298,6 +361,30 @@ class AgentTaskExecutor:
         self._execution_count += 1
         started_at = datetime.now(timezone.utc)
         start_time = time.time()
+
+        # Issue #3857: Defense-in-depth input validation before dispatch
+        # TaskNode is already validated by FlowController, but we validate again
+        # to ensure no malicious content reaches the agent dispatcher
+        try:
+            validate_task_node(task)
+        except TaskValidationError as e:
+            logger.warning(
+                "[AgentTaskExecutor] Task validation failed",
+                extra={
+                    "task_id": getattr(task, 'task_id', 'unknown'),
+                    "validation_error": str(e),
+                    "operation": "validate",
+                }
+            )
+            return TaskResult(
+                task_id=getattr(task, 'task_id', 'invalid'),
+                status=ExecutionStatus.FAILED,
+                outputs={},
+                error_message="Task validation failed. Check logs for details.",
+                started_at=started_at,
+                completed_at=datetime.now(timezone.utc),
+                actual_duration_minutes=0,
+            )
 
         logger.info(
             "[AgentTaskExecutor] Starting task execution",

--- a/handoff/20250928/40_App/orchestrator/memory/memory_integration.py
+++ b/handoff/20250928/40_App/orchestrator/memory/memory_integration.py
@@ -826,6 +826,36 @@ def get_memory_stats() -> Dict[str, Any]:
         return {"enabled": True, "error": str(e)}
 
 
+def _sanitize_diff_for_storage(diff_snippet: Optional[str]) -> tuple[Optional[str], int]:
+    """
+    Sanitize diff snippet before storing in Knowledge Base.
+
+    Issue #4007: Add sanitization for sensitive data in review feedback storage.
+    Blueprint Section 4.7: Defense in Depth - prevent credential leakage.
+
+    This reuses the secrets redaction patterns from llm_reviewer_adapter
+    to ensure consistent sanitization across the codebase.
+
+    Args:
+        diff_snippet: Raw diff snippet to sanitize
+
+    Returns:
+        Tuple of (sanitized_diff, redaction_count)
+    """
+    if not diff_snippet:
+        return diff_snippet, 0
+
+    try:
+        from llm_reviewer_adapter import sanitize_diff_content
+        return sanitize_diff_content(diff_snippet)
+    except ImportError:
+        logger.warning(
+            "[MemoryIntegration] Could not import sanitize_diff_content, "
+            "storing diff without sanitization"
+        )
+        return diff_snippet, 0
+
+
 def save_review_feedback(
     pr_number: int,
     repo: str,
@@ -846,6 +876,9 @@ def save_review_feedback(
 
     This enables the system to learn from past reviews and provide
     better suggestions for similar code patterns in the future.
+
+    Issue #4007: Diff snippets are now sanitized before storage to prevent
+    credential leakage if secrets are present in the diff.
 
     Args:
         pr_number: Pull request number
@@ -873,6 +906,21 @@ def save_review_feedback(
     try:
         from .memory_v2 import MemoryEntry, MemoryLayer, MemoryScope
 
+        # Issue #4007: Sanitize diff snippet before storage to prevent credential leakage
+        sanitized_diff, redaction_count = _sanitize_diff_for_storage(diff_snippet)
+        if redaction_count > 0:
+            logger.info(
+                "[MemoryIntegration] Redacted %d potential secrets from diff_snippet",
+                redaction_count,
+                extra={
+                    "pr_number": pr_number,
+                    "repo": repo,
+                    "redaction_count": redaction_count,
+                    "trace_id": trace_id,
+                    "operation": "sanitize_diff_for_storage",
+                }
+            )
+
         content = json.dumps({
             "pr_number": pr_number,
             "repo": repo,
@@ -882,7 +930,7 @@ def save_review_feedback(
             "review_comments": review_comments,
             "file_paths": file_paths,
             "blocker_count": blocker_count,
-            "diff_snippet": diff_snippet,  # Already truncated by caller
+            "diff_snippet": sanitized_diff,  # Sanitized for credential protection
             "saved_at": datetime.now(timezone.utc).isoformat(),
         })
 


### PR DESCRIPTION
## Summary

This PR adds two defense-in-depth security improvements:

**#4007 - Sanitization for review feedback storage:**
- Added `_sanitize_diff_for_storage()` in `memory_integration.py` that sanitizes diff snippets before storing in Knowledge Base
- Reuses existing `SECRETS_REDACTION_PATTERNS` from `llm_reviewer_adapter` for consistent secret detection
- Gracefully degrades if import fails (logs warning, stores unsanitized)

**#3857 - Input validation for TaskNode in AgentTaskExecutor:**
- Added `validate_task_node()` function with validation for:
  - `task_id`: non-empty, max 256 chars, alphanumeric with `-_:.`
  - `task_type`: must be valid TaskType enum
  - `description`: non-empty, max 10000 chars
- Returns FAILED TaskResult with generic error message on validation failure (security: doesn't expose details)

Both align with Blueprint Section 4.7: Defense in Depth.

## Review & Testing Checklist for Human

- [ ] **Verify task_id regex pattern** (`^[a-zA-Z0-9_\-:.]+$`) matches all valid task_id formats currently used in the codebase - this could reject legitimate task IDs if too restrictive
- [ ] **Test the import path** - verify `from llm_reviewer_adapter import sanitize_diff_content` works correctly from the `memory_integration.py` context
- [ ] **Consider adding unit tests** for `validate_task_node()` and `_sanitize_diff_for_storage()` - these are security-critical functions without test coverage in this PR

**Suggested test plan:**
1. Run existing tests to ensure no regressions
2. Manually test with a diff containing a secret pattern (e.g., `ghp_xxx...`) to verify redaction works
3. Verify normal task execution still works with valid TaskNode inputs

### Notes
- The C901 complexity warning on `search_review_patterns` is pre-existing and unrelated to this PR
- Both features are defense-in-depth (additional validation layers on top of existing checks)

Link to Devin run: https://app.devin.ai/sessions/99bde2b561764eb39a0608b93621ddeb
Requested by: @RC918

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds two defense-in-depth safeguards across orchestrator components.
> 
> - **Task validation in `AgentTaskExecutor`**: New `validate_task_node()` enforces `task_id` format/length, `task_type` enum, and `description` presence/length; `execute()` validates before dispatch and returns a FAILED `TaskResult` with a generic error on violation (logs details safely).
> - **Diff sanitization for review feedback**: New `memory_integration._sanitize_diff_for_storage()` reuses `llm_reviewer_adapter.sanitize_diff_content`; `save_review_feedback()` now stores sanitized `diff_snippet` and logs redaction counts; gracefully falls back if the sanitizer import is unavailable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e22ffe5ef6c398d0af263b5051faa2aa91963c1a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->