### PR TITLE
fix: Python 3.9 compatibility - use datetime.timezone.utc

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/middleware/auth_middleware.py
+++ b/handoff/20250928/40_App/api-backend/src/middleware/auth_middleware.py
@@ -404,8 +404,8 @@ def generate_jwt_token(user_data, expires_hours=24):
         'user_id': user_data.get('id'),
         'username': user_data.get('username'),
         'role': normalized_role,
-        'exp': datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=expires_hours),
-        'iat': datetime.datetime.now(datetime.UTC)
+        'exp': datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=expires_hours),
+        'iat': datetime.datetime.now(datetime.timezone.utc)
     }
 
     # Issue #4220: Use centralized TokenService for JWT operations
@@ -564,8 +564,8 @@ def create_platform_admin_token(user_id=0, username='platform_admin'):
         'username': username,
         'role': 'admin',
         'is_platform_admin': True,
-        'exp': datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=24),
-        'iat': datetime.datetime.now(datetime.UTC)
+        'exp': datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=24),
+        'iat': datetime.datetime.now(datetime.timezone.utc)
     }
 
     # Issue #4220: Use centralized TokenService for JWT operations

--- a/handoff/20250928/40_App/api-backend/src/routes/auth.py
+++ b/handoff/20250928/40_App/api-backend/src/routes/auth.py
@@ -63,7 +63,7 @@ def login():
             'user_id': user_data['id'],
             'username': username,
             'role': user_data['role'],
-            'exp': datetime.datetime.now(datetime.UTC) + datetime.timedelta(hours=24)
+            'exp': datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(hours=24)
         }, jwt_secret, algorithm='HS256')
         
         user_info = {

--- a/handoff/20250928/40_App/api-backend/src/routes/auth_2fa.py
+++ b/handoff/20250928/40_App/api-backend/src/routes/auth_2fa.py
@@ -233,10 +233,10 @@ def verify_enroll_2fa():
             )
             return jsonify({"error": "Invalid TOTP code"}), 401
 
-        from datetime import datetime, UTC
+        from datetime import datetime, timezone
 
         supabase.table("user_2fa").update(
-            {"enabled": True, "verified_at": datetime.now(UTC).isoformat()}
+            {"enabled": True, "verified_at": datetime.now(timezone.utc).isoformat()}
         ).eq("user_id", user_id).execute()
 
         backup_manager = get_backup_manager()
@@ -400,7 +400,7 @@ def challenge_2fa():
                 {
                     "used": True,
                     "used_at": __import__("datetime")
-                    .datetime.now(__import__("datetime").UTC)
+                    .datetime.now(__import__("datetime").timezone.utc)
                     .isoformat(),
                 }
             ).eq("id", valid_code_id).execute()

--- a/handoff/20250928/40_App/api-backend/src/services/auth_service.py
+++ b/handoff/20250928/40_App/api-backend/src/services/auth_service.py
@@ -339,7 +339,7 @@ def generate_access_token(user_id: str, email: str, role: str) -> Tuple[str, int
     Returns:
         Tuple of (token, expiry_timestamp_ms)
     """
-    now = datetime.datetime.now(datetime.UTC)
+    now = datetime.datetime.now(datetime.timezone.utc)
     expiry = now + datetime.timedelta(minutes=get_access_token_expiry_minutes())
     expiry_timestamp = int(expiry.timestamp() * 1000)  # milliseconds
     
@@ -365,7 +365,7 @@ def generate_refresh_token(user_id: str, email: str) -> str:
         Refresh token string
     """
     import uuid
-    now = datetime.datetime.now(datetime.UTC)
+    now = datetime.datetime.now(datetime.timezone.utc)
     expiry = now + datetime.timedelta(days=REFRESH_TOKEN_EXPIRY_DAYS)
     
     payload = {

--- a/handoff/20250928/40_App/api-backend/src/utils/pre_auth_token.py
+++ b/handoff/20250928/40_App/api-backend/src/utils/pre_auth_token.py
@@ -15,7 +15,7 @@ Security Features:
 import os
 import uuid
 import logging
-from datetime import datetime, timedelta, UTC
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Any, Literal
 import jwt
 import redis.exceptions
@@ -89,7 +89,7 @@ class PreAuthTokenManager:
             JWT token string
         """
         jti = str(uuid.uuid4())
-        now = datetime.now(UTC)
+        now = datetime.now(timezone.utc)
         expiry = now + timedelta(minutes=PRE_AUTH_TOKEN_EXPIRY_MINUTES)
 
         payload = {
@@ -217,7 +217,7 @@ class PreAuthTokenManager:
             return False
 
         self.redis_client.hset(redis_key, "consumed", "True")
-        self.redis_client.hset(redis_key, "consumed_at", datetime.now(UTC).isoformat())
+        self.redis_client.hset(redis_key, "consumed_at", datetime.now(timezone.utc).isoformat())
 
         logger.info(f"Token jti {jti} consumed successfully")
         return True
@@ -238,7 +238,7 @@ class PreAuthTokenManager:
             True if successfully consumed (first use), False if already consumed or not found
         """
         redis_key = f"{REDIS_KEY_PREFIX}:pre_auth:jti:{jti}"
-        now_iso = datetime.now(UTC).isoformat()
+        now_iso = datetime.now(timezone.utc).isoformat()
 
         for attempt in range(max_retries):
             pipeline = self.redis_client.pipeline()


### PR DESCRIPTION
## Summary

Replaces `datetime.UTC` with `datetime.timezone.utc` across authentication-related code for Python 3.9/3.10 compatibility.

`datetime.UTC` was introduced in Python 3.11, causing `AttributeError` on older Python versions. `datetime.timezone.utc` is available since Python 3.2 and is functionally equivalent.

**Files changed:**
- `auth_middleware.py` - JWT token generation
- `auth.py` - Login token creation
- `auth_2fa.py` - 2FA verification timestamps
- `auth_service.py` - Access/refresh token generation
- `pre_auth_token.py` - Pre-auth token management

## Review & Testing Checklist for Human

- [ ] Verify auth flows work end-to-end (login, token refresh, 2FA if enabled)
- [ ] Confirm no other `datetime.UTC` usages remain in codebase: `grep -r "datetime.UTC" .`
- [ ] Test on Python 3.9 environment if available

**Recommended test plan:**
```bash
# Run auth-related tests
pytest handoff/20250928/40_App/api-backend/tests/test_auth*.py -v

# Manual verification: attempt login flow
```

### Notes

This is part of splitting the larger `chore/governance-and-fixes` branch into focused PRs for safer review.

**Requested by:** Ryan Chen (@RC918)
**Devin run:** https://app.devin.ai/sessions/83fb37289daa4e3d80722971e415e1ca

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures UTC handling works on Python <3.11 by standardizing on `datetime.timezone.utc`.
> 
> - **JWT generation**: Updated `exp`/`iat` in `auth_middleware.py` and `routes/auth.py`
> - **2FA flows**: Use `timezone.utc` for `verified_at` and backup code `used_at` in `routes/auth_2fa.py`
> - **Token service**: Access/refresh token `now`/expiry timestamps switched in `services/auth_service.py`
> - **Pre-auth tokens**: Token `iat`/`exp` and Redis `consumed_at` timestamps use `timezone.utc` in `utils/pre_auth_token.py`
> 
> No behavioral changes beyond UTC constant usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 086f16350ff7690e407d6ec9c53aa97e247536e4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->