### PR TITLE
feat(config): add deprecation warning for JWT_EXPIRATION_MINUTES (fixes #4219)

### DIFF
--- a/common/config/settings.py
+++ b/common/config/settings.py
@@ -3417,6 +3417,17 @@ class Settings(BaseSettings):
                     stacklevel=2
                 )
 
+        # P2: Check for legacy JWT_EXPIRATION_MINUTES usage (Issue #4219)
+        # This field uses AliasChoices, so both names work but we want to
+        # encourage migration to the preferred name.
+        if os.getenv("JWT_EXPIRATION_MINUTES") and not os.getenv("ACCESS_TOKEN_EXPIRY_MINUTES"):
+            warnings.warn(
+                "JWT_EXPIRATION_MINUTES is deprecated. Please use ACCESS_TOKEN_EXPIRY_MINUTES instead. "
+                "Support for JWT_EXPIRATION_MINUTES will be removed after 2026-06-30.",
+                DeprecationWarning,
+                stacklevel=2
+            )
+
 
 _settings_instance = None
 


### PR DESCRIPTION
## Summary

Adds a deprecation warning in `log_deprecation_warnings()` that triggers when the legacy `JWT_EXPIRATION_MINUTES` environment variable is used without the preferred `ACCESS_TOKEN_EXPIRY_MINUTES`.

This is a follow-up from PR #4216 which introduced `AliasChoices` support for JWT expiration configuration. Both names work, but this warning encourages migration to the preferred naming convention.

**Changes:**
- Added deprecation check in `Settings.log_deprecation_warnings()` method
- Warning only triggers if `JWT_EXPIRATION_MINUTES` is set AND `ACCESS_TOKEN_EXPIRY_MINUTES` is NOT set
- Removal date set to 2026-06-30 (5+ months notice)

## Review & Testing Checklist for Human

- [ ] Verify the condition logic is correct: warning should only appear when legacy env var is used without the new one
- [ ] Confirm the 2026-06-30 removal date aligns with your migration timeline

**Test plan:**
```bash
# Should trigger warning
JWT_EXPIRATION_MINUTES=60 python -c "from common.config.settings import get_settings; get_settings()"

# Should NOT trigger warning (new name used)
ACCESS_TOKEN_EXPIRY_MINUTES=60 python -c "from common.config.settings import get_settings; get_settings()"

# Should NOT trigger warning (both set - user is migrating)
JWT_EXPIRATION_MINUTES=60 ACCESS_TOKEN_EXPIRY_MINUTES=60 python -c "from common.config.settings import get_settings; get_settings()"
```

### Notes

Blueprint alignment: Section 4.3 Model Governance Framework v2 - Clean tech debt management

Link to Devin run: https://app.devin.ai/sessions/fb70960e8d714ce396d9ece377851f8d
Requested by: Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Encourages migration to the preferred env var for JWT expiry.
> 
> - Adds a check in `Settings.log_deprecation_warnings()` (in `common/config/settings.py`) to warn if legacy `JWT_EXPIRATION_MINUTES` is used without `ACCESS_TOKEN_EXPIRY_MINUTES`
> - Warns with `DeprecationWarning`; support removal date set to 2026-06-30
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b2062714d7205dc9870e5072bbfaaab8049f1ce. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->