### PR TITLE
refactor(runtime-policy-enforcer): use PIICategory enum dynamically (Fixes #4051)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/governance/pii_scanner.py
+++ b/handoff/20250928/40_App/orchestrator/governance/pii_scanner.py
@@ -88,6 +88,13 @@ class PIICategory(str, Enum):
     DRIVER_LICENSE = "driver_license"
 
 
+# Issue #4051: Export PII category values as a constant for dynamic filtering
+# This provides a single source of truth for PII categories, avoiding hardcoded
+# lists in other modules like RuntimePolicyEnforcer.
+# Blueprint Reference: Section 4.2 (Compliance Radar v2), Section 9.2 (Safe by Design)
+PII_CATEGORIES: tuple[str, ...] = tuple(c.value for c in PIICategory)
+
+
 class PIIRiskLevel(str, Enum):
     """Risk levels for PII findings"""
     CRITICAL = "critical"  # SSN, Credit Card - immediate action required

--- a/handoff/20250928/40_App/orchestrator/governance/runtime_policy_enforcer.py
+++ b/handoff/20250928/40_App/orchestrator/governance/runtime_policy_enforcer.py
@@ -766,11 +766,10 @@ class RuntimePolicyEnforcer:
                 return self._create_allowed_result(reason, telemetry_event)
             elif action == EnforcementAction.REDACT:
                 # Issue #3951: Handle REDACT action - redact PII and allow content to proceed
-                # Filter PII findings from all findings for redaction
-                pii_findings = [f for f in findings if f.get("category") in (
-                    "email", "phone", "ssn", "credit_card", "name", "address",
-                    "ip_address", "date_of_birth", "passport", "driver_license"
-                )]
+                # Issue #4051: Use PII_CATEGORIES constant for dynamic filtering
+                # This ensures new PII categories are automatically included
+                from governance.pii_scanner import PII_CATEGORIES
+                pii_findings = [f for f in findings if f.get("category") in PII_CATEGORIES]
                 redacted_content = self._redact_pii_content(content, pii_findings)
 
                 # Update telemetry for redaction event


### PR DESCRIPTION
## Summary

Replaces a hardcoded list of PII categories in `RuntimePolicyEnforcer.check_content_safety()` with a dynamically generated constant from the `PIICategory` enum.

**Changes:**
- Add `PII_CATEGORIES` constant to `pii_scanner.py` - a tuple of all `PIICategory` enum values
- Update `RuntimePolicyEnforcer` to import and use `PII_CATEGORIES` instead of the hardcoded list

This ensures that when new PII categories are added to the `PIICategory` enum, they are automatically included in PII filtering without requiring manual updates to `RuntimePolicyEnforcer`.

**Blueprint Reference:** Section 4.2 (Compliance Radar v2), Section 9.2 (Safe by Design)

## Review & Testing Checklist for Human

- [ ] **Verify constant values match**: Confirm `PII_CATEGORIES` tuple contains the same 10 values as the original hardcoded list (email, phone, ssn, credit_card, name, address, ip_address, date_of_birth, passport, driver_license)
- [ ] **Test PII redaction flow**: Trigger a content safety check with REDACT action and verify PII is still correctly filtered and redacted

**Recommended test plan:**
1. Run existing PII-related tests to ensure no regressions
2. Manually test content with various PII types to verify redaction still works

### Notes

- This is a pure refactoring PR with no behavioral changes intended
- The lazy import pattern (`from governance.pii_scanner import PII_CATEGORIES` inside the function) is consistent with existing imports in the file
- Link to Devin run: https://app.devin.ai/sessions/c6330a3682fb4872afdc866d753237b7
- Requested by: Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Refactors PII category handling for redaction**
> 
> - Adds `PII_CATEGORIES` in `pii_scanner.py` (tuple of all `PIICategory` enum values)
> - Updates `RuntimePolicyEnforcer.check_content_safety()` to import `PII_CATEGORIES` and filter PII findings dynamically during `REDACT`
> 
> *Effect:* New PII categories added to `PIICategory` are automatically included in redaction filtering; no intended behavior change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f57ba4764f7e7a712ccd0b25f58bd3afd579b4bb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->