### PR TITLE
test: add comprehensive webhooks edge case tests (fixes #4227)

### DIFF
--- a/handoff/20250928/40_App/api-backend/tests/test_webhooks_routes.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_webhooks_routes.py
@@ -1312,8 +1312,11 @@ class TestEnqueueCIFailureTask:
         with patch("src.routes.webhooks.settings") as mock_settings:
             mock_settings.redis_url = "redis://localhost:6379"
             mock_settings.github_repo = None
-            result = _enqueue_ci_failure_task(mock_task)
-            assert result is None
+            with patch("redis.Redis") as mock_redis_class:
+                mock_redis = MagicMock()
+                mock_redis_class.from_url.return_value = mock_redis
+                result = _enqueue_ci_failure_task(mock_task)
+                assert result is None
 
     def test_enqueue_ci_failure_task_no_pr_number(self):
         """Should return None when no PR number is specified."""
@@ -1327,8 +1330,11 @@ class TestEnqueueCIFailureTask:
         with patch("src.routes.webhooks.settings") as mock_settings:
             mock_settings.redis_url = "redis://localhost:6379"
             mock_settings.github_repo = "test/repo"
-            result = _enqueue_ci_failure_task(mock_task)
-            assert result is None
+            with patch("redis.Redis") as mock_redis_class:
+                mock_redis = MagicMock()
+                mock_redis_class.from_url.return_value = mock_redis
+                result = _enqueue_ci_failure_task(mock_task)
+                assert result is None
 
     def test_enqueue_ci_failure_task_success(self):
         """Should enqueue CI failure task successfully."""
@@ -1416,8 +1422,11 @@ class TestEnqueueMetaAgentTask:
         with patch("src.routes.webhooks.settings") as mock_settings:
             mock_settings.redis_url = "redis://localhost:6379"
             mock_settings.github_repo = None
-            result = _enqueue_meta_agent_task(mock_task)
-            assert result is None
+            with patch("redis.Redis") as mock_redis_class:
+                mock_redis = MagicMock()
+                mock_redis_class.from_url.return_value = mock_redis
+                result = _enqueue_meta_agent_task(mock_task)
+                assert result is None
 
     def test_enqueue_meta_agent_task_success(self):
         """Should enqueue meta agent task successfully."""
@@ -1445,7 +1454,7 @@ class TestEnqueueMetaAgentTask:
                     mock_queue.enqueue.return_value = mock_job
                     mock_queue_class.return_value = mock_queue
 
-                    with patch("redis_queue.worker.run_orchestrator_task"):
+                    with patch("redis_queue.worker.run_meta_agent_task"):
                         result = _enqueue_meta_agent_task(mock_task)
                         assert result == "meta-job-456"
 
@@ -1560,8 +1569,8 @@ class TestSlackWebhookEdgeCases:
                 },
                 content_type="application/x-www-form-urlencoded"
             )
-            # Should not crash, gracefully handles invalid JSON
-            assert response.status_code in [200, 400]
+            # Should not crash and return 200 OK, as the invalid JSON is currently ignored.
+            assert response.status_code == 200
 
     def test_slack_webhook_with_task_creation(self, client, mock_normalizer):
         """Should create task for actionable Slack events."""


### PR DESCRIPTION
# test: add comprehensive webhooks edge case tests (fixes #4227)

## Summary

Adds 32 new edge case tests for `routes/webhooks.py` to improve test coverage. The tests cover internal helper functions and edge cases for all webhook endpoints (GitHub, Jira, Slack, test).

**New test classes added:**
- `TestSanitizeDedupKeyComponent` (10 tests) - Input sanitization for dedup keys
- `TestEnqueueCIFailureTask` (5 tests) - CI failure task enqueue edge cases
- `TestEnqueueMetaAgentTask` (3 tests) - Meta agent task enqueue edge cases
- `TestJiraWebhookEdgeCases` (3 tests) - Invalid JSON, task creation, payload size
- `TestSlackWebhookEdgeCases` (6 tests) - Interactive components, challenge response
- `TestGitHubWebhookEdgeCases` (2 tests) - Payload size, hook_id handling
- `TestTestWebhookEdgeCases` (1 test) - Task creation
- `TestIdempotencyWithHookId` (2 tests) - Hook ID in dedup key

All 95 tests pass locally.

## Review & Testing Checklist for Human

- [ ] Verify mock paths match actual import locations (e.g., `utils.redis_client.get_redis_client`, `redis_queue.worker.run_orchestrator_task`)
- [ ] Verify `_sanitize_dedup_key_component` behavior matches test assertions (especially special character handling)
- [ ] Run coverage report to confirm improvement from 65% baseline
- [ ] Consider if rate limit header test should be fixed rather than omitted

**Recommended test plan:**
```bash
cd handoff/20250928/40_App/api-backend
FLASK_SECRET_KEY=test-secret ENVIRONMENT=development \
  PYTHONPATH="$PWD/src:$PWD/../../../.." \
  pytest tests/test_webhooks_routes.py -v --cov=src/routes/webhooks
```

### Notes

- One test (`test_rate_limit_decorator_adds_headers_to_successful_response`) was removed due to complexity in mocking the full request pipeline - rate limit headers are already tested in `TestRateLimiting` class
- Link to Devin run: https://app.devin.ai/sessions/3211816339374a4d8acb554450c05f12
- Requested by: @RC918 (Ryan Chen)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands test coverage across webhook flows and internal helpers to validate robustness and idempotency.
> 
> - Adds tests for `_sanitize_dedup_key_component` (empty/whitespace, invalid chars, underscores) and idempotency keys using `hook_id`
> - Covers enqueueing helpers: `_enqueue_ci_failure_task` and `_enqueue_meta_agent_task` (missing config, Redis errors, success paths)
> - Adds edge-case tests for `GitHub`, `Jira`, `Slack`, and `test` endpoints: invalid JSON handling, 413 payload limits, interactive Slack payloads, and task creation paths
> - Verifies GitHub idempotency header handling (`X-GitHub-Delivery`, `X-GitHub-Hook-ID`) and duplicate-delivery short-circuiting
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d77c8f1776ff0d0e6b13a1cb8376dd0e10311037. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->