### PR TITLE
feat: Add D-4 CI failure auto-fix verification test

### DIFF
--- a/handoff/20250928/40_App/api-backend/src/utils/helpers.py
+++ b/handoff/20250928/40_App/api-backend/src/utils/helpers.py
@@ -8,6 +8,10 @@ Tests should patch via 'src.main._as_bool' (not 'src.utils.helpers._as_bool').
 See: docs/PHASE1_MAIN_PY_REFACTORING_PLAN.md - Patch Canonical Target
 """
 
+# D-4 Test: Intentional lint error for CI failure auto-fix testing
+# This unused import will trigger ruff F401 error
+import json
+
 
 def _as_bool(val):
     """Check if a value is truthy (handles bool, None, and string values).

--- a/handoff/20250928/40_App/api-backend/src/utils/helpers.py
+++ b/handoff/20250928/40_App/api-backend/src/utils/helpers.py
@@ -10,7 +10,6 @@ See: docs/PHASE1_MAIN_PY_REFACTORING_PLAN.md - Patch Canonical Target
 
 # D-4 Test: Intentional lint error for CI failure auto-fix testing
 # This unused import will trigger ruff F401 error
-import json
 
 
 def _as_bool(val):


### PR DESCRIPTION
## Summary

This PR intentionally introduces a lint error (unused `import json`) to verify the D-4 CI failure auto-fix functionality with the newly deployed `get_check_run_logs` function (PR #4327).

**Important:** This is a TEST PR. The lint error is intentional and should trigger D-4 to automatically create a fix commit.

## Why a new PR?

The previous test PR #4310 used a `devin/*` branch, which D-4 skips by design to prevent self-trigger loops. This PR uses `feature/d4-test-verification` to bypass that filter.

## Expected Behavior

1. CI lint check fails with ruff F401 (unused import)
2. D-4 detects the CI failure via webhook
3. D-4 uses `get_check_run_logs` to fetch error details
4. D-4 automatically commits a fix removing the unused import

## Review & Testing Checklist for Human

- [ ] Monitor PROD logs for `[EventNormalizer]` to confirm CI failure event is received (not skipped)
- [ ] Search for `ROUTER_STATE_DEBUG` with `ci_failure_trigger=True` to confirm D-4 routing
- [ ] Search for `[Fixer]` logs to confirm auto-fix execution
- [ ] Verify D-4 creates a commit removing the unused import
- [ ] Close this PR after test verification (do NOT merge with intentional lint error)

### Notes

- Requested by: Ryan Chen (@RC918)
- Devin session: https://app.devin.ai/sessions/f56d4ce47bf843bbb04965e24df526a7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Test change to verify CI auto-fix**
> 
> - Adds an intentional unused import `json` in `src/utils/helpers.py` to trigger ruff F401 and validate D-4 CI failure auto-fix behavior
> - No functional code changes; `_as_bool` remains unchanged and runtime behavior is unaffected
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dde56e05851344cf4d6ad8aa203a92db1e296e09. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->