### PR TITLE
fix(security): add path traversal protection to validate_config_coverage.py (fixes #4242)

### DIFF
--- a/scripts/validate_config_coverage.py
+++ b/scripts/validate_config_coverage.py
@@ -297,6 +297,38 @@ def print_report(
         print("RESULT: PASS")
 
 
+def validate_path_security(file_path: Path, repo_root: Path, arg_name: str) -> Path:
+    """
+    Validate that a file path is within the repository root directory.
+
+    This prevents path traversal attacks when the script is run in automated
+    environments where an attacker might control the arguments.
+
+    Args:
+        file_path: The file path to validate
+        repo_root: The repository root directory
+        arg_name: The argument name (for error messages)
+
+    Returns:
+        The resolved absolute path
+
+    Raises:
+        ValueError: If path traversal is detected
+    """
+    resolved_path = file_path.resolve()
+
+    try:
+        resolved_path.relative_to(repo_root)
+    except ValueError:
+        raise ValueError(
+            f"Path traversal detected for {arg_name}: "
+            f"'{file_path}' resolves to '{resolved_path}' which is outside "
+            f"the repository root '{repo_root}'"
+        )
+
+    return resolved_path
+
+
 def main() -> int:
     """
     Main entry point.
@@ -324,13 +356,29 @@ def main() -> int:
         action="store_true",
         help="Treat warnings as errors",
     )
+    parser.add_argument(
+        "--allow-external-paths",
+        action="store_true",
+        help="Skip path traversal validation (use with caution)",
+    )
 
     args = parser.parse_args()
 
     try:
+        # Get repository root directory
+        repo_root = Path(__file__).parent.parent.resolve()
+
+        # Validate paths are within repository (security check)
+        if not args.allow_external_paths:
+            prod_file = validate_path_security(args.prod_file, repo_root, "--prod-file")
+            schema_file = validate_path_security(args.schema_file, repo_root, "--schema-file")
+        else:
+            prod_file = args.prod_file.resolve()
+            schema_file = args.schema_file.resolve()
+
         # Parse files
-        prod_config = parse_prod_md(args.prod_file)
-        schema = parse_schema(args.schema_file)
+        prod_config = parse_prod_md(prod_file)
+        schema = parse_schema(schema_file)
 
         # Validate
         errors, warnings, info = validate_config(prod_config, schema)


### PR DESCRIPTION
## Summary

Adds path traversal protection to the configuration validation script to prevent potential security issues when running in automated environments where an attacker might control command-line arguments.

**Changes:**
- New `validate_path_security()` function that validates file paths are within the repository root directory
- New `--allow-external-paths` flag to bypass validation for legitimate external path use cases
- Both `--prod-file` and `--schema-file` arguments are now validated by default

Blueprint Alignment: Section 4.7 Capability-Based Security

Fixes #4242

## Review & Testing Checklist for Human

- [ ] Verify the script still works with default paths: `python scripts/validate_config_coverage.py`
- [ ] Test path traversal is blocked: `python scripts/validate_config_coverage.py --prod-file ../../../etc/passwd` (should fail with ValueError)
- [ ] Test bypass flag works: `python scripts/validate_config_coverage.py --allow-external-paths --prod-file /tmp/test.md` (should work if file exists)

### Notes

This is a P3 low-priority security improvement. The script is a CLI tool typically run locally, so the risk is minimal, but this follows security best practices for defense in depth.

---
**Requested by:** @RC918
**Link to Devin run:** https://app.devin.ai/sessions/fb70960e8d714ce396d9ece377851f8d

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens the `validate_config_coverage.py` CLI with path traversal safeguards.
> 
> - Adds `validate_path_security()` to ensure `--prod-file` and `--schema-file` resolve within the repo root
> - New `--allow-external-paths` flag to explicitly bypass the check when needed
> - `main()` now resolves repo root, validates or bypasses paths, and uses the resolved paths for parsing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f12d99322b054a75979b4f521f32f084afabc4c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->