### PR TITLE
chore(F-6): Enable USE_DEBATE_HOOK for automatic debate triggering

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -201,6 +201,8 @@ services:
         value: "true"
       - key: USE_DEBATE_ENGINE
         value: "true"
+      - key: USE_DEBATE_HOOK
+        value: "true"
       - key: USE_DEPENDENCY_ANALYSIS
         value: "true"
       - key: USE_MULTI_SPECIALIST_REVIEW


### PR DESCRIPTION
## Summary

Enables `USE_DEBATE_HOOK=true` for the morningai-agent-worker service. This allows DebateHook to automatically trigger debates when Planning creates HIGH or CRITICAL risk plans.

**Context:** During investigation of why Memory Consolidation (G-2) was finding 0 expiring memories, discovered that while `USE_DEBATE_ENGINE=true` was set, `USE_DEBATE_HOOK` was not configured (defaulting to `false`). This meant DebateHook was always returning early without triggering debates, so no debate results were being saved to AGENT_INTERACTION memory.

**Code flow:**
- `DebateHook.on_plan_created()` checks `_use_debate_hook()` first (model_tier_selection.py:424)
- Without this flag, the hook returns immediately without invoking DebateEngine
- With this flag enabled, high-risk plans will trigger debates → save results to AGENT_INTERACTION memory → Memory Consolidation can process them

## Review & Testing Checklist for Human

- [ ] Confirm enabling automatic debates for HIGH/CRITICAL risk plans is desired behavior
- [ ] Consider cost implications (more LLM calls when debates are triggered)
- [ ] After deployment, monitor logs for `[DebateHook] Triggering debate for high-risk plan` messages

### Notes

Blueprint Reference: Section F-6 DebateHook

This PR was requested by @RC918 and created with assistance from Devin.
Link to Devin run: https://app.devin.ai/sessions/55832c623b294639871d23b39290eae5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables automatic debate triggering in the agent worker.
> 
> - Sets `USE_DEBATE_HOOK` to `"true"` in `render.yaml` for `morningai-agent-worker`
> - Complements existing `USE_DEBATE_ENGINE` flag to ensure debates can be invoked by hooks
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09947ae35363f5f155b4db91c06f8f8a099dd22e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->