### PR TITLE
test: D-4 auto-fix verification v2 - introduce lint error

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/services/auth_service.py
+++ b/handoff/20250928/40_App/api-backend/src/services/auth_service.py
@@ -85,6 +85,8 @@ def _as_bool(val):
     if val is None:
         return False
     s = str(val).strip().lower()
+    # D-4 test v2: undefined variable to trigger lint error (F821)
+    _ = d4_test_undefined_var
     return s in ("1", "true", "yes", "on")
 
 def is_testing_mode():


### PR DESCRIPTION
## Summary

**⚠️ TEST PR - DO NOT MERGE ⚠️**

This PR intentionally introduces a lint error (F821: undefined name `d4_test_undefined_var`) to verify that D-4 Auto-Fix is working correctly after the following fixes:

- PR #4289: Added logging for drift retry ImportError
- PR #4291: Fixed vector search_path in `match_memory_v2_knowledge` function (migration 046)

The previous test PR (#4288) exhausted its retry counter (max 3 attempts), so this new PR provides a fresh counter for testing.

## Review & Testing Checklist for Human

- [ ] **Monitor staging worker logs** for `ci_failure` events after CI fails
- [ ] **Verify D-4 triggers** - search for `GeneralCoder` or `autofix` in logs
- [ ] **Confirm vector search error is gone** - no more "operator does not exist: extensions.vector" errors
- [ ] **Close this PR** after verification (regardless of D-4 success/failure)

**Test Plan:**
1. Wait for CI to fail (lint error is intentional)
2. Check staging logs: `morningai-backend-v2-stg-worker`
3. Search for `ci_failure_actionable` to confirm D-4 received the event
4. If D-4 succeeds, a new commit will appear removing the undefined variable
5. Close PR after verification

### Notes

- Branch uses `fix/*` naming (not `devin/*`) to avoid D-4's self-trigger loop protection
- This is the second test attempt after PR #4288 hit the 3-retry limit

---
**Requested by:** Ryan Chen (@RC918)
**Devin run:** https://app.devin.ai/sessions/23203fa207bc47fdb51ae4b2d0427c5e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Validates D-4 auto-fix by intentionally introducing a lint error.
> 
> - In `auth_service.py`, adds a reference to undefined `d4_test_undefined_var` inside `/_as_bool/` to trigger flake8 F821
> - No other functional changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7996d66d327e5ac17388e9b345d4111c536e74bb. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->