### PR TITLE
fix: add logging for drift retry ImportError to aid debugging

### DIFF
--- a/handoff/20250928/40_App/orchestrator/llm/client.py
+++ b/handoff/20250928/40_App/orchestrator/llm/client.py
@@ -620,8 +620,16 @@ class LLMClient:
                     timeout=remaining_timeout,
                     **retry_kwargs
                 )
-        except ImportError:
-            pass  # Drift retry not available, continue normally
+        except ImportError as e:
+            logger.warning(
+                "[LLMClient] Drift retry module not available (ImportError), "
+                "skipping retry. Ensure governance.drift_retry is deployed.",
+                extra={
+                    "provider": self._provider_name,
+                    "model": self.model,
+                    "error": str(e)
+                }
+            )
         except Exception as e:
             # Log retry errors but don't block - return original response
             logger.warning(


### PR DESCRIPTION
## Summary

During D-4 Auto-Fix testing on staging, we discovered that drift retry was silently failing because the `governance.drift_retry` module could not be imported. The existing code caught `ImportError` with a bare `pass`, making it impossible to diagnose why `DRIFT_RETRY_ENABLED=true` wasn't working.

This change adds a warning log when `ImportError` occurs, including provider, model, and error context to help operators identify deployment issues.

**Before:** Silent failure, no logs
**After:** `[LLMClient] Drift retry module not available (ImportError), skipping retry...`

## Review & Testing Checklist for Human

- [ ] Verify the log message is clear and actionable for operators
- [ ] Confirm the `extra` fields (provider, model, error) are appropriate for structured logging

### Notes

- This is a non-blocking change - the original behavior (skip retry and return original response) is preserved
- The fix was identified during investigation of why D-4 couldn't auto-fix CI failures despite correct settings

---
**Requested by:** Ryan Chen (@RC918)
**Devin run:** https://app.devin.ai/sessions/23203fa207bc47fdb51ae4b2d0427c5e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds observability to drift-triggered retry failures without changing behavior.
> 
> - In `LLMClient._handle_drift_retry`, replace silent `ImportError` handling with a warning log when `governance.drift_retry` is unavailable, including `provider`, `model`, and `error` in `extra` context
> - Retry flow remains non-blocking; on failure, returns `None` and original response is used
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ed61e6ed42092caa64233888fdb7177fd64725a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->