### PR TITLE
feat(G-2): Add test script to trigger debate for Memory Consolidation verification

### DIFF
--- a/handoff/20250928/40_App/orchestrator/scripts/test_debate_trigger.py
+++ b/handoff/20250928/40_App/orchestrator/scripts/test_debate_trigger.py
@@ -8,6 +8,9 @@ This script directly calls DebateEngine.debate() to:
 3. Create an AGENT_INTERACTION memory entry for consolidation to process
 
 Usage:
+    cd ~/repos/morningai
+    source .venv/bin/activate
+    export PYTHONPATH="$PWD:$PWD/handoff/20250928/40_App/orchestrator:$PYTHONPATH"
     cd handoff/20250928/40_App/orchestrator
     python scripts/test_debate_trigger.py
 


### PR DESCRIPTION
## Summary

Adds a test script to manually trigger a debate and verify the Memory Consolidation fix (PR #4275). This script directly calls `DebateEngine.debate()` to create an AGENT_INTERACTION memory entry with `expires_at` set, allowing verification that Memory Consolidation can find and process expiring memories.

**Context:** After enabling `USE_DEBATE_HOOK` in PR #4299, we need a way to trigger a test debate since no high-risk Planning tasks have occurred naturally. This script provides a manual way to create a debate result for verification.

**Key details:**
- Uses `enable_llm=False` for fast template-based testing (no LLM calls)
- Creates a test debate with `risk_level="high"` 
- Outputs verification steps for checking logs

## Review & Testing Checklist for Human

- [ ] Verify PYTHONPATH setup instructions are correct for production environment
- [ ] After merging, run the script in production and check Render logs for `[MemoryIntegration] Saved debate result` with `expires_at` field

### Test Plan
1. Deploy this PR
2. SSH into production worker or run via Render shell:
   ```bash
   cd handoff/20250928/40_App/orchestrator
   python scripts/test_debate_trigger.py
   ```
3. Check Render logs for `[MemoryIntegration] Saved debate result` with `expires_at`
4. After 18-24 hours, check consolidation logs for `Scanned N expiring memories` where N > 0

### Notes

Blueprint Reference: G-2 Memory Consolidation verification

This PR was requested by @RC918 and created with assistance from Devin.
Link to Devin run: https://app.devin.ai/sessions/55832c623b294639871d23b39290eae5

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a minimal script to manually trigger a debate and generate an expiring memory for consolidation checks.
> 
> - Adds `scripts/test_debate_trigger.py` to call `DebateEngine.debate()` with `enable_llm=False`
> - Creates a high-risk `DebateTopic` and logs outcome, confidence, and verification steps
> - Guides checking logs for `[MemoryIntegration] Saved debate result` with `expires_at`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 94794dec17a9ca40a7c40785c0c76a37713a3638. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->