### PR TITLE
refactor(pii-scanner): expose public redaction utility method (Fixes #4050)

### DIFF
--- a/common/config/settings.py
+++ b/common/config/settings.py
@@ -1999,13 +1999,24 @@ class Settings(BaseSettings):
         description="Maximum regression tests to generate per run (H-2.3). Limits LLM costs. Valid range: 1-20."
     )
 
-    # NOTE: regression_test_output_dir is defined for H-2.4 (Regression Test Execution)
-    # which will write generated tests to disk. Currently unused in H-2.3.
-    # (gemini-code-assist: clarify future-enhancement settings)
+    # H-2.4: Regression Test Execution (Blueprint Section 5.4)
+    # Writes generated tests to disk, CI enforcement, Safety Governor integration
     regression_test_output_dir: str = Field(
         default="tests/regression",
         alias="REGRESSION_TEST_OUTPUT_DIR",
-        description="Directory to write generated regression tests (H-2.4). Relative to repo root. Currently unused - will be used when H-2.4 implements test file writing."
+        description="Directory to write generated regression tests (H-2.4). Relative to repo root."
+    )
+
+    regression_test_write_to_disk: bool = Field(
+        default=False,
+        alias="REGRESSION_TEST_WRITE_TO_DISK",
+        description="Enable writing generated regression tests to disk (H-2.4). When True, tests are written to regression_test_output_dir. Requires USE_REGRESSION_PIPELINE=True."
+    )
+
+    regression_test_protection_enabled: bool = Field(
+        default=True,
+        alias="REGRESSION_TEST_PROTECTION_ENABLED",
+        description="Enable Safety Governor protection for regression tests (H-2.4). When True, deletion of protected tests is blocked and modifications require approval."
     )
 
     # Coverage Thresholds (Blueprint Section 5.4: CI Enforcement)

--- a/handoff/20250928/40_App/orchestrator/simulation/regression.py
+++ b/handoff/20250928/40_App/orchestrator/simulation/regression.py
@@ -13,15 +13,22 @@ H-2.3 Test Generation Integration:
 - Bridges RegressionTestGenerator with LLM for actual test code generation
 - Uses MRE from Diagnostic Agent to create functional tests
 - Falls back to template generation if LLM fails
