### PR TITLE
feat(B-18.1.2): Add reaction event handling for PR review comments

### DIFF
--- a/handoff/20250928/40_App/orchestrator/review_context/review_comment_feedback.py
+++ b/handoff/20250928/40_App/orchestrator/review_context/review_comment_feedback.py
@@ -393,6 +393,126 @@ def create_feedback_from_webhook(
     return feedback
 
 
+def create_feedback_from_reaction(
+    event_metadata: Dict[str, Any],
+    pr_number: int,
+    repo: str,
+    action: str,
+) -> Optional[ReviewCommentFeedback]:
+    """
+    Create a ReviewCommentFeedback from a reaction webhook event.
+
+    B-18.1.2: Reaction events on PR review comments (thumbs up/down)
+
+    Args:
+        event_metadata: Metadata from the parsed webhook event
+        pr_number: Pull request number
+        repo: Repository in owner/repo format
+        action: The webhook action ("created" or "deleted")
+
+    Returns:
+        ReviewCommentFeedback or None if feedback cannot be created
+
+    Event Codes (greppable):
+        [FEEDBACK_REACTION_CREATED] - Feedback object created from reaction
+        [FEEDBACK_REACTION_SKIPPED] - Feedback creation skipped
+    """
+    if not settings.enable_review_comment_feedback:
+        logger.debug("[FEEDBACK_REACTION_SKIPPED] Feature flag disabled")
+        return None
+
+    comment_id = event_metadata.get("comment_id")
+    reaction_content = event_metadata.get("reaction_content", "")
+    reaction_sentiment = event_metadata.get("reaction_sentiment", "neutral")
+
+    if not comment_id:
+        logger.warning(
+            "[FEEDBACK_REACTION_SKIPPED] Missing comment_id in metadata"
+        )
+        return None
+
+    # Only process feedback for AI reviewer comments
+    is_ai_comment = event_metadata.get("comment_author_is_ai", False)
+    if not is_ai_comment:
+        logger.debug(
+            "[FEEDBACK_REACTION_SKIPPED] Comment is not from AI reviewer: comment_id=%s",
+            comment_id,
+        )
+        return None
+
+    # Classify based on reaction sentiment
+    # For "created" action: positive reaction = ACCEPTED, negative = REJECTED
+    # For "deleted" action: we record but with lower confidence (user changed mind)
+    if action == "created":
+        if reaction_sentiment == "positive":
+            classification = FeedbackClassification.ACCEPTED
+            confidence = 0.7  # Lower than explicit "good catch" reply
+        elif reaction_sentiment == "negative":
+            classification = FeedbackClassification.REJECTED
+            confidence = 0.9  # Thumbs down is a strong rejection signal
+        else:
+            classification = FeedbackClassification.UNKNOWN
+            confidence = 0.3
+    elif action == "deleted":
+        # Reaction was removed - user changed their mind
+        # We still record this but with lower confidence
+        classification = FeedbackClassification.UNKNOWN
+        confidence = 0.2
+    else:
+        classification = FeedbackClassification.UNKNOWN
+        confidence = 0.0
+
+    logger.info(
+        "[FEEDBACK_REACTION_CLASSIFIED] Reaction %s: content=%s, sentiment=%s -> %s (confidence=%.2f)",
+        action,
+        reaction_content,
+        reaction_sentiment,
+        classification.value,
+        confidence,
+    )
+
+    feedback = ReviewCommentFeedback(
+        comment_id=comment_id,
+        thread_id=0,  # Reactions don't have thread context
+        pr_number=pr_number,
+        repo=repo,
+        classification=classification,
+        confidence=confidence,
+        signal_source=f"reaction:{action}:{reaction_content}",
+        comment_body=event_metadata.get("comment_body", ""),
+        comment_path=event_metadata.get("comment_path"),
+        comment_line=event_metadata.get("comment_line"),
+        is_ai_comment=True,
+        ai_source=event_metadata.get("comment_ai_source"),
+        code_changed=False,
+        metadata={
+            "reaction_id": event_metadata.get("reaction_id"),
+            "reaction_content": reaction_content,
+            "reaction_sentiment": reaction_sentiment,
+            "reaction_user": event_metadata.get("reaction_user"),
+            "comment_node_id": event_metadata.get("comment_node_id"),
+        },
+    )
+
+    logger.info(
+        "[FEEDBACK_REACTION_CREATED] Created feedback from reaction: comment_id=%s, reaction=%s, classification=%s",
+        comment_id,
+        reaction_content,
+        classification.value,
+        extra={
+            "comment_id": comment_id,
+            "pr_number": pr_number,
+            "repo": repo,
+            "reaction_content": reaction_content,
+            "classification": classification.value,
+            "confidence": confidence,
+            "ai_source": feedback.ai_source,
+        }
+    )
+
+    return feedback
+
+
 class ReviewCommentFeedbackCollector:
     """
     Collects and processes review comment feedback.
@@ -401,8 +521,9 @@ class ReviewCommentFeedbackCollector:
 
     This class provides:
     1. process_thread_event(): Process thread resolved/unresolved events
-    2. process_reply(): Process reply text for feedback signals
-    3. get_stats(): Get collection statistics
+    2. process_reaction_event(): Process reaction events (B-18.1.2)
+    3. process_reply(): Process reply text for feedback signals
+    4. get_stats(): Get collection statistics
     """
 
     def __init__(self, trace_id: Optional[str] = None):
@@ -417,6 +538,7 @@ class ReviewCommentFeedbackCollector:
         self._feedbacks_collected = 0
         self._ai_comments_processed = 0
         self._human_comments_skipped = 0
+        self._reactions_processed = 0
 
     @property
     def is_enabled(self) -> bool:
@@ -463,6 +585,46 @@ class ReviewCommentFeedbackCollector:
 
         return feedback
 
+    def process_reaction_event(
+        self,
+        event_metadata: Dict[str, Any],
+        pr_number: int,
+        repo: str,
+        action: str,
+    ) -> Optional[ReviewCommentFeedback]:
+        """
+        Process a reaction event on a review comment.
+
+        B-18.1.2: Reaction events on PR review comments (thumbs up/down)
+
+        Args:
+            event_metadata: Metadata from the parsed webhook event
+            pr_number: Pull request number
+            repo: Repository in owner/repo format
+            action: The webhook action ("created" or "deleted")
+
+        Returns:
+            ReviewCommentFeedback or None if not applicable
+        """
+        if not self._enabled:
+            return None
+
+        feedback = create_feedback_from_reaction(
+            event_metadata=event_metadata,
+            pr_number=pr_number,
+            repo=repo,
+            action=action,
+        )
+
+        if feedback:
+            self._feedbacks_collected += 1
+            self._reactions_processed += 1
+            self._ai_comments_processed += 1
+        elif event_metadata.get("comment_author_is_ai", False) is False:
+            self._human_comments_skipped += 1
+
+        return feedback
+
     def get_stats(self) -> Dict[str, Any]:
         """Get feedback collection statistics."""
         return {
@@ -470,6 +632,7 @@ class ReviewCommentFeedbackCollector:
             "feedbacks_collected": self._feedbacks_collected,
             "ai_comments_processed": self._ai_comments_processed,
             "human_comments_skipped": self._human_comments_skipped,
+            "reactions_processed": self._reactions_processed,
             "trace_id": self.trace_id,
         }
 

--- a/handoff/20250928/40_App/orchestrator/webhooks/bot_protocol.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/bot_protocol.py
@@ -58,6 +58,9 @@ class WebhookEventType(Enum):
     # These events capture human feedback signals on AI review comments
     REVIEW_THREAD_RESOLVED = "review_thread_resolved"
     REVIEW_THREAD_UNRESOLVED = "review_thread_unresolved"
+    # B-18.1.2: Reaction events on PR review comments (thumbs up/down)
+    REVIEW_COMMENT_REACTION_CREATED = "review_comment_reaction_created"
+    REVIEW_COMMENT_REACTION_DELETED = "review_comment_reaction_deleted"
 
     # Message events (Slack)
     MESSAGE_RECEIVED = "message_received"

--- a/handoff/20250928/40_App/orchestrator/webhooks/handlers/github_handler.py
+++ b/handoff/20250928/40_App/orchestrator/webhooks/handlers/github_handler.py
@@ -149,6 +149,13 @@ GITHUB_EVENT_MAP: Dict[str, Dict[str, WebhookEventType]] = {
         "resolved": WebhookEventType.REVIEW_THREAD_RESOLVED,
         "unresolved": WebhookEventType.REVIEW_THREAD_UNRESOLVED,
     },
+    # B-18.1.2: Reaction events on PR review comments
+    # pull_request_review_comment_reaction events capture thumbs up/down reactions
+    # These provide explicit feedback signals on AI review comments
+    "pull_request_review_comment_reaction": {
+        "created": WebhookEventType.REVIEW_COMMENT_REACTION_CREATED,
+        "deleted": WebhookEventType.REVIEW_COMMENT_REACTION_DELETED,
+    },
 }
 
 
