### PR TITLE
fix: Add fallback for check_run name matching in get_check_run_logs

### DIFF
--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -2010,12 +2010,14 @@ def get_check_run_logs(
 
                         # If failed_check_name is provided, try to match
                         if failed_check_name:
-                            # Guard against None name (follows codebase pattern)
-                            check_run_name = check_run.name.lower() if check_run.name else ""
+                            # Guard against None/empty name (follows codebase pattern)
+                            check_run_name = check_run.name.lower().strip() if check_run.name else ""
                             # Try both directions: name in failed_check_name OR failed_check_name in name
                             # This handles cases where webhook sends "GitHub Actions" but check_run is "lint"
+                            # Guard: only check reverse direction if check_run_name is non-empty
+                            # (empty string is substring of any string, causing false positives)
                             if (failed_check_name.lower() in check_run_name or
-                                    check_run_name in failed_check_name.lower()):
+                                    (check_run_name and check_run_name in failed_check_name.lower())):
                                 target_check_run = check_run
                                 break
                         else:

--- a/handoff/20250928/40_App/orchestrator/tools/github_api.py
+++ b/handoff/20250928/40_App/orchestrator/tools/github_api.py
@@ -1998,20 +1998,45 @@ def get_check_run_logs(
 
                 failure_conclusions = {"failure", "cancelled", "timed_out", "startup_failure", "action_required"}
 
+                # Track first failed check_run as fallback (in case name matching fails)
+                first_failed_check_run = None
+
                 for check_run in check_runs:
                     # Find failed check_runs
                     if check_run.conclusion in failure_conclusions:
+                        # Capture first failed check_run as fallback
+                        if first_failed_check_run is None:
+                            first_failed_check_run = check_run
+
                         # If failed_check_name is provided, try to match
                         if failed_check_name:
                             # Guard against None name (follows codebase pattern)
                             check_run_name = check_run.name.lower() if check_run.name else ""
-                            if failed_check_name.lower() in check_run_name:
+                            # Try both directions: name in failed_check_name OR failed_check_name in name
+                            # This handles cases where webhook sends "GitHub Actions" but check_run is "lint"
+                            if (failed_check_name.lower() in check_run_name or
+                                    check_run_name in failed_check_name.lower()):
                                 target_check_run = check_run
                                 break
                         else:
                             # Use first failed check_run
                             target_check_run = check_run
                             break
+
+                # Fallback: use first failed check_run if name matching failed
+                if not target_check_run and first_failed_check_run:
+                    target_check_run = first_failed_check_run
+                    logger.info(
+                        "[GitHub] get_check_run_logs: Using first failed check_run as fallback (name mismatch)",
+                        extra={
+                            "operation": "get_check_run_logs",
+                            "trace_id": trace_id,
+                            "check_suite_id": check_suite_id,
+                            "check_run_id": target_check_run.id,
+                            "check_run_name": target_check_run.name,
+                            "failed_check_name": failed_check_name,
+                        }
+                    )
 
                 if target_check_run:
                     logger.info(


### PR DESCRIPTION
## Summary

Fixes an issue where `get_check_run_logs` fails to find the failed check_run when the webhook's `failed_check_name` (e.g., "GitHub Actions") doesn't match the actual check_run name (e.g., "lint").

**Changes:**
1. Track first failed check_run as fallback during iteration
2. Add bidirectional name matching (checks both `failed_check_name in check_run_name` AND `check_run_name in failed_check_name`)
3. If name matching fails entirely, use first failed check_run as fallback with diagnostic logging

**Root cause:** The webhook sends the workflow name ("GitHub Actions") as `failed_check_name`, but the actual check_run has a job name ("lint"). The original unidirectional matching `"github actions" in "lint"` always fails.

## Review & Testing Checklist for Human

- [ ] **Verify empty string edge case**: If `check_run.name` is None/empty, `check_run_name` becomes `""`, and `"" in failed_check_name.lower()` is always True - this could cause false positive matches. Consider adding a guard: `check_run_name and check_run_name in failed_check_name.lower()`
- [ ] **Test with actual CI failure**: Deploy and trigger a lint failure on a test PR to verify D-4 now correctly finds the failed check_run
- [ ] **Review fallback behavior**: When multiple checks fail, the fallback picks the first one - verify this is acceptable behavior

**Recommended test plan:**
1. Deploy to PROD
2. Trigger CI failure on PR #4330 (or create new test PR)
3. Search PROD logs for `get_check_run_logs` and verify either "Found failed check_run" or "Using first failed check_run as fallback" appears
4. Verify D-4 successfully applies the fix

### Notes
- This is part of the D-4 CI failure auto-fix feature (Issue #4327)
- Previous fix in PR #4327 added the `get_check_run_logs` function, this PR fixes a name matching bug discovered during testing

Link to Devin run: https://app.devin.ai/sessions/f56d4ce47bf843bbb04965e24df526a7
Requested by: Ryan Chen (@RC918)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances resilience of `get_check_run_logs` when webhook `failed_check_name` doesn't match the actual check name.
> 
> - Tracks the first failed `check_run` as a fallback during suite iteration
> - Uses bidirectional substring matching between `failed_check_name` and `check_run.name`
> - Falls back to the first failed `check_run` if no name match, with informative logging
> - No other modules changed
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86559659609fcb85744f45382cae0ea0ab4cf6d8. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->