+
+H-2.4 Regression Test Execution:
+- Writes generated tests to disk (regression_test_output_dir)
+- CI enforcement rules (block PR on failure, require approval on modification)
+- Safety Governor integration (block deletion of protected tests)
 """
 
 import ast
 import hashlib
 import logging
+import os
+import re
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 logger = logging.getLogger(__name__)
 
@@ -1020,6 +1027,436 @@ REGRESSION_METADATA = {{
             )
             results.append(result)
         return results
+
+    # =========================================================================
+    # H-2.4: Regression Test Execution - Write Tests to Disk
+    # =========================================================================
+
+    def write_test_to_disk(
+        self,
+        test_code: str,
+        test_name: str,
+        candidate_id: str,
+        repo_path: str,
+        output_dir: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Write a generated regression test to disk.
+
+        H-2.4 Regression Test Execution (Blueprint Section 5.4):
+        - Writes generated tests to regression_test_output_dir
+        - Sanitizes file paths to prevent directory traversal
+        - Creates directory structure if needed
+        - Adds REGRESSION_METADATA for CI enforcement
+
+        Args:
+            test_code: Generated test code to write
+            test_name: Name of the test (used for filename)
+            candidate_id: ID of the regression candidate
+            repo_path: Path to the repository root
+            output_dir: Output directory (relative to repo_path).
+                       Uses regression_test_output_dir setting if not specified.
+
+        Returns:
+            Dict with:
+                - success: bool
+                - file_path: str (absolute path to written file)
+                - relative_path: str (path relative to repo_path)
+                - error: Optional[str] (if failed)
+        """
+        result: Dict[str, Any] = {
+            "success": False,
+            "file_path": "",
+            "relative_path": "",
+            "error": None,
+        }
+
+        # Get output directory from settings if not specified
+        if output_dir is None:
+            try:
+                from common.config.settings import settings
+                output_dir = getattr(
+                    settings, 'regression_test_output_dir', 'tests/regression'
+                )
+            except ImportError:
+                output_dir = "tests/regression"
+
+        # Sanitize test_name to prevent directory traversal
+        safe_test_name = self._sanitize_filename(test_name)
+        if not safe_test_name:
+            result["error"] = "Invalid test name after sanitization"
+            logger.warning(
+                "[Regression] H-2.4: Invalid test name",
+                extra={
+                    "operation": "simulation.regression.write",
+                    "test_name": test_name,
+                    "candidate_id": candidate_id,
+                }
+            )
+            return result
+
+        # Build file path
+        filename = f"{safe_test_name}.py"
+        relative_path = os.path.join(output_dir, filename)
+
+        # Validate path doesn't escape repo_path (directory traversal protection)
+        # (Cursor Bugbot: add trailing separator to prevent sibling directory bypass)
+        abs_repo_path = os.path.abspath(repo_path)
+        abs_file_path = os.path.abspath(os.path.join(repo_path, relative_path))
+
+        # Use trailing separator to prevent bypass via sibling directories
+        # e.g., /home/user/myrepo_evil would bypass startswith(/home/user/myrepo)
+        if not abs_file_path.startswith(abs_repo_path + os.sep):
+            result["error"] = "Path traversal detected - file path escapes repo"
+            logger.error(
+                "[Regression] H-2.4: Path traversal attempt blocked",
+                extra={
+                    "operation": "simulation.regression.write",
+                    "test_name": test_name,
+                    "candidate_id": candidate_id,
+                    "attempted_path": relative_path,
+                }
+            )
+            return result
+
+        try:
+            # Create directory if it doesn't exist
+            abs_output_dir = os.path.dirname(abs_file_path)
+            os.makedirs(abs_output_dir, exist_ok=True)
+
+            # Write test file
+            with open(abs_file_path, 'w', encoding='utf-8') as f:
+                f.write(test_code)
+
+            result["success"] = True
+            result["file_path"] = abs_file_path
+            result["relative_path"] = relative_path
+
+            logger.info(
+                f"[Regression] H-2.4: Wrote test to disk: {relative_path}",
+                extra={
+                    "operation": "simulation.regression.write",
+                    "test_name": test_name,
+                    "candidate_id": candidate_id,
+                    "file_path": abs_file_path,
+                    "relative_path": relative_path,
+                }
+            )
+
+        except OSError as e:
+            result["error"] = f"Failed to write file: {e}"
+            logger.error(
+                f"[Regression] H-2.4: Failed to write test: {e}",
+                extra={
+                    "operation": "simulation.regression.write",
+                    "test_name": test_name,
+                    "candidate_id": candidate_id,
+                    "error": str(e),
+                }
+            )
+
+        return result
+
+    def _sanitize_filename(self, name: str) -> str:
+        """
+        Sanitize a filename to prevent directory traversal and invalid chars.
+
+        Args:
+            name: Original filename (without extension)
+
+        Returns:
+            Sanitized filename safe for filesystem use
+        """
+        # Remove path separators and parent directory references
+        name = name.replace("/", "_").replace("\\", "_")
+        name = name.replace("..", "_")
+
+        # Remove or replace invalid characters
+        # Keep only alphanumeric, underscore, hyphen
+        name = re.sub(r'[^a-zA-Z0-9_\-]', '_', name)
+
+        # Remove leading/trailing underscores and collapse multiple underscores
+        name = re.sub(r'_+', '_', name).strip('_')
+
+        # Ensure name is not empty and has reasonable length
+        if not name:
+            return ""
+        if len(name) > 200:
+            name = name[:200]
+
+        return name
+
+    def write_tests_to_disk(
+        self,
+        repo_path: str,
+        output_dir: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Write all generated tests to disk.
+
+        H-2.4 Regression Test Execution (Blueprint Section 5.4).
+
+        Args:
+            repo_path: Path to the repository root
+            output_dir: Output directory (relative to repo_path)
+
+        Returns:
+            Dict with:
+                - success: bool (True if all tests written successfully)
+                - written_count: int
+                - failed_count: int
+                - files: List[Dict] (details of each written file)
+                - errors: List[str] (any errors encountered)
+        """
+        result: Dict[str, Any] = {
+            "success": True,
+            "written_count": 0,
+            "failed_count": 0,
+            "files": [],
+            "errors": [],
+        }
+
+        for test_info in self._generated_tests:
+            write_result = self.write_test_to_disk(
+                test_code=test_info["test_code"],
+                test_name=test_info["test_name"],
+                candidate_id=test_info["candidate_id"],
+                repo_path=repo_path,
+                output_dir=output_dir,
+            )
+
+            if write_result["success"]:
+                result["written_count"] += 1
+                result["files"].append({
+                    "test_name": test_info["test_name"],
+                    "file_path": write_result["file_path"],
+                    "relative_path": write_result["relative_path"],
+                })
+            else:
+                result["failed_count"] += 1
+                result["success"] = False
+                result["errors"].append(
+                    f"{test_info['test_name']}: {write_result['error']}"
+                )
+
+        logger.info(
+            f"[Regression] H-2.4: Wrote {result['written_count']} tests to disk, "
+            f"{result['failed_count']} failed",
+            extra={
+                "operation": "simulation.regression.write_all",
+                "written_count": result["written_count"],
+                "failed_count": result["failed_count"],
+            }
+        )
+
+        return result
+
+
+class RegressionTestProtector:
+    """
+    Protects regression tests from unauthorized modification or deletion.
+
+    H-2.4 Regression Test Execution (Blueprint Section 5.4):
+    - CI Enforcement: regression test failure → block PR
+    - CI Enforcement: regression test modification → require reviewer approval
+    - CI Enforcement: regression test deletion → Safety Governor blocks
+
+    This class provides utilities to:
+    1. Detect if a file is a protected regression test
+    2. Check if changes to regression tests require approval
+    3. Integrate with Safety Governor for deletion protection
+    """
+
+    # Marker comment that identifies protected regression tests
+    PROTECTION_MARKER = "REGRESSION_METADATA"
+
+    def __init__(self, regression_test_dir: Optional[str] = None):
+        """
+        Initialize the RegressionTestProtector.
+
+        Args:
+            regression_test_dir: Directory containing regression tests.
+                               Uses regression_test_output_dir setting if not specified.
+        """
+        # (MorningAI Reviewer: use settings value instead of hardcoded default)
+        if regression_test_dir is None:
+            try:
+                from common.config.settings import settings
+                regression_test_dir = getattr(
+                    settings, 'regression_test_output_dir', 'tests/regression'
+                )
+            except ImportError:
+                regression_test_dir = "tests/regression"
+        self.regression_test_dir = regression_test_dir
+        self._protected_files: Set[str] = set()
+
+    def is_regression_test_file(self, file_path: str) -> bool:
+        """
+        Check if a file is in the regression test directory.
+
+        Args:
+            file_path: Path to check (relative or absolute)
+
+        Returns:
+            True if file is in regression test directory
+        """
+        # (gemini-code-assist + Cursor Bugbot: use proper path matching to prevent
+        # false positives from similarly named directories like tests/regression_backup)
+        normalized_path = os.path.normpath(file_path).replace('\\', '/')
+        normalized_dir = os.path.normpath(self.regression_test_dir).replace('\\', '/')
+
+        # Check if path equals or starts with the directory (with trailing slash)
+        return normalized_path == normalized_dir or \
+            normalized_path.startswith(normalized_dir + '/')
+
+    def is_protected_test(self, file_path: str, file_content: str) -> bool:
+        """
+        Check if a test file is protected (has REGRESSION_METADATA marker).
+
+        Args:
+            file_path: Path to the test file
+            file_content: Content of the test file
+
+        Returns:
+            True if file contains protection marker
+        """
+        if not self.is_regression_test_file(file_path):
+            return False
+
+        return self.PROTECTION_MARKER in file_content
+
+    def check_file_modification(
+        self,
+        file_path: str,
+        old_content: Optional[str],
+        new_content: Optional[str],
+    ) -> Dict[str, Any]:
+        """
+        Check if a file modification requires approval.
+
+        H-2.4 CI Enforcement (Blueprint Section 5.4):
+        - Modification of protected test → require reviewer approval
+        - Deletion of protected test → Safety Governor blocks
+
+        Args:
+            file_path: Path to the file being modified
+            old_content: Original file content (None if new file)
+            new_content: New file content (None if deleted)
+
+        Returns:
+            Dict with:
+                - allowed: bool
+                - requires_approval: bool
+                - blocked: bool (deletion blocked by Safety Governor)
+                - reason: str
+        """
+        result: Dict[str, Any] = {
+            "allowed": True,
+            "requires_approval": False,
+            "blocked": False,
+            "reason": "",
+        }
+
+        # New file - always allowed
+        if old_content is None:
+            result["reason"] = "New file creation is allowed"
+            return result
+
+        # Check if old file was protected
+        was_protected = self.is_protected_test(file_path, old_content)
+
+        if not was_protected:
+            result["reason"] = "File is not a protected regression test"
+            return result
+
+        # Deletion of protected test - blocked by Safety Governor
+        if new_content is None:
+            result["allowed"] = False
+            result["blocked"] = True
+            result["reason"] = (
+                "Deletion of protected regression test blocked by Safety Governor. "
+                "Protected tests cannot be deleted without explicit override."
+            )
+            logger.warning(
+                f"[Regression] H-2.4: Blocked deletion of protected test: {file_path}",
+                extra={
+                    "operation": "simulation.regression.protect",
+                    "file_path": file_path,
+                    "action": "delete_blocked",
+                }
+            )
+            return result
+
+        # Modification of protected test - requires approval
+        result["requires_approval"] = True
+        result["reason"] = (
+            "Modification of protected regression test requires reviewer approval. "
+            "This test was auto-generated to prevent regression of a known bug."
+        )
+        logger.info(
+            f"[Regression] H-2.4: Modification of protected test requires approval: "
+            f"{file_path}",
+            extra={
+                "operation": "simulation.regression.protect",
+                "file_path": file_path,
+                "action": "requires_approval",
+            }
+        )
+        return result
+
+    def scan_directory_for_protected_tests(
+        self,
+        repo_path: str,
+    ) -> List[str]:
+        """
+        Scan the regression test directory for protected tests.
+
+        Args:
+            repo_path: Path to the repository root
+
+        Returns:
+            List of relative paths to protected test files
+        """
+        protected_files: List[str] = []
+        abs_test_dir = os.path.join(repo_path, self.regression_test_dir)
+
+        if not os.path.exists(abs_test_dir):
+            return protected_files
+
+        for root, _, files in os.walk(abs_test_dir):
+            for filename in files:
+                if not filename.endswith('.py'):
+                    continue
+
+                abs_path = os.path.join(root, filename)
+                rel_path = os.path.relpath(abs_path, repo_path)
+
+                try:
+                    with open(abs_path, 'r', encoding='utf-8') as f:
+                        content = f.read()
+
+                    if self.is_protected_test(rel_path, content):
+                        protected_files.append(rel_path)
+                        self._protected_files.add(rel_path)
+
+                except OSError as e:
+                    logger.warning(
+                        f"[Regression] H-2.4: Could not read file {rel_path}: {e}"
+                    )
+
+        logger.info(
+            f"[Regression] H-2.4: Found {len(protected_files)} protected tests",
+            extra={
+                "operation": "simulation.regression.scan",
+                "protected_count": len(protected_files),
+            }
+        )
+
+        return protected_files
+
+    def get_protected_files(self) -> Set[str]:
+        """Get the set of known protected files."""
+        return self._protected_files.copy()
 
 
 # Global collector instance for convenience


### PR DESCRIPTION
## Summary

Extracts the private `_redact_text` method from `PIIScanner` into a public module-level function `redact_pii_text()`. This addresses the tight coupling issue where `RuntimePolicyEnforcer` was calling `scanner._redact_text()`, a private method.

**Changes:**
- Add public `redact_pii_text(text, category)` function at module level in `pii_scanner.py`
- Update `PIIScanner._redact_text()` to delegate to the new public function (backward compatibility)
- Update `RuntimePolicyEnforcer._redact_pii_content()` to import and use `redact_pii_text()` directly

**Blueprint Reference:** Section 4.2 (Compliance Radar v2), Section 9.2 (Safe by Design)

## Review & Testing Checklist for Human

- [ ] **Verify logic preservation**: Confirm the redaction logic in `redact_pii_text()` is identical to the original `_redact_text()` implementation (it should be a direct extraction)
- [ ] **Test PII redaction end-to-end**: Run a scan with various PII types (email, SSN, credit card, phone, IP) and verify redaction output matches expected format

**Recommended test plan:**
1. Trigger a PII scan on content containing various PII types
2. Verify redacted output format matches expected patterns (e.g., `u***@e***.com` for emails)
3. Confirm no regressions in existing PII handling workflows

### Notes

- This is a pure refactoring PR with no behavioral changes intended
- The `scanner` variable was removed from `_redact_pii_content()` since it's no longer needed
- Link to Devin run: https://app.devin.ai/sessions/c6330a3682fb4872afdc866d753237b7
- Requested by: Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a stable public API for PII redaction and updates consumers accordingly.
> 
> - Adds module-level `redact_pii_text(text, category)` in `pii_scanner.py` (extracted from `PIIScanner._redact_text`)
> - Changes `PIIScanner._redact_text()` to delegate to `redact_pii_text()` for backward compatibility
> - Updates `RuntimePolicyEnforcer._redact_pii_content()` to import and call `redact_pii_text()` instead of `scanner._redact_text`, keeping existing position/original_length replacement logic
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93efbb47958ec09556c18bdb298d150372244062. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->