@@ -525,6 +532,33 @@ class GitHubWebhookHandler(BaseWebhookHandler):
             labels = [label.get("name") for label in pr.get("labels", [])]
             assignees = [a.get("login") for a in pr.get("assignees", [])]
 
+        # B-18.1.2: Handle pull_request_review_comment_reaction events
+        # This captures thumbs up/down reactions on AI review comments
+        elif github_event == "pull_request_review_comment_reaction":
+            comment = payload.get("comment", {})
+            reaction = payload.get("reaction", {})
+            pr = payload.get("pull_request", {})
+            action = payload.get("action", "")
+
+            # Extract PR info
+            pr_number = pr.get("number")
+            resource_id = str(pr_number) if pr_number is not None else None
+            resource_type = "review_comment_reaction"
+            resource_url = pr.get("html_url")
+            url = comment.get("html_url", "")
+
+            # Extract reaction info
+            reaction_content = reaction.get("content", "")  # "+1", "-1", "laugh", etc.
+            comment_body = comment.get("body", "")
+            comment_path = comment.get("path", "")
+
+            title = f"Reaction {action.capitalize()}: {reaction_content} on {comment_path}"
+            description = f"Reaction '{reaction_content}' {action} on comment: {comment_body[:100]}..."
+
+            # Store PR labels and assignees
+            labels = [label.get("name") for label in pr.get("labels", [])]
+            assignees = [a.get("login") for a in pr.get("assignees", [])]
+
         # Build metadata
         metadata: Dict[str, Any] = {
             "github_event": github_event,
@@ -618,6 +652,52 @@ class GitHubWebhookHandler(BaseWebhookHandler):
                 payload.get("action"),
                 thread.get("id"),
                 first_comment.get("id"),
+                metadata.get("comment_ai_source", "human"),
+            )
+
+        # B-18.1.2: Add reaction metadata for feedback processing
+        if github_event == "pull_request_review_comment_reaction":
+            comment = payload.get("comment", {})
+            reaction = payload.get("reaction", {})
+
+            # Comment identification
+            metadata["comment_id"] = comment.get("id")
+            metadata["comment_node_id"] = comment.get("node_id", "")
+            metadata["comment_body"] = comment.get("body", "")
+            metadata["comment_path"] = comment.get("path", "")
+            metadata["comment_line"] = comment.get("line") or comment.get("original_line")
+
+            # Reaction details
+            metadata["reaction_id"] = reaction.get("id")
+            metadata["reaction_content"] = reaction.get("content", "")  # "+1", "-1", etc.
+            metadata["reaction_user"] = reaction.get("user", {}).get("login", "")
+
+            # Check if the comment author is an AI reviewer
+            comment_author = comment.get("user", {}).get("login", "")
+            if ai_source := AI_REVIEWER_BOTS.get(comment_author):
+                metadata["comment_author_is_ai"] = True
+                metadata["comment_ai_source"] = ai_source
+            else:
+                metadata["comment_author_is_ai"] = False
+
+            # Determine if this is a positive or negative reaction
+            # GitHub reaction content values: "+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"
+            positive_reactions = {"+1", "heart", "hooray", "rocket"}
+            negative_reactions = {"-1", "confused"}
+            reaction_content = reaction.get("content", "")
+            if reaction_content in positive_reactions:
+                metadata["reaction_sentiment"] = "positive"
+            elif reaction_content in negative_reactions:
+                metadata["reaction_sentiment"] = "negative"
+            else:
+                metadata["reaction_sentiment"] = "neutral"
+
+            logger.info(
+                "[GitHubWebhookHandler] Review comment reaction %s: comment_id=%s, reaction=%s, sentiment=%s, ai_source=%s",
+                payload.get("action"),
+                comment.get("id"),
+                reaction_content,
+                metadata.get("reaction_sentiment"),
                 metadata.get("comment_ai_source", "human"),
             )
 


