### PR TITLE
feat: Add D-4 CI failure auto-fix test function

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/utils/helpers.py
+++ b/handoff/20250928/40_App/api-backend/src/utils/helpers.py
@@ -8,6 +8,11 @@ Tests should patch via 'src.main._as_bool' (not 'src.utils.helpers._as_bool').
 See: docs/PHASE1_MAIN_PY_REFACTORING_PLAN.md - Patch Canonical Target
 """
 
+# D-4 Test: Intentional lint error for CI failure auto-fix testing
+# This unused import will trigger ruff F401 error
+import json
+unused_test_variable = "This variable is intentionally unused to trigger F841"
+
 
 def _as_bool(val):
     """Check if a value is truthy (handles bool, None, and string values).

--- a/handoff/20250928/40_App/orchestrator/utils/constants.py
+++ b/handoff/20250928/40_App/orchestrator/utils/constants.py
@@ -39,3 +39,9 @@ REVIEWER_VERSION = "v1"
 LABEL_ORCHESTRATOR_DOCS = "orchestrator-docs"
 LABEL_ORCHESTRATOR_DOCS_TEST = "orchestrator-docs-test"
 LABEL_ORCHESTRATOR_APPROVED = "orchestrator-approved"
+
+# D-4 Test: Intentional lint error for CI failure auto-fix testing
+# This unused variable will trigger flake8 F841 error
+def d4_test_function():
+    unused_variable = "This variable is intentionally unused to trigger lint error"
+    return True


### PR DESCRIPTION
## Summary

This PR intentionally introduces a lint error (flake8 F841 - unused variable) to test the D-4 CI failure auto-fix functionality. The orchestrator should detect the CI failure and automatically push a fix.

**Important**: This is a test PR and should NOT be merged. It exists solely to verify D-4 functionality.

## Review & Testing Checklist for Human

- [ ] Verify CI fails with flake8 F841 error on `unused_variable`
- [ ] Monitor orchestrator logs for `[CROSS_PROVIDER_FALLBACK]` and `[ROUTER_STATE_DEBUG]` entries
- [ ] Confirm D-4 auto-fix triggers (check for `ci_failure_trigger=True` in logs)
- [ ] Verify the fix commit is pushed automatically by the orchestrator

### Test Plan
1. Wait for CI to fail on this PR
2. Check Render logs for `morningai-backend-v2-stg-worker` service
3. Search for `ROUTER_STATE_DEBUG` to confirm router execution with `ci_failure_trigger=True`
4. If D-4 triggers correctly, a fix commit should be pushed automatically

### Notes

Branch name `feature/d4-test-ci-failure-*` was chosen specifically to avoid the `devin/*` and `orchestrator/*` branch filters in EventNormalizer that would skip CI failure events.

---
**Link to Devin run**: https://app.devin.ai/sessions/f56d4ce47bf843bbb04965e24df526a7
**Requested by**: Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a deliberate lint failure to validate the orchestrator's CI auto-fix flow.
> 
> - Adds `d4_test_function` in `orchestrator/utils/constants.py` with an intentionally unused variable to trigger `flake8 F841`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36d1384544e7fb2df2414ad71ce6846dc1d0df16. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->