### PR TITLE
fix: D-4 test v4 - verify LLM_REQUEST_TIMEOUT with auto-fix

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/services/auth_service.py
+++ b/handoff/20250928/40_App/api-backend/src/services/auth_service.py
@@ -85,6 +85,8 @@ def _as_bool(val):
     if val is None:
         return False
     s = str(val).strip().lower()
+    # D-4 test v4: undefined variable to trigger lint error (F821)
+    _ = d4_test_v4_undefined_var
     return s in ("1", "true", "yes", "on")
 
 def is_testing_mode():


### PR DESCRIPTION
## Summary

**⚠️ TEST PR - DO NOT MERGE - CLOSE AFTER VERIFICATION ⚠️**

This PR intentionally introduces a lint error (F821: undefined name `d4_test_v4_undefined_var`) to verify that the D-4 Auto-Fix system is working correctly with the newly deployed `LLM_REQUEST_TIMEOUT=60s` setting from PR #4298.

### What this tests:
1. CI lint check fails with F821 error ✓
2. D-4 detects the failure and triggers auto-fix
3. D-4 uses `LLM_REQUEST_TIMEOUT=60s` (should not hang on Gemini)
4. If Gemini fails, cross-provider fallback to alicloud should work
5. D-4 pushes a fix commit to remove the undefined variable

## Review & Testing Checklist for Human

- [ ] **DO NOT MERGE** - Close this PR after D-4 verification is complete
- [ ] Monitor staging Worker logs for `ci_failure_actionable` to confirm D-4 triggered
- [ ] Check logs for `LLM_REQUEST_TIMEOUT=60s` being used
- [ ] Verify D-4 successfully pushes a fix commit (or check if it fails and why)

### Test Plan
1. Wait for CI to fail (lint error)
2. Search staging logs: `ci_failure_actionable` and `LLM_REQUEST_TIMEOUT`
3. If D-4 succeeds, a new commit will appear on this PR
4. Close PR regardless of outcome

### Notes
- Previous test PRs (#4288, #4293, #4294) encountered issues: Worker crashes, Gemini API hangs, `test:` prefix filtering
- This PR uses `fix:` prefix to avoid smart filtering
- Branch name `fix/d4-test-v4-*` avoids `devin/*` branch skip rule

---
Requested by: Ryan Chen (@RC918)
Link to Devin run: https://app.devin.ai/sessions/23203fa207bc47fdb51ae4b2d0427c5e

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Purpose**
> - Intentionally trigger a lint failure to verify D-4 auto-fix behavior and timeout configuration.
> 
> **Key Change**
> - In `auth_service.py`, adds a reference to undefined `d4_test_v4_undefined_var` inside `_as_bool`, causing F821 during linting.
> 
> **Scope**
> - No other code paths or files modified.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5095bb8954a09946ddddf60793ef44564239ef22. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->