### PR DESCRIPTION
## Summary

Implements B-18.1.2 of EPIC B-18 (Review Comment Feedback) to capture emoji reactions on AI review comments as human feedback signals. This enables the system to learn from thumbs up/down reactions on AI-generated code review comments.

**Changes:**
- Add `REVIEW_COMMENT_REACTION_CREATED` and `REVIEW_COMMENT_REACTION_DELETED` event types to `WebhookEventType` enum
- Extend `GITHUB_EVENT_MAP` to handle `pull_request_review_comment_reaction` webhook events
- Parse reaction payload in `github_handler.py` (reaction content, comment ID, user, sentiment)
- Add `create_feedback_from_reaction()` function with sentiment-based classification
- Add `process_reaction_event()` method to `ReviewCommentFeedbackCollector`

**Reaction Sentiment Mapping:**
| Reaction | Sentiment | Classification | Confidence |
|----------|-----------|----------------|------------|
| +1, heart, hooray, rocket | positive | ACCEPTED | 0.7 |
| -1, confused | negative | REJECTED | 0.9 |
| laugh, eyes | neutral | UNKNOWN | 0.3 |
| (deleted) | - | UNKNOWN | 0.2 |

## Review & Testing Checklist for Human

- [ ] **Verify GitHub webhook payload structure** - The `pull_request_review_comment_reaction` event structure is based on GitHub docs; confirm it matches actual payloads
- [ ] **Review confidence values** - The hardcoded confidence scores (0.7, 0.9, 0.3, 0.2) are design decisions that may need tuning
- [ ] **Check thread_id=0 handling** - Reactions don't have thread context, so `thread_id=0` is used; verify downstream code handles this gracefully
- [ ] **Test with real webhook** - Enable `ENABLE_REVIEW_COMMENT_FEEDBACK=true` in staging and add a reaction to an AI review comment to verify end-to-end

