### PR TITLE
chore: add deprecation warnings to legacy RefactorAgent (fixes #4232)

### DIFF
--- a/.github/workflows/refactor-agent-nightly.yml
+++ b/.github/workflows/refactor-agent-nightly.yml
@@ -110,7 +110,12 @@ jobs:
 
           echo "Running Refactor Agent with max_errors=$MAX_ERRORS, dry_run=$DRY_RUN"
 
+          # NOTE: Using legacy refactor_agent.agent (deprecated) because RefactorAgentV2
+          # does not yet have full PR automation features (run_refactor, create_pr).
+          # See Issue #4232 for migration tracking.
           python -c "
+          import warnings
+          warnings.filterwarnings('ignore', category=DeprecationWarning)
           import json
           from refactor_agent.agent import run_nightly_refactor
 

--- a/handoff/20250928/40_App/orchestrator/refactor_agent/__init__.py
+++ b/handoff/20250928/40_App/orchestrator/refactor_agent/__init__.py
@@ -3,21 +3,52 @@ Refactor Agent - Phase 4 (#1818)
 
 Automated TypeScript strict mode error fixing agent.
 Runs nightly to fix TS errors and submit PRs automatically.
+
+.. note::
+    The legacy RefactorAgent is deprecated. New code should use RefactorAgentV2
+    which provides BaseAgent integration and RoutingEngine support.
+
+    Recommended imports for new code::
+
+        from refactor_agent.agent_v2 import (
+            RefactorAgentV2,
+            get_refactor_agent_v2,
+        )
+
+    Legacy imports (deprecated, will emit warnings)::
+
+        from refactor_agent import RefactorAgent, get_refactor_agent
 """
+# V2 imports (recommended)
+from refactor_agent.agent_v2 import (
+    RefactorAgentV2,
+    RefactorRisk,
+    RefactorTask,
+    RefactorResultV2,
+    TSError,
+    get_refactor_agent_v2,
+)
+
+# Legacy imports (deprecated - will emit DeprecationWarning when used)
 from refactor_agent.agent import (
     RefactorAgent,
-    RefactorTask,
     RefactorResult,
-    RefactorRisk,
     get_refactor_agent,
     run_nightly_refactor,
 )
 
 __all__ = [
-    "RefactorAgent",
-    "RefactorTask",
-    "RefactorResult",
+    # V2 exports (recommended)
+    "RefactorAgentV2",
+    "RefactorResultV2",
+    "get_refactor_agent_v2",
+    # Shared types
     "RefactorRisk",
+    "RefactorTask",
+    "TSError",
+    # Legacy exports (deprecated)
+    "RefactorAgent",
+    "RefactorResult",
     "get_refactor_agent",
     "run_nightly_refactor",
 ]

--- a/handoff/20250928/40_App/orchestrator/refactor_agent/agent.py
+++ b/handoff/20250928/40_App/orchestrator/refactor_agent/agent.py
@@ -2,6 +2,17 @@
 """
 Refactor Agent - Phase 4 (#1818, #1888, #1889, #1890)
 
+.. deprecated:: 2026.01
+    This module is deprecated. Use :mod:`refactor_agent.agent_v2` instead.
+    The RefactorAgentV2 class provides the same functionality with BaseAgent
+    integration and RoutingEngine support.
+
+    Migration guide:
+    - Replace `from refactor_agent.agent import RefactorAgent` with
+      `from refactor_agent.agent_v2 import RefactorAgentV2`
+    - Replace `get_refactor_agent()` with `get_refactor_agent_v2()`
+    - The v2 API uses AgentInput/AgentOutput instead of direct method calls
+
 Automated TypeScript strict mode error fixing agent.
 Runs nightly to fix TS errors and submit PRs automatically.
 
@@ -15,6 +26,7 @@ Design Principles:
 - PR Automation: Automatically creates PRs with changelog (#1890)
 """
 import logging
+import warnings
 import re
 import shutil
 import subprocess
@@ -362,6 +374,9 @@ class RefactorAgent:
     """
     Refactor Agent for automated TypeScript strict mode error fixing.
 
+    .. deprecated:: 2026.01
+        Use :class:`refactor_agent.agent_v2.RefactorAgentV2` instead.
+
     Phase 4 Features (#1818):
     - Nightly execution: Runs automatically at configured time
     - Incremental fixes: Fixes configurable number of errors per run
@@ -375,6 +390,12 @@ class RefactorAgent:
 
     def __init__(self, repo_path: Optional[str] = None):
         """Initialize RefactorAgent with configuration"""
+        warnings.warn(
+            "RefactorAgent is deprecated and will be removed in a future release. "
+            "Use RefactorAgentV2 from refactor_agent.agent_v2 instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         self.repo_path = Path(repo_path) if repo_path else self._find_repo_path()
         self._load_settings()
         logger.info("[RefactorAgent] Initialized - Phase 4 (#1818)")
@@ -1925,7 +1946,18 @@ _refactor_agent: Optional[RefactorAgent] = None
 
 
 def get_refactor_agent() -> RefactorAgent:
-    """Get or create the singleton RefactorAgent instance"""
+    """
+    Get or create the singleton RefactorAgent instance.
+
+    .. deprecated:: 2026.01
+        Use :func:`refactor_agent.agent_v2.get_refactor_agent_v2` instead.
+    """
+    warnings.warn(
+        "get_refactor_agent() is deprecated. "
+        "Use get_refactor_agent_v2() from refactor_agent.agent_v2 instead.",
+        DeprecationWarning,
+        stacklevel=2
+    )
     global _refactor_agent
     if _refactor_agent is None:
         _refactor_agent = RefactorAgent()
@@ -1939,6 +1971,10 @@ def run_nightly_refactor(
     """
     Convenience function for nightly refactor runs.
 
+    .. deprecated:: 2026.01
+        This function uses the deprecated RefactorAgent.
+        Consider migrating to RefactorAgentV2 for new implementations.
+
     Args:
         max_errors: Maximum number of errors to fix
         dry_run: If True, don't apply fixes
@@ -1946,5 +1982,11 @@ def run_nightly_refactor(
     Returns:
         RefactorResult with summary
     """
+    warnings.warn(
+        "run_nightly_refactor() uses deprecated RefactorAgent. "
+        "Consider migrating to RefactorAgentV2 for new implementations.",
+        DeprecationWarning,
+        stacklevel=2
+    )
     agent = get_refactor_agent()
     return agent.run_refactor(max_errors=max_errors, dry_run=dry_run)


### PR DESCRIPTION
# chore: add deprecation warnings to legacy RefactorAgent (fixes #4232)

## Summary

Adds deprecation warnings to the legacy `refactor_agent.agent` module as part of the Agent Catalog V2 migration (Blueprint Section 3.3). This is the first phase of the deprecation cycle - adding warnings before removal in a future release.

**Changes:**
- `RefactorAgent` class now emits `DeprecationWarning` on instantiation
- `get_refactor_agent()` and `run_nightly_refactor()` functions emit deprecation warnings
- Updated `refactor_agent/__init__.py` to export both v2 (recommended) and legacy (deprecated) versions
- Updated nightly workflow to suppress deprecation warnings (since RefactorAgentV2 doesn't yet have full PR automation features)

**Note:** `debugger_agent` and `test_agent` were already migrated to v2 in previous work. Only `refactor_agent` needed deprecation warnings added.

## Review & Testing Checklist for Human

- [ ] **Verify deprecation warnings work correctly** - Run `python -c "from refactor_agent import RefactorAgent; RefactorAgent()"` and confirm a `DeprecationWarning` is emitted
- [ ] **Verify existing imports still work** - Confirm `from refactor_agent import RefactorAgent, get_refactor_agent` still works (with warnings)
- [ ] **Verify v2 imports work** - Confirm `from refactor_agent import RefactorAgentV2, get_refactor_agent_v2` works without warnings

**Recommended test plan:**
1. Run orchestrator tests: `cd handoff/20250928/40_App/orchestrator && pytest refactor_agent/tests/ -v`
2. Verify 150+ tests pass with deprecation warnings visible
3. Optionally trigger the nightly workflow manually to confirm it still works

### Notes

Blueprint Reference: Section 3.3 Agent Catalog V2

One pre-existing test failure (`test_call_llm_uses_routing_engine`) is unrelated to these changes - it's a `core.routing` module import issue that existed before this PR.

---
Link to Devin run: https://app.devin.ai/sessions/3211816339374a4d8acb554450c05f12
Requested by: @RC918

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces the first deprecation step for the legacy refactor agent and highlights V2 as the recommended API.
> 
> - **Deprecation warnings (legacy)**: `RefactorAgent` constructor, `get_refactor_agent()`, and `run_nightly_refactor()` now emit `DeprecationWarning`; module/docstrings updated with migration guidance
> - **Package exports updated**: `refactor_agent/__init__.py` now exports V2 (`RefactorAgentV2`, `RefactorResultV2`, `get_refactor_agent_v2`) plus shared types (`RefactorRisk`, `RefactorTask`, `TSError`) and retains legacy exports
> - **Nightly workflow**: continues using legacy `run_nightly_refactor` but suppresses `DeprecationWarning` output; comments link to issue tracking full V2 migration (#4232)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eccdeb00202ed8896a9cad686f8c958ac2700542. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->