### PR TITLE
fix(orchestrator): prevent infinite loop in CI failure flow (Issue #4165)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -2739,6 +2739,12 @@ class AgentState(TypedDict):
     # CRITICAL: This field MUST be defined in AgentState for LangGraph to properly
     # propagate it between nodes. Without this definition, the flag may be lost.
     loop_protection_triggered: Optional[bool]
+    # Issue #4165: Secondary Loop Protection Counter
+    # Incremented by hitl_gate_node on each pass through the routing loop.
+    # Checked by should_fix_or_finalize to prevent infinite loops that bypass fixer_node.
+    # CRITICAL: This field MUST be defined in AgentState for LangGraph to properly
+    # propagate it between nodes. Without this definition, the counter may be lost.
+    routing_iteration_count: Optional[int]
     # EPIC F Phase F-3c: FlowController v3 Integration Fields
     # Set by flow_executor_node when ENABLE_FLOW_CONTROLLER_V3=true.
     # These fields track the execution state of plans via FlowController.
@@ -8775,7 +8781,9 @@ def should_fix_or_finalize(state: AgentState) -> str:
     merge_decision = state.get("merge_decision", "pending")
     retry_count = state.get("retry_count", 0)
     trace_id = state.get("trace_id", "unknown")
-    ci_failure_trigger = state.get("ci_failure_trigger", False)
+    # Issue #4165: Use strict boolean check to prevent bugs from truthy string values
+    # like "False" which could come from serialization. Consistent with codebase pattern.
+    ci_failure_trigger = state.get("ci_failure_trigger") is True
     metrics = _get_metrics()
 
     outcome_to_node = {


### PR DESCRIPTION
# fix(orchestrator): prevent infinite loop in CI failure flow (Issue #4165)

## Summary

Fixes a P0 bug where the LangGraph orchestrator would crash with "Recursion limit of 100 reached" when processing CI failures.

**Root Cause:** When `ci_failure_trigger=True` and `merge_decision="pending"`, the flow would route to `ci_monitor` instead of `fixer`, completely bypassing the `retry_count` increment logic. This created an infinite loop: `hitl_gate → ci_monitor → reviewer → router → hitl_gate → ...`

**Fix:**
1. In `should_fix_or_finalize`: When `ci_failure_trigger=True` and `merge_decision="pending"`, force routing to `fixer` instead of `ci_monitor` to ensure `retry_count` increments correctly
2. Add secondary loop protection via `routing_iteration_count` (max 20 iterations) as a safeguard
3. Increment `routing_iteration_count` in `hitl_gate_node` for tracking

## Review & Testing Checklist for Human

- [ ] **Verify routing logic change**: Confirm that forcing route to `fixer` when `ci_failure_trigger=True` and `merge_decision="pending"` is the correct behavior (vs routing to `ci_monitor`)
- [ ] **Check for side effects**: Ensure normal (non-CI-failure) flows where `merge_decision="pending"` still correctly route to `ci_monitor`
- [ ] **Validate MAX_ROUTING_ITERATIONS=20**: Confirm this threshold is appropriate (each loop iteration = ~5 nodes, so 20 iterations = ~100 nodes before protection kicks in)
- [ ] **Test in staging**: Deploy to staging and trigger a CI failure to verify the fix works end-to-end

**Recommended Test Plan:**
1. Create a test PR with intentional CI failure (like PR #4164)
2. Monitor Production/Staging logs for `[CI_FAILURE_PENDING_FIX]` or `[ROUTING_LOOP_PROTECTION]` log entries
3. Verify orchestrator completes without hitting recursion limit
4. Verify `retry_count` increments correctly (should stop after MAX_FIXER_RETRIES=3)

### Notes

- No unit tests added for this fix - consider adding tests for the new routing logic
- The `routing_iteration_count` state key is new and not persisted to database
- Greppable log events: `[ROUTING_LOOP_PROTECTION]`, `[CI_FAILURE_PENDING_FIX]`

Link to Devin run: https://app.devin.ai/sessions/b78d7c972ce048559ae28239ff0f7e6a
Requested by: Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents infinite routing loops in CI-failure scenarios and adds secondary safeguards.
> 
> - Update `should_fix_or_finalize`: when `ci_failure_trigger=True` and `merge_decision="pending"`, route to `fixer` (respecting `MAX_FIXER_RETRIES`); otherwise pending routes to `ci_monitor`.
> - Add `routing_iteration_count` with `MAX_ROUTING_ITERATIONS=20`; if exceeded, force `finalize`, with structured logs and metrics transition recording.
> - Increment `routing_iteration_count` in `hitl_gate` for each pass to enable the secondary loop protection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cf5e46a1342c238daeb191ec1363ae0969fc5a65. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->