### PR TITLE
feat(governance): sync VALID_AGENT_TYPES with AgentType enum (Fixes #4121)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/governance/principal_context.py
+++ b/handoff/20250928/40_App/orchestrator/governance/principal_context.py
@@ -31,6 +31,7 @@ class AgentType(str, Enum):
 
     Blueprint Reference: Section 3.3 - 13 Agent Types
     Issue: #4118 (EPIC K P0: AgentType Enum Extension)
+    Sync: #4121 (EPIC K: Sync VALID_AGENT_TYPES with AgentType enum)
 
     Categories (13 Blueprint types → 19 enum values total):
     - Core Engineering Agents (5): Planner, Coding, Reviewer, Test, Debugger
@@ -38,8 +39,8 @@ class AgentType(str, Enum):
     - Governance/Reasoning Agents (3 types, 4 values): Judge, Debate Left, Debate Right, Risk Analyzer
     - Legacy/Compatibility (6): dev_agent, ops_agent, pm_agent, etc.
 
-    Note: VALID_AGENT_TYPES in reputation_engine.py only includes legacy types.
-    New Blueprint agent types will be integrated in follow-up issues.
+    VALID_AGENT_TYPES in reputation_engine.py is synced with this enum (excluding 'unknown').
+    DB constraint updated in migration 044_extend_agent_type_constraint.sql.
     """
     # === Core Engineering Agents (Blueprint 3.3) ===
     PLANNER = "planner"

--- a/handoff/20250928/40_App/orchestrator/governance/reputation_engine.py
+++ b/handoff/20250928/40_App/orchestrator/governance/reputation_engine.py
@@ -29,8 +29,32 @@ def _is_valid_uuid(value: str) -> bool:
         return False
 
 
-# Valid agent_types as defined in DB constraint (migration 021_agent_reputation_system.sql)
+# Valid agent_types as defined in DB constraint (migration 044_extend_agent_type_constraint.sql)
+# Blueprint Reference: Section 3.3 - Agent Catalog V2 (13 Agent Types → 18 values)
+# Issue: #4121 (EPIC K: Sync VALID_AGENT_TYPES with AgentType enum)
+#
+# Benchmark Framework (from Issue #4121):
+# - Core Engineering Agents: Benchmark against Devin AI
+# - UX/UI Agents: Benchmark against Figma plugins, Lighthouse, Percy
+# - Governance Agents: Benchmark against Lakera Guard, Portkey, Arize AI
 VALID_AGENT_TYPES = frozenset({
+    # === Core Engineering Agents (Blueprint 3.3) ===
+    'planner',
+    'coding',
+    'reviewer',
+    'test',
+    'debugger',
+    # === UX/UI Agents (Blueprint 3.3) ===
+    'ui_consistency',
+    'ux_heuristic',
+    'visual_regression',
+    'design_token_governance',
+    # === Governance/Reasoning Agents (Blueprint 3.3) ===
+    'judge',
+    'debate_left',
+    'debate_right',
+    'risk_analyzer',
+    # === Legacy Agent Types (backward compatibility) ===
     'dev_agent',
     'ops_agent',
     'pm_agent',
@@ -145,8 +169,12 @@ class ReputationEngine:
         """Get or create agent reputation record.
         
         Args:
-            agent_type: Must be one of VALID_AGENT_TYPES (dev_agent, ops_agent, 
-                       pm_agent, growth_strategist, meta_agent)
+            agent_type: Must be one of VALID_AGENT_TYPES. See Blueprint Section 3.3
+                       for the full list of 18 valid agent types including:
+                       - Core Engineering: planner, coding, reviewer, test, debugger
+                       - UX/UI: ui_consistency, ux_heuristic, visual_regression, design_token_governance
+                       - Governance: judge, debate_left, debate_right, risk_analyzer
+                       - Legacy: dev_agent, ops_agent, pm_agent, growth_strategist, meta_agent
         
         Returns:
             Agent UUID if successful, None otherwise

--- a/migrations/044_extend_agent_type_constraint.sql
+++ b/migrations/044_extend_agent_type_constraint.sql
@@ -1,0 +1,45 @@
+-- Migration 044: Extend agent_type CHECK constraint for Blueprint 3.3 Agent Types
+-- Issue: #4121 (EPIC K: Sync VALID_AGENT_TYPES with AgentType enum)
+-- Blueprint Reference: Section 3.3 - Agent Catalog V2 (13 Agent Types)
+--
+-- This migration extends the agent_type CHECK constraint to include all
+-- Blueprint 3.3 defined agent types, enabling the reputation system to
+-- track new agent categories:
+--   - Core Engineering Agents (5): planner, coding, reviewer, test, debugger
+--   - UX/UI Agents (4): ui_consistency, ux_heuristic, visual_regression, design_token_governance
+--   - Governance/Reasoning Agents (4): judge, debate_left, debate_right, risk_analyzer
+--   - Legacy Agents (5): dev_agent, ops_agent, pm_agent, growth_strategist, meta_agent
+
+-- Step 1: Drop the existing CHECK constraint
+ALTER TABLE agent_reputation DROP CONSTRAINT IF EXISTS agent_reputation_agent_type_check;
+
+-- Step 2: Add the new CHECK constraint with all Blueprint 3.3 agent types
+ALTER TABLE agent_reputation ADD CONSTRAINT agent_reputation_agent_type_check 
+    CHECK (agent_type IN (
+        -- Core Engineering Agents (Blueprint 3.3)
+        'planner',
+        'coding', 
+        'reviewer',
+        'test',
+        'debugger',
+        -- UX/UI Agents (Blueprint 3.3)
+        'ui_consistency',
+        'ux_heuristic',
+        'visual_regression',
+        'design_token_governance',
+        -- Governance/Reasoning Agents (Blueprint 3.3)
+        'judge',
+        'debate_left',
+        'debate_right',
+        'risk_analyzer',
+        -- Legacy Agent Types (backward compatibility)
+        'dev_agent',
+        'ops_agent',
+        'pm_agent',
+        'growth_strategist',
+        'meta_agent'
+    ));
+
+-- Step 3: Add comment documenting the change
+COMMENT ON CONSTRAINT agent_reputation_agent_type_check ON agent_reputation IS 
+    'Valid agent types as defined in Blueprint Section 3.3 (Agent Catalog V2). Extended in migration 044 to include all 18 Blueprint agent types.';


### PR DESCRIPTION
# feat(governance): sync VALID_AGENT_TYPES with AgentType enum (Fixes #4121)

## Summary

This PR completes EPIC K by syncing `VALID_AGENT_TYPES` in `reputation_engine.py` with the `AgentType` enum from `principal_context.py`. This enables the reputation system to track all 18 Blueprint agent types (13 new + 5 legacy).

**Changes:**
- Extended `VALID_AGENT_TYPES` frozenset from 5 legacy types to 18 Blueprint types
- Added DB migration 044 to update the `agent_type` CHECK constraint
- Updated docstrings to reference Blueprint Section 3.3 and benchmark framework

**Agent Types Added:**
- Core Engineering (5): planner, coding, reviewer, test, debugger
- UX/UI (4): ui_consistency, ux_heuristic, visual_regression, design_token_governance
- Governance (4): judge, debate_left, debate_right, risk_analyzer

## Review & Testing Checklist for Human

- [ ] Verify the 18 agent types in `VALID_AGENT_TYPES` (Python) exactly match the 18 types in migration 044 (SQL)
- [ ] Confirm that excluding 'unknown' from `VALID_AGENT_TYPES` is intentional (it's a fallback type, not meant for reputation tracking)
- [ ] Review migration 044 - ensure no existing `agent_reputation` rows have agent_types that would violate the new constraint (should be safe since we're only adding types)

**Test Plan:** After migration runs, verify that `get_or_create_agent()` accepts new agent types like 'planner', 'coding', etc. without validation errors.

### Notes

Blueprint Reference: Section 3.3 - Agent Catalog V2

This PR was requested by @RC918 and assisted by Devin.
Link to Devin run: https://app.devin.ai/sessions/c6330a3682fb4872afdc866d753237b7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns the reputation system with Blueprint Section 3.3 by syncing agent types across code and database.
> 
> - Expands `VALID_AGENT_TYPES` in `reputation_engine.py` from 5 legacy types to 18 Blueprint types (Core Engineering, UX/UI, Governance, Legacy)
> - Adds migration `044_extend_agent_type_constraint.sql` to update `agent_reputation.agent_type` CHECK constraint to the same 18 values
> - Updates `AgentType` enum docstring in `principal_context.py` and `get_or_create_agent()` docstring to reference the synced list and migration
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d144df32fee3102fd3a6810108df140efe269b2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->