### PR TITLE
fix(reviewer): enforce addition-lines-only constraint in specialist prompts (P0)

### DIFF
--- a/handoff/20250928/40_App/orchestrator/review_context/multi_specialist_reviewer.py
+++ b/handoff/20250928/40_App/orchestrator/review_context/multi_specialist_reviewer.py
@@ -230,11 +230,15 @@ SPECIALIST_PROMPTS: Dict[ReviewSpecialist, str] = {
     ReviewSpecialist.SECURITY: """You are a security-focused code reviewer for MorningAI.
 Your role is to identify security vulnerabilities and risks in code changes.
 
-CRITICAL CONSTRAINT - DIFF-ONLY REVIEW:
+CRITICAL CONSTRAINT - ADDITION LINES ONLY:
 - You MUST ONLY comment on files that appear in the diff (files with "--- a/" or "+++ b/" headers)
-- You MUST ONLY reference line numbers that appear in diff hunks (lines starting with + or context lines)
+- You MUST ONLY reference line numbers for ADDITION lines (lines starting with "+") in the diff
+- Do NOT reference context lines (lines starting with space) - GitHub cannot post inline comments on context lines
 - Do NOT comment on files that are imported, referenced, or called but not changed in this PR
-- If you cannot find security issues in the actual diff content, return an empty array: []
+- If you cannot find security issues in the ADDITION lines, return an empty array: []
+
+IMPORTANT: When providing line_number, it must be the line number of an ADDITION line ("+") in the final file.
+Context lines are for understanding only - do not report issues on context lines.
 
 Focus areas:
 - SQL injection, XSS, CSRF vulnerabilities
@@ -258,11 +262,15 @@ If no security issues are found, return an empty array: []""",
     ReviewSpecialist.PERFORMANCE: """You are a performance-focused code reviewer for MorningAI.
 Your role is to identify performance issues and inefficiencies in code changes.
 
-CRITICAL CONSTRAINT - DIFF-ONLY REVIEW:
+CRITICAL CONSTRAINT - ADDITION LINES ONLY:
 - You MUST ONLY comment on files that appear in the diff (files with "--- a/" or "+++ b/" headers)
-- You MUST ONLY reference line numbers that appear in diff hunks (lines starting with + or context lines)
+- You MUST ONLY reference line numbers for ADDITION lines (lines starting with "+") in the diff
+- Do NOT reference context lines (lines starting with space) - GitHub cannot post inline comments on context lines
 - Do NOT comment on files that are imported, referenced, or called but not changed in this PR
-- If you cannot find performance issues in the actual diff content, return an empty array: []
+- If you cannot find performance issues in the ADDITION lines, return an empty array: []
+
+IMPORTANT: When providing line_number, it must be the line number of an ADDITION line ("+") in the final file.
+Context lines are for understanding only - do not report issues on context lines.
 
 Focus areas:
 - N+1 query problems
@@ -287,11 +295,15 @@ If no performance issues are found, return an empty array: []""",
     ReviewSpecialist.ARCHITECTURE: """You are an architecture-focused code reviewer for MorningAI.
 Your role is to identify architectural issues and design problems in code changes.
 
-CRITICAL CONSTRAINT - DIFF-ONLY REVIEW:
+CRITICAL CONSTRAINT - ADDITION LINES ONLY:
 - You MUST ONLY comment on files that appear in the diff (files with "--- a/" or "+++ b/" headers)
-- You MUST ONLY reference line numbers that appear in diff hunks (lines starting with + or context lines)
+- You MUST ONLY reference line numbers for ADDITION lines (lines starting with "+") in the diff
+- Do NOT reference context lines (lines starting with space) - GitHub cannot post inline comments on context lines
 - Do NOT comment on files that are imported, referenced, or called but not changed in this PR
-- If you cannot find architectural issues in the actual diff content, return an empty array: []
+- If you cannot find architectural issues in the ADDITION lines, return an empty array: []
+
+IMPORTANT: When providing line_number, it must be the line number of an ADDITION line ("+") in the final file.
+Context lines are for understanding only - do not report issues on context lines.
 
 Focus areas:
 - SOLID principle violations


### PR DESCRIPTION
## Summary

Updates Multi-Specialist Reviewer prompts to enforce that LLM only references **addition lines** (lines starting with `+`) instead of allowing both addition lines and context lines. This addresses the root cause of inline comments being downgraded to file-level comments.

**Problem**: GitHub API only allows inline comments on addition lines in a PR diff. When the LLM references context lines (lines starting with space), the Publisher must downgrade these to file-level comments with `[Line info removed: ...]` prefix.

**Solution**: Updated the CRITICAL CONSTRAINT section in all three specialist prompts (SECURITY, PERFORMANCE, ARCHITECTURE) to:
- Explicitly prohibit referencing context lines
- Explain that GitHub cannot post inline comments on context lines
- Add IMPORTANT note reinforcing that `line_number` must be for addition lines only

## Review & Testing Checklist for Human

- [ ] **Verify prompt clarity** - Review the updated prompt wording to ensure it's unambiguous for the LLM. The key change is from "lines starting with + or context lines" to "ADDITION lines (lines starting with '+') only"
- [ ] **Test with a real PR** - Deploy to staging and create a test PR with code changes. Observe whether the `context_line_rejected` downgrade count decreases in Publisher logs
- [ ] **Monitor for reduced findings** - Check if the stricter constraint causes the LLM to produce significantly fewer findings (acceptable trade-off for better inline comment success rate)

**Suggested test plan:**
1. Deploy to staging
2. Create a PR with obvious issues in both addition lines and context lines
3. Check MorningAI review output - findings should only reference addition lines
4. Verify inline comments appear on GitHub instead of file-level comments

### Notes

This is a prompt-only change. LLM behavior is inherently unpredictable, so the effectiveness can only be verified through real-world testing. The SELF_CRITIQUE prompt was intentionally not modified as it operates on findings from other specialists rather than the diff directly.

Requested by: Ryan Chen (@RC918)
Link to Devin run: https://app.devin.ai/sessions/7ec3367d397e49449e9196c85ae991d5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Prompt-only update to multi-specialist reviewer**
> 
> - Updates `CRITICAL CONSTRAINT` in SECURITY, PERFORMANCE, and ARCHITECTURE prompts to require referencing only ADDITION lines (`+`), explicitly forbid context lines, and return empty arrays if no issues are found on additions
> - Adds an IMPORTANT note that `line_number` must correspond to an addition line in the final file
> - No changes to SELF_CRITIQUE or review logic; code paths and execution remain the same
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f77f5e2a9a1636a87e0416492ffd5a930c337740. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->