### PR TITLE
feat(G-2): Add expires_at to memory save logs for debugging

### DIFF
--- a/handoff/20250928/40_App/orchestrator/memory/memory_integration.py
+++ b/handoff/20250928/40_App/orchestrator/memory/memory_integration.py
@@ -163,6 +163,7 @@ def save_flow_state(
                     "plan_id": plan_id,
                     "trace_id": trace_id,
                     "current_stage": current_stage,
+                    "expires_at": entry.expires_at,
                     "operation": "save_flow_state",
                 }
             )
@@ -353,6 +354,7 @@ def save_debate_result(
                     "trace_id": trace_id,
                     "outcome": outcome,
                     "rounds_completed": rounds_completed,
+                    "expires_at": entry.expires_at,
                     "operation": "save_debate_result",
                 }
             )


### PR DESCRIPTION
## Summary

Adds the `expires_at` timestamp to log output when saving flow state and debate results to Memory v2. This helps with debugging Memory Consolidation (G-2) by making it visible in logs when memories will expire.

**Changes:**
- `save_flow_state()`: Added `expires_at` to log extras
- `save_debate_result()`: Added `expires_at` to log extras

## Review & Testing Checklist for Human

- [ ] Verify log output format is consistent with existing patterns in the codebase

### Test Plan
After deployment, check Render logs for entries like:
```
[MemoryIntegration] Saved debate result {..., "expires_at": "2026-01-23T12:00:00+00:00", ...}
```

### Notes

This PR also serves to verify that PR #4275 (which added `expires_at` to memory entries) is working correctly by triggering the MorningAI Reviewer Agent.

**Link to Devin run:** https://app.devin.ai/sessions/55832c623b294639871d23b39290eae5
**Requested by:** Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Surfaces memory expiration timestamps in logs to aid debugging and observability for Memory v2 saves.
> 
> - Adds `expires_at` to the log `extra` payload after successful `save_flow_state()` writes
> - Adds `expires_at` to the log `extra` payload after successful `save_debate_result()` writes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6166983a5743e5ef9147236a95aef5d7bc1c6730. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->