### PR TITLE
feat: Add get_check_run_logs for D-4 CI failure auto-fix

### DIFF
--- a/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
+++ b/handoff/20250928/40_App/orchestrator/langgraph_orchestrator.py
@@ -4955,54 +4955,109 @@ def _attempt_self_correction_fix(
 
     # Issue #3803: Fetch CI logs from GitHub Actions if error_summary is empty
     # GitHub Actions annotations (source of error_summary) are not automatically
-    # created by pytest. We need to fetch the actual CI logs using get_ci_test_logs().
+    # created by pytest. We need to fetch the actual CI logs.
+    # Issue #4327: Use get_check_run_logs for D-4 CI failure auto-fix (fail-fast recovery)
+    # This avoids "Workflow still in_progress" issue when lint fails but tests are still running.
     if not test_output:
         pr_number = ci_context.get("pr_number")
         head_sha = ci_context.get("head_sha")
+        check_suite_id = ci_context.get("check_suite_id")
+        check_run_id = ci_context.get("check_run_id")
+        failed_check_name = ci_context.get("failed_check_name")
         if pr_number:
             try:
-                from tools.github_api import get_ci_test_logs, get_repo
+                from tools.github_api import get_check_run_logs, get_ci_test_logs, get_repo
                 repo = get_repo()
                 if repo:
-                    logger.info(
-                        f"[SELF_CORRECTION_INTEGRATION_FETCH_LOGS] Fetching CI logs from GitHub Actions. "
-                        f"pr_number={pr_number}, trace_id={trace_id}",
-                        extra={
-                            "operation": "self_correction_fetch_logs",
-                            "trace_id": trace_id,
-                            "event_code": "SELF_CORRECTION_INTEGRATION_FETCH_LOGS",
-                            "pr_number": pr_number,
-                        }
-                    )
-                    ci_logs_result = get_ci_test_logs(
-                        repo=repo,
-                        pr_number=pr_number,
-                        head_sha=head_sha,
-                        trace_id=trace_id
-                    )
-                    if ci_logs_result.get("success"):
-                        test_output = ci_logs_result.get("logs", "")
+                    # Issue #4327: Try get_check_run_logs first (direct check_run access)
+                    # This is faster and works even when other workflows are still running
+                    if check_suite_id or check_run_id:
                         logger.info(
-                            f"[SELF_CORRECTION_INTEGRATION_LOGS_FETCHED] Successfully fetched CI logs. "
-                            f"logs_length={len(test_output)}, trace_id={trace_id}",
+                            f"[SELF_CORRECTION_INTEGRATION_FETCH_CHECK_RUN_LOGS] Fetching logs from check_run. "
+                            f"check_suite_id={check_suite_id}, check_run_id={check_run_id}, trace_id={trace_id}",
                             extra={
-                                "operation": "self_correction_logs_fetched",
+                                "operation": "self_correction_fetch_check_run_logs",
                                 "trace_id": trace_id,
-                                "event_code": "SELF_CORRECTION_INTEGRATION_LOGS_FETCHED",
-                                "logs_length": len(test_output),
+                                "event_code": "SELF_CORRECTION_INTEGRATION_FETCH_CHECK_RUN_LOGS",
+                                "check_suite_id": check_suite_id,
+                                "check_run_id": check_run_id,
+                                "failed_check_name": failed_check_name,
                             }
                         )
-                    else:
-                        logger.warning(
-                            f"[SELF_CORRECTION_INTEGRATION_LOGS_FETCH_FAILED] Failed to fetch CI logs. "
-                            f"error={ci_logs_result.get('error', 'unknown')}, trace_id={trace_id}",
+                        check_run_result = get_check_run_logs(
+                            repo=repo,
+                            check_suite_id=check_suite_id,
+                            check_run_id=check_run_id,
+                            failed_check_name=failed_check_name,
+                            trace_id=trace_id
+                        )
+                        if check_run_result.get("success"):
+                            test_output = check_run_result.get("logs", "")
+                            logger.info(
+                                f"[SELF_CORRECTION_INTEGRATION_CHECK_RUN_LOGS_FETCHED] Successfully fetched check_run logs. "
+                                f"logs_length={len(test_output)}, check_run_name={check_run_result.get('check_run_name')}, trace_id={trace_id}",
+                                extra={
+                                    "operation": "self_correction_check_run_logs_fetched",
+                                    "trace_id": trace_id,
+                                    "event_code": "SELF_CORRECTION_INTEGRATION_CHECK_RUN_LOGS_FETCHED",
+                                    "logs_length": len(test_output),
+                                    "check_run_name": check_run_result.get("check_run_name"),
+                                    "annotations_count": len(check_run_result.get("annotations", [])),
+                                }
+                            )
+                        else:
+                            logger.warning(
+                                f"[SELF_CORRECTION_INTEGRATION_CHECK_RUN_LOGS_FAILED] Failed to fetch check_run logs. "
+                                f"error={check_run_result.get('error', 'unknown')}, trace_id={trace_id}",
+                                extra={
+                                    "operation": "self_correction_check_run_logs_failed",
+                                    "trace_id": trace_id,
+                                    "event_code": "SELF_CORRECTION_INTEGRATION_CHECK_RUN_LOGS_FAILED",
+                                    "error": check_run_result.get("error", "unknown"),
+                                }
+                            )
+
+                    # Fallback to get_ci_test_logs if check_run logs not available
+                    if not test_output:
+                        logger.info(
+                            f"[SELF_CORRECTION_INTEGRATION_FETCH_LOGS] Fetching CI logs from GitHub Actions. "
+                            f"pr_number={pr_number}, trace_id={trace_id}",
                             extra={
-                                "operation": "self_correction_logs_fetch_failed",
+                                "operation": "self_correction_fetch_logs",
                                 "trace_id": trace_id,
-                                "event_code": "SELF_CORRECTION_INTEGRATION_LOGS_FETCH_FAILED",
-                                "error": ci_logs_result.get("error", "unknown"),
+                                "event_code": "SELF_CORRECTION_INTEGRATION_FETCH_LOGS",
+                                "pr_number": pr_number,
                             }
                         )
+                        ci_logs_result = get_ci_test_logs(
+                            repo=repo,
+                            pr_number=pr_number,
+                            head_sha=head_sha,
+                            trace_id=trace_id
+                        )
+                        if ci_logs_result.get("success"):
+                            test_output = ci_logs_result.get("logs", "")
+                            logger.info(
+                                f"[SELF_CORRECTION_INTEGRATION_LOGS_FETCHED] Successfully fetched CI logs. "
+                                f"logs_length={len(test_output)}, trace_id={trace_id}",
+                                extra={
+                                    "operation": "self_correction_logs_fetched",
+                                    "trace_id": trace_id,
+                                    "event_code": "SELF_CORRECTION_INTEGRATION_LOGS_FETCHED",
+                                    "logs_length": len(test_output),
+                                }
+                            )
+                        else:
+                            logger.warning(
+                                f"[SELF_CORRECTION_INTEGRATION_LOGS_FETCH_FAILED] Failed to fetch CI logs. "
+                                f"error={ci_logs_result.get('error', 'unknown')}, trace_id={trace_id}",
+                                extra={
+                                    "operation": "self_correction_logs_fetch_failed",
+                                    "trace_id": trace_id,
+                                    "event_code": "SELF_CORRECTION_INTEGRATION_LOGS_FETCH_FAILED",
+                                    "error": ci_logs_result.get("error", "unknown"),
+                                }
+                            )
             except Exception as fetch_err:
                 logger.warning(
                     f"[SELF_CORRECTION_INTEGRATION_LOGS_FETCH_ERROR] Error fetching CI logs: {fetch_err}. "

--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -1913,6 +1913,247 @@ def cleanup_stale_orchestrator_branches(max_age_days: int = 7, dry_run: bool = T
     return results
 
 
+def get_check_run_logs(
+    repo,
+    check_suite_id: Optional[int] = None,
+    check_run_id: Optional[int] = None,
+    failed_check_name: Optional[str] = None,
+    trace_id: str = "unknown"
+) -> dict:
+    """
+    Fetch logs from a specific failed check_run for D-4 CI failure auto-fix.
+
+    Issue #4327: Separate function for D-4 Self-Correction (distinct from DiscoveryAuditor)
+    This function directly fetches logs from the failed check_run that triggered D-4,
+    avoiding the "Workflow still in_progress" issue when lint fails but tests are still running.
+
+    Unlike get_ci_test_logs (designed for DiscoveryAuditor to audit test coverage),
+    this function targets the specific failed check_run for immediate error context.
+
+    Args:
+        repo: GitHub repository object
+        check_suite_id: The check_suite ID from ci_failure_context (preferred)
+        check_run_id: The specific check_run ID (if known)
+        failed_check_name: Name of the failed check (e.g., "lint") for matching
+        trace_id: Trace ID for logging
+
+    Returns:
+        dict with keys:
+        - logs: str - The CI logs content
+        - success: bool - Whether logs were successfully fetched
+        - error: str - Error message if failed
+        - check_run_id: int - The check_run ID that was fetched
+        - check_run_name: str - The name of the check_run
+        - annotations: list - Annotations from the check_run (error details)
+    """
+    result = {
+        "logs": "",
+        "success": False,
+        "error": "",
+        "check_run_id": None,
+        "check_run_name": "",
+        "annotations": []
+    }
+
+    if repo is None:
+        result["error"] = "Repository not available"
+        logger.warning(
+            "[GitHub] get_check_run_logs: Repository not available",
+            extra={"operation": "get_check_run_logs", "trace_id": trace_id}
+        )
+        return result
+
+    try:
+        target_check_run = None
+
+        # Strategy 1: Use check_run_id directly if provided
+        if check_run_id:
+            try:
+                target_check_run = repo.get_check_run(check_run_id)
+                logger.info(
+                    "[GitHub] get_check_run_logs: Found check_run by ID",
+                    extra={
+                        "operation": "get_check_run_logs",
+                        "trace_id": trace_id,
+                        "check_run_id": check_run_id,
+                        "check_run_name": target_check_run.name if target_check_run else None,
+                    }
+                )
+            except Exception as e:
+                logger.warning(
+                    f"[GitHub] get_check_run_logs: Failed to get check_run by ID: {e}",
+                    extra={
+                        "operation": "get_check_run_logs",
+                        "trace_id": trace_id,
+                        "check_run_id": check_run_id,
+                        "error": str(e)[:100],
+                    }
+                )
+
+        # Strategy 2: Find failed check_run in check_suite
+        if not target_check_run and check_suite_id:
+            try:
+                check_suite = repo.get_check_suite(check_suite_id)
+                check_runs = check_suite.get_check_runs()
+
+                failure_conclusions = {"failure", "cancelled", "timed_out", "startup_failure", "action_required"}
+
+                for check_run in check_runs:
+                    # Find failed check_runs
+                    if check_run.conclusion in failure_conclusions:
+                        # If failed_check_name is provided, try to match
+                        if failed_check_name:
+                            if failed_check_name.lower() in check_run.name.lower():
+                                target_check_run = check_run
+                                break
+                        else:
+                            # Use first failed check_run
+                            target_check_run = check_run
+                            break
+
+                if target_check_run:
+                    logger.info(
+                        "[GitHub] get_check_run_logs: Found failed check_run in suite",
+                        extra={
+                            "operation": "get_check_run_logs",
+                            "trace_id": trace_id,
+                            "check_suite_id": check_suite_id,
+                            "check_run_id": target_check_run.id,
+                            "check_run_name": target_check_run.name,
+                        }
+                    )
+                else:
+                    logger.warning(
+                        "[GitHub] get_check_run_logs: No failed check_run found in suite",
+                        extra={
+                            "operation": "get_check_run_logs",
+                            "trace_id": trace_id,
+                            "check_suite_id": check_suite_id,
+                            "failed_check_name": failed_check_name,
+                        }
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"[GitHub] get_check_run_logs: Failed to get check_suite: {e}",
+                    extra={
+                        "operation": "get_check_run_logs",
+                        "trace_id": trace_id,
+                        "check_suite_id": check_suite_id,
+                        "error": str(e)[:100],
+                    }
+                )
+
+        if not target_check_run:
+            result["error"] = "No check_run found"
+            return result
+
+        result["check_run_id"] = target_check_run.id
+        result["check_run_name"] = target_check_run.name
+
+        # Extract annotations (structured error information)
+        try:
+            annotations = list(target_check_run.get_annotations())
+            annotation_data = []
+            for ann in annotations:
+                ann_info = {
+                    "path": getattr(ann, 'path', None),
+                    "start_line": getattr(ann, 'start_line', None),
+                    "end_line": getattr(ann, 'end_line', None),
+                    "message": getattr(ann, 'message', None),
+                    "annotation_level": getattr(ann, 'annotation_level', None),
+                }
+                annotation_data.append(ann_info)
+            result["annotations"] = annotation_data
+
+            # Build error summary from annotations
+            if annotation_data:
+                error_lines = []
+                for ann in annotation_data[:10]:  # Limit to first 10 annotations
+                    if ann.get("path") and ann.get("message"):
+                        line = ann.get("start_line", 0)
+                        error_lines.append(f"{ann['path']}:{line}: {ann['message'][:200]}")
+                if error_lines:
+                    result["logs"] = "\n".join(error_lines)
+                    result["success"] = True
+                    logger.info(
+                        f"[GitHub] get_check_run_logs: Extracted {len(annotation_data)} annotations",
+                        extra={
+                            "operation": "get_check_run_logs",
+                            "trace_id": trace_id,
+                            "check_run_id": target_check_run.id,
+                            "annotations_count": len(annotation_data),
+                        }
+                    )
+                    return result
+        except Exception as ann_err:
+            logger.warning(
+                f"[GitHub] get_check_run_logs: Failed to get annotations: {ann_err}",
+                extra={
+                    "operation": "get_check_run_logs",
+                    "trace_id": trace_id,
+                    "check_run_id": target_check_run.id,
+                    "error": str(ann_err)[:100],
+                }
+            )
+
+        # Fallback: Try to get output summary
+        try:
+            output = target_check_run.output
+            if output:
+                summary = output.get("summary") if isinstance(output, dict) else getattr(output, "summary", None)
+                text = output.get("text") if isinstance(output, dict) else getattr(output, "text", None)
+
+                if summary or text:
+                    result["logs"] = f"{summary or ''}\n{text or ''}".strip()
+                    result["success"] = True
+                    logger.info(
+                        "[GitHub] get_check_run_logs: Got output summary",
+                        extra={
+                            "operation": "get_check_run_logs",
+                            "trace_id": trace_id,
+                            "check_run_id": target_check_run.id,
+                            "logs_length": len(result["logs"]),
+                        }
+                    )
+                    return result
+        except Exception as output_err:
+            logger.warning(
+                f"[GitHub] get_check_run_logs: Failed to get output: {output_err}",
+                extra={
+                    "operation": "get_check_run_logs",
+                    "trace_id": trace_id,
+                    "check_run_id": target_check_run.id,
+                    "error": str(output_err)[:100],
+                }
+            )
+
+        # If no annotations or output, return with check_run info but no logs
+        result["error"] = "No annotations or output available"
+        logger.info(
+            "[GitHub] get_check_run_logs: No logs available for check_run",
+            extra={
+                "operation": "get_check_run_logs",
+                "trace_id": trace_id,
+                "check_run_id": target_check_run.id,
+                "check_run_name": target_check_run.name,
+            }
+        )
+
+    except Exception as e:
+        result["error"] = f"Unexpected error: {e}"
+        logger.error(
+            "[GitHub] get_check_run_logs: Unexpected error",
+            extra={
+                "operation": "get_check_run_logs",
+                "trace_id": trace_id,
+                "error": str(e)[:200],
+            },
+            exc_info=True
+        )
+
+    return result
+
+
 def get_ci_test_logs(
     repo,
     pr_number: int,

--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -2003,7 +2003,9 @@ def get_check_run_logs(
                     if check_run.conclusion in failure_conclusions:
                         # If failed_check_name is provided, try to match
                         if failed_check_name:
-                            if failed_check_name.lower() in check_run.name.lower():
+                            # Guard against None name (follows codebase pattern)
+                            check_run_name = check_run.name.lower() if check_run.name else ""
+                            if failed_check_name.lower() in check_run_name:
                                 target_check_run = check_run
                                 break
                         else:
@@ -2070,7 +2072,8 @@ def get_check_run_logs(
                 error_lines = []
                 for ann in annotation_data[:10]:  # Limit to first 10 annotations
                     if ann.get("path") and ann.get("message"):
-                        line = ann.get("start_line", 0)
+                        # Use `or 0` instead of default param since key exists with None value
+                        line = ann.get("start_line") or 0
                         error_lines.append(f"{ann['path']}:{line}: {ann['message'][:200]}")
                 if error_lines:
                     result["logs"] = "\n".join(error_lines)


### PR DESCRIPTION
## Summary

Adds a new `get_check_run_logs` function to directly fetch logs from failed check_runs, fixing the "Workflow still in_progress" issue in D-4 CI failure auto-fix.

**Problem:** When lint fails but tests are still running, `get_ci_test_logs` returns an error because it waits for the entire workflow to complete. This leaves D-4's GeneralCoder without error context, causing incorrect patches.

**Solution:** The new function directly accesses the specific failed check_run's annotations and output, enabling immediate error context retrieval without waiting for other workflows.

**Changes:**
- `github_api.py`: New `get_check_run_logs` function that fetches logs via check_suite_id or check_run_id
- `langgraph_orchestrator.py`: Modified `_attempt_self_correction_fix` to try `get_check_run_logs` first, with fallback to `get_ci_test_logs`

## Review & Testing Checklist for Human

- [ ] **Verify PyGithub API compatibility**: Confirm that `repo.get_check_run()`, `repo.get_check_suite()`, `check_suite.get_check_runs()`, and `check_run.get_annotations()` methods exist and work as expected
- [ ] **Check annotation attribute access**: The code uses `getattr(ann, 'path', None)` etc. - verify these match actual PyGithub CheckRunAnnotation object attributes
- [ ] **Confirm check_suite_id availability**: Verify that `ci_failure_context` contains `check_suite_id` (added in Issue #3821) when D-4 triggers
- [ ] **Test end-to-end**: Create a PR with a lint error (not on devin/* branch), wait for CI failure, and verify D-4 can now fetch error context and generate correct fix

**Recommended test plan:**
1. Create a test PR on a non-devin/* branch with an intentional lint error (e.g., unused import in `api-backend/src`)
2. Wait for CI lint check to fail
3. Monitor PROD logs for `SELF_CORRECTION_INTEGRATION_FETCH_CHECK_RUN_LOGS` and `CHECK_RUN_LOGS_FETCHED` events
4. Verify D-4 successfully commits a fix

### Notes
- This PR does not include unit tests for the new function
- The existing `get_ci_test_logs` is preserved for DiscoveryAuditor use case (complete test logs)
- Complexity warning (C901) is pre-existing in the codebase

Link to Devin run: https://app.devin.ai/sessions/f56d4ce47bf843bbb04965e24df526a7
Requested by: @RC918

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves D-4 CI failure auto-fix by sourcing error context directly from failed `check_run` before falling back to workflow logs.
> 
> - New `get_check_run_logs` in `github_api.py` fetches logs/annotations from a specific failed `check_run` via `check_suite_id`/`check_run_id` (with output/annotation fallbacks)
> - Updates `langgraph_orchestrator.py` self-correction flow to attempt `get_check_run_logs` first, then fallback to `get_ci_test_logs`, with expanded structured logging and context fields (`check_suite_id`, `check_run_id`, `failed_check_name`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06da1e2a8322e1ff3cc13b76865edfdf4654e8b5. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->