### PR TITLE
refactor(ux-agents): code quality improvements (Fixes #4127)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/ux_agents/design_token_agent.py
+++ b/handoff/20250928/40_App/orchestrator/ux_agents/design_token_agent.py
@@ -602,16 +602,17 @@ class DesignTokenGovernanceAgent:
 
         base_score = int(compliance_rate)
 
+        severity_multiplier_map = {
+            ViolationSeverity.CRITICAL: 15,
+            ViolationSeverity.HIGH: 10,
+            ViolationSeverity.MEDIUM: 5,
+            ViolationSeverity.LOW: 2,
+            ViolationSeverity.INFO: 1,
+        }
         total_deduction = 0
         for violation in violations:
             weight = TYPE_WEIGHTS.get(violation.violation_type, 0.05)
-            severity_multiplier = {
-                ViolationSeverity.CRITICAL: 15,
-                ViolationSeverity.HIGH: 10,
-                ViolationSeverity.MEDIUM: 5,
-                ViolationSeverity.LOW: 2,
-                ViolationSeverity.INFO: 1,
-            }.get(violation.severity, 1)
+            severity_multiplier = severity_multiplier_map.get(violation.severity, 1)
             total_deduction += int(severity_multiplier * (1 + weight))
 
         return max(0, min(base_score, 100 - total_deduction))

--- a/handoff/20250928/40_App/orchestrator/ux_agents/ui_consistency_agent.py
+++ b/handoff/20250928/40_App/orchestrator/ux_agents/ui_consistency_agent.py
@@ -460,11 +460,12 @@ class UIConsistencyAgent:
         component_pattern = re.compile(
             r"(?:export\s+)?(?:const|function)\s+([a-zA-Z_][a-zA-Z0-9_]*)"
         )
+        pascal_case_pattern = re.compile(r"^[A-Z][a-zA-Z0-9]*$")
         components = component_pattern.findall(code_content)
 
         for component in components:
-            if not re.match(r"^[A-Z][a-zA-Z0-9]*$", component):
-                if component[0].isupper():
+            if not pascal_case_pattern.match(component):
+                if component[0].isupper() and '_' not in component:
                     score -= 10
                     findings.append(UIConsistencyFinding(
                         category=ConsistencyCategory.COMPONENT_NAMING,


### PR DESCRIPTION
## Summary

Addresses code quality improvements identified during PR #4126 review, following Blueprint Section 9 (Self-Governed) maintainability principles.

**Changes:**
1. **Fix redundant component naming check logic (P1)** - The original regex only captured PascalCase names, making the subsequent validation check ineffective. Now captures all function/const names and properly validates those starting with uppercase.

2. **Extract magic values to named constants (P2)** - Added `ALLOWED_HARDCODED_SPACING_VALUES` constants in both `ui_consistency_agent.py` and `design_token_agent.py`.

3. **Integrate unused constants (P2)** - `SEVERITY_THRESHOLDS` and `TYPE_WEIGHTS` were previously defined but unused. Now integrated into `_determine_severity()` and `_calculate_overall_score()`.

## Review & Testing Checklist for Human

- [ ] **Verify scoring formula change** - The new `_calculate_overall_score()` uses `TYPE_WEIGHTS` which changes deduction calculation from fixed values to `int(severity_multiplier * (1 + weight))`. Confirm this produces sensible scores for your use cases.
- [ ] **Verify component naming logic** - The fix now only flags names that start with uppercase but don't follow strict PascalCase (e.g., `MyComponent_v2` would be flagged, but `myHelper` would not). Confirm this is the desired behavior.
- [ ] **Run the 54 UX agent tests** - `pytest ux_agents/tests/test_ux_agents.py -v`

### Notes

- All 54 existing tests pass
- The `SEVERITY_THRESHOLDS` constant naming may seem inverted (e.g., `CRITICAL: 90` is used to return `INFO`), but this matches the original hardcoded logic

**Link to Devin run:** https://app.devin.ai/sessions/c6330a3682fb4872afdc866d753237b7
**Requested by:** Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements targeted refactors to improve correctness and configurability in UX agents.
> 
> - **Component naming fix (UI Consistency):** Regex now captures all identifiers (`const|function <name>`); flags only uppercase-starting names that aren’t strict PascalCase.
> - **Magic values -> constants:** Adds `ALLOWED_HARDCODED_SPACING_VALUES` in `ui_consistency_agent.py` and `design_token_agent.py`, replacing inline lists in spacing checks.
> - **Scoring/severity updates (Design Token):** `_calculate_overall_score()` now factors `TYPE_WEIGHTS` with a severity multiplier; `_determine_severity()` uses `SEVERITY_THRESHOLDS` instead of hardcoded cutoffs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c5537ff51195c0d18759f240d3dfa8a5d929d2b. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->