### PR TITLE
fix(F-5): Fix LLMClient.generate() parameter mismatch in DebateEngine

### DIFF
--- a/handoff/20250928/40_App/orchestrator/core/planner/debate_engine.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/debate_engine.py
@@ -357,7 +357,7 @@ Format your response as JSON with these fields:
             system_prompt=system_prompt,
         )
 
-        return self._parse_argument_response(response, round_number)
+        return self._parse_argument_response(response.content, round_number)
 
     def _build_user_prompt(
         self,
@@ -566,7 +566,7 @@ Format your response as JSON with these fields:
             system_prompt=self.SYSTEM_PROMPT,
         )
 
-        return self._parse_decision_response(response)
+        return self._parse_decision_response(response.content)
 
     def _build_evaluation_prompt(
         self,

--- a/handoff/20250928/40_App/orchestrator/core/planner/debate_engine.py
+++ b/handoff/20250928/40_App/orchestrator/core/planner/debate_engine.py
@@ -353,9 +353,8 @@ Format your response as JSON with these fields:
         )
 
         response = client.generate(
+            prompt=user_prompt,
             system_prompt=system_prompt,
-            user_prompt=user_prompt,
-            trace_id=self.trace_id,
         )
 
         return self._parse_argument_response(response, round_number)
@@ -563,9 +562,8 @@ Format your response as JSON with these fields:
         user_prompt = self._build_evaluation_prompt(topic, arguments)
 
         response = client.generate(
+            prompt=user_prompt,
             system_prompt=self.SYSTEM_PROMPT,
-            user_prompt=user_prompt,
-            trace_id=self.trace_id,
         )
 
         return self._parse_decision_response(response)

--- a/handoff/20250928/40_App/orchestrator/tests/test_debate_engine.py
+++ b/handoff/20250928/40_App/orchestrator/tests/test_debate_engine.py
@@ -10,6 +10,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'core', 'planner'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'llm', 'providers'))
 
 from debate_engine import (
     DebateRole,
@@ -895,7 +896,9 @@ class TestLLMIntegration:
     def test_debate_agent_llm_success(self, mock_get_client):
         """Test successful LLM-based argument generation."""
         mock_client = MagicMock()
-        mock_client.generate.return_value = '''
+        # LLMClient.generate() returns LLMResponse object with .content attribute
+        mock_response = MagicMock()
+        mock_response.content = '''
         {
             "position": "LLM position",
             "reasoning": "LLM reasoning",
@@ -904,6 +907,7 @@ class TestLLMIntegration:
             "confidence": 0.9
         }
         '''
+        mock_client.generate.return_value = mock_response
         mock_get_client.return_value = mock_client
 
         agent = DebateAgent(
@@ -942,7 +946,9 @@ class TestLLMIntegration:
     def test_judge_agent_llm_success(self, mock_get_client):
         """Test successful LLM-based judge decision."""
         mock_client = MagicMock()
-        mock_client.generate.return_value = '''
+        # LLMClient.generate() returns LLMResponse object with .content attribute
+        mock_response = MagicMock()
+        mock_response.content = '''
         {
             "outcome": "synthesis",
             "winning_position": "Combined approach",
@@ -956,6 +962,7 @@ class TestLLMIntegration:
             "action_items": []
         }
         '''
+        mock_client.generate.return_value = mock_response
         mock_get_client.return_value = mock_client
 
         judge = JudgeAgent(trace_id="test-123", enable_llm=True)


### PR DESCRIPTION
## Summary

Fixes a bug where `DebateEngine` was calling `LLMClient.generate()` with incorrect parameter names, causing all LLM-based debate generation to fail and fall back to template-based arguments.

The issues were:
- Code used `user_prompt=` but `LLMClient.generate()` expects `prompt=` as the first required argument
- This caused: `LLMClient.generate() missing 1 required positional argument: 'prompt'`
- Code passed the `LLMResponse` object directly to parse methods instead of extracting `response.content`

The fix updates both `_generate_llm_argument()` and `_generate_llm_decision()` methods to:
1. Use the correct parameter name (`prompt=` instead of `user_prompt=`)
2. Remove unsupported `trace_id` parameter
3. Extract `response.content` from the `LLMResponse` object before passing to parse methods

## Updates since last revision

- **Fixed Cursor Bugbot High Severity issue**: `LLMClient.generate()` returns an `LLMResponse` object with a `.content` attribute, not a string. The parse methods (`_parse_argument_response`, `_parse_decision_response`) expect strings and call `.find()` on them. Now correctly passing `response.content` instead of `response`.
- **Updated tests**: Test mocks now return `LLMResponse`-like objects with `.content` attribute to match actual API behavior.

## Review & Testing Checklist for Human

- [ ] Verify `LLMClient.generate()` signature in `llm/client.py` returns `LLMResponse` with `.content` attribute
- [ ] Confirm `LLMResponse` dataclass structure in `llm/providers/base.py` matches expected usage
- [ ] Test in Render environment: run `python scripts/test_debate_hook.py` and verify no more "LLM argument generation failed" warnings appear

### Test Plan
```bash
cd ~/project/src
source .venv/bin/activate
export PYTHONPATH="$PWD:$PWD/handoff/20250928/40_App/orchestrator:$PYTHONPATH"
cd handoff/20250928/40_App/orchestrator
python scripts/test_debate_hook.py
```

Expected: Debate should complete without "LLM argument generation failed" warnings (previously these appeared on every round).

### Notes
- All 62 existing debate engine tests pass
- The system was correctly falling back to template-based arguments, so this was not causing failures, just preventing LLM-enhanced debate functionality
- Cursor Bugbot correctly identified the `response.content` issue - this was a real bug that would have caused `AttributeError` at runtime

Link to Devin run: https://app.devin.ai/sessions/55832c623b294639871d23b39290eae5
Requested by: Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Fix LLM client invocation in debate engine**
> 
> - In `DebateAgent._generate_llm_argument` and `JudgeAgent._generate_llm_decision`, replace `user_prompt=` with `prompt=` when calling `client.generate` and remove the unsupported `trace_id` parameter
> - Aligns calls with `LLMClient.generate(prompt, system_prompt)` signature to enable LLM-backed argument generation and judging
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa319b1d596483e7b8f5be3d63cce208a753d9a3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->