**Recommended Test Plan:**
1. Deploy to staging with `ENABLE_REVIEW_COMMENT_FEEDBACK=true`
2. Create a PR that triggers AI review
3. Add thumbs up/down reactions to AI comments
4. Check logs for `[FEEDBACK_REACTION_CREATED]` and `[FEEDBACK_REACTION_CLASSIFIED]` entries

### Notes

This is Phase 1 infrastructure for B-18. The feedback is captured and classified but not yet written to Memory v2 (that's B-18.2).

Requested by: Ryan Chen (@RC918)
Link to Devin run: https://app.devin.ai/sessions/8d1dc97cb1d849a5b714b4bfa87b32d2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements reaction-based feedback capture for AI review comments, enabling sentiment-driven classification from GitHub emoji reactions.
> 
> - Adds `REVIEW_COMMENT_REACTION_CREATED`/`REVIEW_COMMENT_REACTION_DELETED` to `WebhookEventType` and maps `pull_request_review_comment_reaction` in `GITHUB_EVENT_MAP`
> - Extends GitHub handler to parse reaction payloads, extract comment/reaction metadata, detect AI author, and derive `reaction_sentiment` (positive/negative/neutral)
> - Introduces `create_feedback_from_reaction()` with sentiment → `FeedbackClassification` mapping and confidence scores; uses `thread_id=0`
> - Updates `ReviewCommentFeedbackCollector` with `process_reaction_event()` flow, counters, and stats (`reactions_processed`)
> - Adds structured logging hooks for classification/creation and honors `enable_review_comment_feedback` flag
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1bf6bf8b5549b95d2eb23a9bfd2e6c4526064af. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->