### PR TITLE
fix(auth): implement thread-safe singleton for TokenService (fixes #4233)

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/services/token_service.py
+++ b/handoff/20250928/40_App/api-backend/src/services/token_service.py
@@ -207,6 +207,7 @@ def get_token_service() -> TokenService:
         1. Only one instance is ever created, even under concurrent access
         2. After initialization, no lock acquisition is needed (fast path)
         3. The lock is only acquired during the first initialization
+        4. Local variable caching prevents TOCTOU race conditions
 
     Returns:
         TokenService singleton instance.
@@ -216,16 +217,19 @@ def get_token_service() -> TokenService:
         token = token_service.encode({'user_id': '123'})
     """
     global _token_service_instance
-    # Fast path: instance already exists (no lock needed)
-    if _token_service_instance is not None:
-        return _token_service_instance
+    # Fast path: cache in local variable to prevent TOCTOU race
+    # (another thread could call reset_token_service() between check and return)
+    instance = _token_service_instance
+    if instance is not None:
+        return instance
 
     # Slow path: acquire lock and double-check
     with _token_service_lock:
         # Double-check after acquiring lock (another thread may have created it)
         if _token_service_instance is None:
             _token_service_instance = TokenService()
-    return _token_service_instance
+        # Return inside lock to prevent TOCTOU race
+        return _token_service_instance
 
 
 def reset_token_service() -> None:


### PR DESCRIPTION
## Summary

Adds thread-safe initialization to the `TokenService` singleton using the double-checked locking pattern. This prevents potential race conditions in multi-threaded environments (e.g., web servers with multiple workers) where concurrent requests could create multiple instances.

**Changes:**
- Added `threading.Lock` for synchronization
- Implemented double-checked locking in `get_token_service()` with fast path (no lock) and slow path (with lock)
- Made `reset_token_service()` thread-safe for testing scenarios

## Review & Testing Checklist for Human

- [ ] **Verify double-checked locking correctness** - The pattern relies on Python's memory model being safe for this use case. The fast path check (`if _token_service_instance is not None`) happens outside the lock intentionally for performance.
- [ ] **Consider adding concurrency tests** - No unit tests were added to verify thread-safety. Consider if a test using `concurrent.futures.ThreadPoolExecutor` would be valuable.

**Recommended test plan:**
1. Run existing auth tests to ensure no regression
2. Optionally, manually test with a multi-threaded scenario to verify only one instance is created

### Notes
- This follows Blueprint Section 4.3 Model Governance Framework v2 for clean architecture patterns
- The lock overhead is minimal - only acquired during first initialization (slow path)

---
*Requested by: Ryan Chen (@RC918)*
*Link to Devin run: https://app.devin.ai/sessions/fb70960e8d714ce396d9ece377851f8d*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures safe singleton initialization for `TokenService` in multi-threaded environments.
> 
> - Adds `threading.Lock` and implements double-checked locking in `get_token_service()` with a fast path
> - Makes `reset_token_service()` thread-safe by guarding with the same lock
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63e0651a49132748d83d22b87273185d5576e810. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->