### PR TITLE
chore: add .coveragerc for api-backend coverage configuration

### DIFF
--- a/handoff/20250928/40_App/api-backend/.coveragerc
+++ b/handoff/20250928/40_App/api-backend/.coveragerc
@@ -1,0 +1,10 @@
+[run]
+branch = True
+source = src
+omit =
+    tests/*
+    .venv_coverage/*
+
+[report]
+show_missing = True
+fail_under = 75


### PR DESCRIPTION
## Summary

Adds a `.coveragerc` configuration file for the api-backend to standardize code coverage settings. This enables branch coverage tracking with a 75% minimum threshold.

Configuration includes:
- Branch coverage enabled
- Source directory set to `src`
- Test files and virtual environments excluded from coverage
- 75% minimum coverage threshold enforced

This is part of splitting the larger `chore/governance-and-fixes` branch into focused PRs for safer review.

## Review & Testing Checklist for Human

- [ ] Verify the 75% coverage threshold (`fail_under = 75`) is appropriate for the project's current state
- [ ] Confirm `source = src` matches the actual source directory structure in `api-backend/`

### Notes

This PR has no code impact - it only adds a coverage configuration file. The configuration will take effect when running `pytest --cov` or similar coverage commands.

**Requested by:** Ryan Chen (@RC918)
**Devin run:** https://app.devin.ai/sessions/83fb37289daa4e3d80722971e415e1ca

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configures coverage settings for `api-backend` via a new `.coveragerc`.
> 
> - Enables branch coverage and sets `source = src`
> - Omits `tests/*` and `.venv_coverage/*` from coverage
> - Reports missing lines and enforces `fail_under = 75`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6a7700d84698c290eb442a352e63c089e82f5195. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->