### PR TITLE
fix(env): reject whitespace-only values for required variables (fixes…

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/utils/env_schema_validator.py
+++ b/handoff/20250928/40_App/api-backend/src/utils/env_schema_validator.py
@@ -24,7 +24,7 @@ def validate_environment() -> Dict[str, Any]:
     
     for var_name, var_type in REQUIRED_ENV_VARS.items():
         value = os.environ.get(var_name)
-        if not value:
+        if not value or not value.strip():
             errors.append(f"Missing required environment variable: {var_name}")
         elif var_type is str and not isinstance(value, str):
             errors.append(f"Invalid type for {var_name}: expected {var_type.__name__}")

--- a/handoff/20250928/40_App/api-backend/tests/test_env_schema_validator.py
+++ b/handoff/20250928/40_App/api-backend/tests/test_env_schema_validator.py
@@ -192,19 +192,18 @@ class TestEnvSchemaValidatorEdgeCases:
     """Edge case tests for env_schema_validator - Issue #4229"""
 
     def test_whitespace_only_required_var(self, clean_env, monkeypatch):
-        """Test validation behavior when required var contains only whitespace.
+        """Test validation fails when required var contains only whitespace.
 
-        Note: Currently whitespace-only values pass validation (treated as truthy).
-        This documents the current behavior. See issue for potential fix.
+        Issue #4257: Whitespace-only values should be treated as missing.
         """
         monkeypatch.setenv('DATABASE_URL', '   ')
         monkeypatch.setenv('APP_VERSION', '1.0.0')
 
         result = validate_environment()
 
-        # Whitespace-only is treated as truthy, so validation passes
-        # This documents the current behavior
-        assert result['valid'] is True
+        # Whitespace-only should be rejected (Issue #4257 fix)
+        assert result['valid'] is False
+        assert any('DATABASE_URL' in error for error in result['errors'])
 
     def test_special_characters_in_env_values(self, monkeypatch):
         """Test validation handles special characters in env values"""


### PR DESCRIPTION
… #4257)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enforces stricter required env var validation and aligns tests.
> 
> - **Behavior change:** `validate_environment` now rejects whitespace-only values for required vars by checking `not value.strip()` in `env_schema_validator.py`
> - **Tests updated:** Edge case test updated to expect failure for whitespace-only `DATABASE_URL` and assert corresponding error (Issue `#4257`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0fe5be398e35924ac49420b94516d999585edb8a. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->