### PR TITLE
feat(memory): upgrade KnowledgeBase save log for observability

### DIFF
--- a/handoff/20250928/40_App/orchestrator/memory/memory_v2.py
+++ b/handoff/20250928/40_App/orchestrator/memory/memory_v2.py
@@ -765,7 +765,7 @@ class KnowledgeBaseMemory(SupabaseMemoryStore):
             }
 
             client.table(self.TABLE).upsert(record, on_conflict="key").execute()
-            logger.debug(f"[Memory:KnowledgeBase] Saved: {entry_copy.key}")
+            logger.info(f"[Memory:KnowledgeBase] Saved: {entry_copy.key}")
             return True
 
         except Exception as e:


### PR DESCRIPTION
## Summary

Upgrades the KnowledgeBase save success log from `debug` to `info` level for better observability in production logs.

This change helps verify that the recent embedding dimension fix (1536 → 1024) is working correctly by making successful saves visible in Render logs.

## Review & Testing Checklist for Human

- [ ] Verify the log level change is appropriate (info vs debug) - consider if this might cause excessive log noise in high-traffic scenarios

### Notes

**Requested by**: @RC918  
**Link to Devin run**: https://app.devin.ai/sessions/2b8d0abec43d403e8f90bd0e4dccaba4

**Context**: This PR also serves to trigger a new Reviewer Agent review to verify the KnowledgeBase embedding dimension fix is working. After this PR triggers a review, check Render logs for `[Memory:KnowledgeBase] Saved:` messages instead of `Failed to save: expected 1536 dimensions` errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Logging**
> 
> - Raise `KnowledgeBaseMemory.save` success log from `debug` to `info` (`[Memory:KnowledgeBase] Saved: <key>`), increasing visibility of successful persistence events in production logs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec3746206b0192f9346e8619622085b8110bfa90. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->