### PR TITLE
fix: Set loop_protection_triggered when CI signature deduplication triggers

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -6753,6 +6753,11 @@ def fixer_node(state: AgentState) -> AgentState:
                 state["messages"] = state.get("messages", []) + [
                     AIMessage(content="AutoFixer skipped - identical CI failure already processed within 24h")
                 ]
+                # Issue #4318: Set loop_protection_triggered to prevent infinite loop
+                # Without this flag, should_proceed_after_fixer routes to ci_monitor,
+                # which sees CI still failing and routes back to fixer, causing recursion
+                # until the LangGraph recursion limit (100) is reached.
+                state["loop_protection_triggered"] = True
                 latency_ms = (time.time() - start_time) * 1000
                 metrics.record_fixer_attempt(trace_id, retry_count, success=False)
                 metrics.record_node_complete("fixer", trace_id, success=False, latency_ms=latency_ms)


### PR DESCRIPTION
## Summary

Fixes an infinite loop bug in the D-4 CI failure auto-fix workflow. When CI signature deduplication detects an identical failure that was already processed, the workflow would loop indefinitely until hitting the LangGraph recursion limit (100).

**Root cause:** When deduplication triggered, it set `state["error"]` and returned, but didn't set `loop_protection_triggered`. The `should_proceed_after_fixer` function then routed to `ci_monitor` (because `ci_failure_trigger=True`), which saw CI still failing and routed back to `fixer`, creating an infinite loop.

**Fix:** Set `state["loop_protection_triggered"] = True` when deduplication triggers, so `should_proceed_after_fixer` routes to `finalizer` instead of `ci_monitor`.

## Review & Testing Checklist for Human

- [ ] Verify `should_proceed_after_fixer` (line ~9145) routes to "finalizer" when `loop_protection_triggered=True`
- [ ] Check if any other code paths read `loop_protection_triggered` that might be affected by this change
- [ ] Consider adding a unit test for the deduplication → finalizer routing scenario

**Test plan:** Trigger a CI failure on a PR, let D-4 attempt to fix it, then trigger the same CI failure again (same commit SHA). The workflow should exit cleanly to finalizer instead of hitting recursion limit.

### Notes

This PR was created as part of investigating D-4 CI failure auto-fix issues. The STG webhook has also been disabled to prevent duplicate processing between STG and PROD environments.

**Link to Devin run:** https://app.devin.ai/sessions/f56d4ce47bf843bbb04965e24df526a7
**Requested by:** Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents infinite recursion in the fixer workflow when an identical CI failure is deduplicated.
> 
> - In `orchestrator/langgraph_orchestrator.py`, when CI signature deduplication detects a prior identical failure, now sets `state["loop_protection_triggered"] = True`
> - Ensures `should_proceed_after_fixer` routes to `finalizer` instead of `ci_monitor`, avoiding LangGraph recursion to 100
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51b31fcf7ad17f5a936acb26f99e7391fe1815f8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->