### PR TITLE
fix(G-2): Add expires_at to memory entries for consolidation

### DIFF
--- a/handoff/20250928/40_App/orchestrator/memory/memory_integration.py
+++ b/handoff/20250928/40_App/orchestrator/memory/memory_integration.py
@@ -27,10 +27,25 @@ Usage:
 
 import json
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 from common.config.settings import settings
+
+
+def _calculate_expires_at(ttl_seconds: int) -> str:
+    """
+    Calculate expires_at timestamp based on TTL.
+
+    Args:
+        ttl_seconds: Time-to-live in seconds
+
+    Returns:
+        ISO format timestamp string for expiration
+    """
+    expires = datetime.now(timezone.utc) + timedelta(seconds=ttl_seconds)
+    return expires.isoformat()
+
 
 if TYPE_CHECKING:
     from .memory_v2 import MemoryV2
@@ -131,6 +146,7 @@ def save_flow_state(
             layer=MemoryLayer.SHORT_TERM,
             scope=MemoryScope.WORKFLOW,
             trace_id=trace_id,
+            expires_at=_calculate_expires_at(settings.memory_v2_short_term_ttl),
             metadata={
                 "plan_id": plan_id,
                 "current_stage": current_stage,
@@ -313,6 +329,7 @@ def save_debate_result(
             layer=MemoryLayer.AGENT_INTERACTION,
             scope=MemoryScope.WORKFLOW,
             trace_id=trace_id,
+            expires_at=_calculate_expires_at(settings.memory_v2_agent_interaction_ttl),
             metadata={
                 "debate_id": debate_id,
                 "topic": topic,


### PR DESCRIPTION
## Summary

Fixes Memory Consolidation finding 0 expiring memories by adding `expires_at` timestamps to memory entries.

**Root Cause:** `save_debate_result()` and `save_flow_state()` were creating `MemoryEntry` objects without setting `expires_at`. The consolidation scanner (`_scan_expiring_memories()`) only processes entries that have `expires_at` set, so all memories were being skipped.

**Changes:**
- Add `_calculate_expires_at(ttl_seconds)` helper function
- Set `expires_at` in `save_flow_state()` using `memory_v2_short_term_ttl` (default: 1 hour)
- Set `expires_at` in `save_debate_result()` using `memory_v2_agent_interaction_ttl` (default: 24 hours)

## Review & Testing Checklist for Human

- [ ] Verify `memory_v2_short_term_ttl` and `memory_v2_agent_interaction_ttl` have sensible default values in settings.py (should be 3600 and 86400 respectively)
- [ ] Confirm the ISO format from `isoformat()` is compatible with consolidation's `fromisoformat()` parsing
- [ ] Consider if other memory functions (governance layer) also need `expires_at` - currently only SHORT_TERM and AGENT_INTERACTION are fixed

**Recommended Test Plan:**
1. Deploy to production (requires PR #4270 to be deployed first for feature flags)
2. Trigger a PR review that uses the debate engine
3. Check logs for `[MemoryIntegration] Saved debate result`
4. Wait for next consolidation run (6 hours) and verify logs show `Scanned N expiring memories` where N > 0

### Notes

This PR is a follow-up to PR #4270 which enabled the Memory v2 feature flags. Both PRs are required for Memory Consolidation to work properly.

---
Requested by: @RC918
Link to Devin run: https://app.devin.ai/sessions/55832c623b294639871d23b39290eae5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures expiring memories are visible to the consolidation scanner by timestamping relevant entries.
> 
> - Add `_calculate_expires_at(ttl_seconds)` helper to compute ISO `expires_at`
> - Set `expires_at` in `save_flow_state()` using `settings.memory_v2_short_term_ttl`
> - Set `expires_at` in `save_debate_result()` using `settings.memory_v2_agent_interaction_ttl`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8766e48d2332b2a20ad4f24848460d3cf890eb4. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->