### PR TITLE
fix: correct vector search_path in match_memory_v2_knowledge function

### DIFF
--- a/migrations/046_fix_memory_v2_vector_search_path.sql
+++ b/migrations/046_fix_memory_v2_vector_search_path.sql
@@ -1,0 +1,115 @@
+-- ============================================================================
+-- Migration 046: Fix Memory v2 Vector Search Path
+-- ============================================================================
+-- 
+-- Purpose: Fix the search_path in match_memory_v2_knowledge function to include
+--          the extensions schema where the vector extension is installed.
+--
+-- Problem: Migration 043 created the function with SET search_path = public,
+--          but Supabase installs the vector extension in the 'extensions' schema.
+--          This causes "operator does not exist: extensions.vector <=> extensions.vector"
+--          errors when calling the function.
+--
+-- Solution: Recreate the function with search_path = extensions, public
+--
+-- Related: D-4 Auto-Fix investigation, PR #4289
+--
+-- ============================================================================
+
+-- Drop and recreate the function with corrected search_path
+CREATE OR REPLACE FUNCTION match_memory_v2_knowledge(
+    query_embedding vector(1024),
+    match_threshold float DEFAULT 0.7,
+    match_count int DEFAULT 10,
+    scope_filter text DEFAULT NULL,
+    trace_id_filter text DEFAULT NULL
+)
+RETURNS TABLE (
+    id bigint,
+    key text,
+    content text,
+    scope text,
+    metadata jsonb,
+    embedding vector(1024),
+    trace_id text,
+    agent_id text,
+    created_at timestamptz,
+    updated_at timestamptz,
+    similarity float
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = extensions, public
+AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        m.id,
+        m.key,
+        m.content,
+        m.scope,
+        m.metadata,
+        m.embedding,
+        m.trace_id,
+        m.agent_id,
+        m.created_at,
+        m.updated_at,
+        1 - (m.embedding <=> query_embedding) AS similarity
+    FROM memory_v2_knowledge m
+    WHERE 
+        m.embedding IS NOT NULL
+        AND 1 - (m.embedding <=> query_embedding) > match_threshold
+        AND (scope_filter IS NULL OR m.scope = scope_filter)
+        AND (trace_id_filter IS NULL OR m.trace_id = trace_id_filter)
+    ORDER BY m.embedding <=> query_embedding
+    LIMIT match_count;
+END;
+$$;
+
+-- Update comment to reflect the fix
+COMMENT ON FUNCTION match_memory_v2_knowledge IS 
+    'Vector similarity search for Memory v2 Knowledge Base layer (search_path fixed in migration 046)';
+
+-- ============================================================================
+-- Verification
+-- ============================================================================
+
+DO $$
+DECLARE
+    func_search_path TEXT;
+BEGIN
+    RAISE NOTICE '
+==============================================================================
+  Migration 046: Fix Memory v2 Vector Search Path - Verification
+==============================================================================
+';
+
+    -- Check the function's search_path setting
+    SELECT proconfig::text INTO func_search_path
+    FROM pg_proc
+    WHERE proname = 'match_memory_v2_knowledge';
+    
+    IF func_search_path LIKE '%extensions%' THEN
+        RAISE NOTICE '  match_memory_v2_knowledge: search_path includes extensions schema';
+        RAISE NOTICE '  Current config: %', func_search_path;
+    ELSE
+        RAISE WARNING '  match_memory_v2_knowledge: search_path may not include extensions schema';
+        RAISE WARNING '  Current config: %', COALESCE(func_search_path, 'NULL');
+    END IF;
+    
+    RAISE NOTICE '
+==============================================================================
+  Migration 046: COMPLETE
+==============================================================================
+  Fixed:
+  - match_memory_v2_knowledge function search_path now includes extensions schema
+  - Vector operators (<=> for cosine distance) will now resolve correctly
+  
+  Before: SET search_path = public
+  After:  SET search_path = extensions, public
+  
+  This fixes the error:
+  "operator does not exist: extensions.vector <=> extensions.vector"
+==============================================================================
+';
+END $$;


### PR DESCRIPTION
## Summary

Migration 043 created the `match_memory_v2_knowledge` function with `SET search_path = public`, but Supabase installs the vector extension in the `extensions` schema. This caused "operator does not exist: extensions.vector <=> extensions.vector" errors when D-4 Auto-Fix attempted to use the Knowledge Base memory layer.

This migration recreates the function with `search_path = extensions, public` so PostgreSQL can find the vector operators (`<=>` for cosine distance) in the correct schema.

**Before:** `SET search_path = public`
**After:** `SET search_path = extensions, public`

## Review & Testing Checklist for Human

- [ ] Verify the vector extension is in `extensions` schema on staging: `SELECT extname, extnamespace::regnamespace FROM pg_extension WHERE extname = 'vector';`
- [ ] Run migration on **staging first** and verify no errors
- [ ] Test vector similarity search works after migration by calling `match_memory_v2_knowledge` with a test embedding
- [ ] Verify the function's search_path was updated: `SELECT proconfig FROM pg_proc WHERE proname = 'match_memory_v2_knowledge';`

**Recommended Test Plan:**
1. Deploy to staging
2. Trigger a D-4 Auto-Fix scenario (or any flow that uses KnowledgeBase memory)
3. Confirm no "operator does not exist" errors in logs
4. Deploy to production

### Notes

- This is a corrective migration for an issue discovered during D-4 Auto-Fix testing
- The function signature is identical to migration 043; only the search_path is changed
- Related: PR #4289 (drift retry logging fix)

---
**Requested by:** Ryan Chen (@RC918)
**Devin run:** https://app.devin.ai/sessions/23203fa207bc47fdb51ae4b2d0427c5e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes vector operator resolution by ensuring the function runs with the extensions schema on the search path.
> 
> - Recreates `match_memory_v2_knowledge` with `SET search_path = extensions, public` (function signature and logic unchanged)
> - Adds/updates function comment to note the fix
> - Adds a verification `DO $$` block that logs and confirms the function’s `search_path` includes `extensions`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c109bdde926660d7d3d0ce34572351cdac10d550. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->