### PR TITLE
fix: Add type check for response.usage in LLM Reviewer

### DIFF
--- a/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
+++ b/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
@@ -1215,8 +1215,21 @@ class LLMReviewerAdapter:
             # Fix TypeError: ensure response.usage is a dict before calling .get()
             # This prevents "list indices must be integers or slices, not str" error
             # when LLM provider returns usage in unexpected format
+            # See follow-up issue for proper runtime type validation in LLMResponse
             if response.usage and isinstance(response.usage, dict):
                 token_count = response.usage.get('completion_tokens') or response.usage.get('output_tokens')
+            elif response.usage:
+                # Log warning to help identify providers returning non-dict usage
+                logger.warning(
+                    f"[LLM Reviewer] response.usage is not a dict: type={type(response.usage).__name__}",
+                    extra={
+                        "operation": "llm_reviewer",
+                        "trace_id": self.trace_id,
+                        "provider": response.provider,
+                        "model": response.model,
+                        "usage_type": type(response.usage).__name__
+                    }
+                )
             log_llm_response_bytes(
                 trace_id=self.trace_id,
                 response_bytes=response_bytes,

--- a/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
+++ b/handoff/20250928/40_App/orchestrator/llm_reviewer_adapter.py
@@ -1212,7 +1212,10 @@ class LLMReviewerAdapter:
             # P1 瘦身計畫 (#3197): Log LLM response bytes for resource profiling
             response_bytes = len(content.encode('utf-8')) if content else 0
             token_count = None
-            if response.usage:
+            # Fix TypeError: ensure response.usage is a dict before calling .get()
+            # This prevents "list indices must be integers or slices, not str" error
+            # when LLM provider returns usage in unexpected format
+            if response.usage and isinstance(response.usage, dict):
                 token_count = response.usage.get('completion_tokens') or response.usage.get('output_tokens')
             log_llm_response_bytes(
                 trace_id=self.trace_id,


### PR DESCRIPTION
## Summary

Fixes a TypeError (`list indices must be integers or slices, not str`) that occurs in the LLM Reviewer when `response.usage` is not a dict. This bug was causing D-4 CI failure auto-fix tasks to fail in the LLM Reviewer stage, preventing them from reaching Router and Fixer nodes.

The fix adds an `isinstance(response.usage, dict)` check before calling `.get()` on the usage object, plus a warning log to help identify which provider returns non-dict usage.

## Updates since last revision

- Added warning log when `response.usage` is not a dict (logs provider, model, and type)
- Created follow-up issue #4317 for proper runtime type validation in `LLMResponse.__post_init__`

## Review & Testing Checklist for Human

- [ ] Verify the fix handles normal dict usage cases correctly (no regression)
- [x] ~~Consider if a warning log should be added when `response.usage` is not a dict~~ (Done - now logs warning with provider/model info)
- [ ] Check if other places in the codebase access `response.usage.get()` without type checking
- [ ] Verify warning log format is appropriate for production monitoring

**Test Plan:** After merging, create a test PR with a lint error to trigger D-4 CI failure auto-fix and verify the task progresses past the LLM Reviewer stage to Router/Fixer nodes.

### Notes

This PR was created to address an issue discovered during D-4 investigation where tasks were failing with the error: `[LLM Reviewer] LLM API call failed: list indices must be integers or slices, not str`

**Follow-up:** Issue #4317 tracks the architectural improvement to add runtime type validation in `LLMResponse.__post_init__` (addresses MorningAI Reviewer's architecture comment).

Link to Devin run: https://app.devin.ai/sessions/f56d4ce47bf843bbb04965e24df526a7
Requested by: Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents crashes in the LLM Reviewer caused by unexpected `response.usage` formats.
> 
> - Adds `isinstance(response.usage, dict)` guard before accessing `.get()` to extract token counts during response telemetry
> - Leaves review generation logic unchanged; only affects logging of `token_count` (falls back to `None` if not a dict)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 692b2c0c1879e5ddf6fd1d683127e0d34a11b211. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->